### PR TITLE
Remove explicit Rails dependency, update homepage

### DIFF
--- a/foreman_discovery.gemspec
+++ b/foreman_discovery.gemspec
@@ -16,14 +16,11 @@ Gem::Specification.new do |s|
   ]
   s.files = Dir["{app,extra,config,db,lib}/**/*"] + ["LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
-  s.homepage = %q{http://github.com/GregSutcliffe/foreman_discovery}
+  s.homepage = %q{http://github.com/theforeman/foreman_discovery}
   s.licenses = ["GPL-3"]
   s.summary = %q{MaaS Discovery Plugin for Foreman}
 
-  s.add_dependency "rails", "~> 3.2.8"
   s.add_dependency "open4"
   s.add_dependency "ftools"
   s.add_dependency "deface"
-
-
 end


### PR DESCRIPTION
This was causing problems for bundler_ext users, since rubygems then tried to install a second copy of rails.
