### PR TITLE
Set local system IP in POST data to Foreman

### DIFF
--- a/extra/discover_host
+++ b/extra/discover_host
@@ -47,6 +47,8 @@ end
 
 def upload
   puts "#{Time.now}: Triggering import of facts from Foreman"
+  ip = Facter.value('ipaddress') 
+  data = ip.nil? ? {} : {'ip' => ip}
   begin
     uri = URI.parse(discover_server)
     http = Net::HTTP.new(uri.host, uri.port)
@@ -55,7 +57,7 @@ def upload
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     end
     req = Net::HTTP::Post.new("/discovers")
-    req.set_form_data({})
+    req.set_form_data(data)
     response = http.request(req)
     puts response.body
   rescue Exception => e


### PR DESCRIPTION
This should allow the discovered system to present it's real IP to Foreman when behind a NAT firewall.

@wnkz would you like to test this? You'll need to rebuild the discovery image (or I can build one for you if you like).
