### PR TITLE
fixes #4174 - fixed locale distribution and jenkins rake task

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,8 @@
+[main]
+host = https://www.transifex.com
+
+[foreman.discovery]
+file_filter = locale/<lang>/discovery.po
+source_file = locale/discovery.pot
+source_lang = en
+type = PO

--- a/foreman_discovery.gemspec
+++ b/foreman_discovery.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
     "LICENSE",
     "README.md"
   ]
-  s.files = Dir["{app,extra,config,db,lib}/**/*"] + ["LICENSE", "Rakefile", "README.md"]
+  s.files = Dir["{app,extra,config,db,lib,locale}/**/*"] + ["LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
   s.homepage = %q{http://github.com/theforeman/foreman_discovery}
   s.licenses = ["GPL-3"]

--- a/lib/discovery.rake
+++ b/lib/discovery.rake
@@ -93,7 +93,10 @@ end
 Rake::Task[:test].enhance do
   Rake::Task['test:discovery'].invoke
 end
+
 load 'tasks/jenkins.rake'
-Rake::Task["jenkins:unit"].enhance do
-  Rake::Task['test:discovery'].invoke
+if Rake::Task.task_defined?(:'jenkins:setup')
+  Rake::Task["jenkins:unit"].enhance do
+    Rake::Task['test:discovery'].invoke
+  end
 end

--- a/locale/discovery.pot
+++ b/locale/discovery.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-11-20 17:47+0100\n"
+"POT-Creation-Date: 2014-01-24 13:57+0100\n"
 "PO-Revision-Date: 2013-03-01 15:45-0500\n"
 "Last-Translator: \n"
 "Language-Team: Foreman Team <foreman-dev@googlegroups.com>\n"
@@ -48,9 +48,6 @@ msgid "Delete hosts"
 msgstr ""
 
 msgid "Destroyed selected hosts"
-msgstr ""
-
-msgid "Discovered Hosts"
 msgstr ""
 
 msgid "Discovered host: %s"
@@ -138,6 +135,9 @@ msgid "Submit"
 msgstr ""
 
 msgid "Subnet"
+msgstr ""
+
+msgid "The default fact name to use for the MAC of the system"
 msgstr ""
 
 msgid "The default location to place discovered hosts in"

--- a/locale/en_GB/discovery.po
+++ b/locale/en_GB/discovery.po
@@ -1,0 +1,169 @@
+# Template file for strings which can be localized in the Foreman Application.
+# 
+# This file is distributed under the same license as the Foreman.
+# 
+# 
+# Translators:
+# domcleal <dcleal@redhat.com>, 2013
+msgid ""
+msgstr ""
+"Project-Id-Version: Foreman\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2013-11-20 17:47+0100\n"
+"PO-Revision-Date: 2013-11-22 09:30+0000\n"
+"Last-Translator: domcleal <dcleal@redhat.com>\n"
+"Language-Team: English (United Kingdom) (http://www.transifex.com/projects/p/foreman/language/en_GB/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en_GB\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "%s - The following hosts are about to be changed"
+msgstr "%s - The following hosts are about to be changed"
+
+msgid "%s ago"
+msgstr "%s ago"
+
+msgid "Are you sure?"
+msgstr "Are you sure?"
+
+msgid "Assign Location"
+msgstr "Assign Location"
+
+msgid "Assign Organization"
+msgstr "Assign Organisation"
+
+msgid "Cancel"
+msgstr "Cancel"
+
+msgid "Could not get facts from proxy: %s"
+msgstr "Could not get facts from proxy: %s"
+
+msgid "Delete"
+msgstr "Delete"
+
+msgid "Delete %s?"
+msgstr "Delete %s?"
+
+msgid "Delete hosts"
+msgstr "Delete hosts"
+
+msgid "Destroyed selected hosts"
+msgstr "Destroyed selected hosts"
+
+msgid "Discovered Hosts"
+msgstr "Discovered Hosts"
+
+msgid "Discovered host: %s"
+msgstr "Discovered host: %s"
+
+msgid "Discovered hosts"
+msgstr "Discovered hosts"
+
+msgid "Fact"
+msgstr "Fact"
+
+msgid "Facts discovered on this host"
+msgstr "Facts discovered on this host"
+
+msgid "Facts refreshed for %s"
+msgstr "Facts refreshed for %s"
+
+msgid "Failed to import facts for Host::Discovered"
+msgstr "Failed to import facts for Host::Discovered"
+
+msgid "Failed to import facts for Host::Discovered: %s"
+msgstr "Failed to import facts for Host::Discovered: %s"
+
+msgid "Failed to reboot: %s"
+msgstr "Failed to reboot: %s"
+
+msgid "Failed to refresh facts for %s"
+msgstr "Failed to refresh facts for %s"
+
+msgid "Host Pool"
+msgstr "Host Pool"
+
+msgid "Imported Host::Discovered"
+msgstr "Imported Host::Discovered"
+
+msgid "Last facts upload"
+msgstr "Last facts upload"
+
+msgid "Location"
+msgstr "Location"
+
+msgid "Model"
+msgstr "Model"
+
+msgid "Name"
+msgstr "Name"
+
+msgid "No hosts selected"
+msgstr "No hosts selected"
+
+msgid "No hosts were found with that id or name"
+msgstr "No hosts were found with that id or name"
+
+msgid "Organization"
+msgstr "Organisation"
+
+msgid "Please Confirm"
+msgstr "Please Confirm"
+
+msgid "Provision"
+msgstr "Provision"
+
+msgid "Rebooting %s"
+msgstr "Rebooting %s"
+
+msgid "Refresh facts"
+msgstr "Refresh facts"
+
+msgid "Select action"
+msgstr "Select action"
+
+msgid "Select all items in this page"
+msgstr "Select all items in this page"
+
+msgid "Select location"
+msgstr "Select location"
+
+msgid "Select organization"
+msgstr "Select organisation"
+
+msgid "Something went wrong while selecting hosts - %s"
+msgstr "Something went wrong while selecting hosts - %s"
+
+msgid "Submit"
+msgstr "Submit"
+
+msgid "Subnet"
+msgstr "Subnet"
+
+msgid "The default location to place discovered hosts in"
+msgstr "The default location to place discovered hosts in"
+
+msgid "The default organization to place discovered hosts in"
+msgstr "The default organisation to place discovered hosts in"
+
+msgid "The following hosts were not deleted: %s"
+msgstr "The following hosts were not deleted: %s"
+
+msgid ""
+"This might take a while, as all hosts, facts and reports will be destroyed "
+"as well"
+msgstr "This might take a while, as all hosts, facts and reports will be destroyed as well"
+
+msgid "Unassigned hosts"
+msgstr "Unassigned hosts"
+
+msgid "Value"
+msgstr "Value"
+
+msgid "Warning"
+msgstr "Warning"
+
+msgid "items selected. Uncheck to Clear"
+msgstr "items selected. Uncheck to Clear"

--- a/locale/es/discovery.po
+++ b/locale/es/discovery.po
@@ -1,0 +1,169 @@
+# Template file for strings which can be localized in the Foreman Application.
+# 
+# This file is distributed under the same license as the Foreman.
+# 
+# 
+# Translators:
+# francisvm <hackgo@gmail.com>, 2013
+msgid ""
+msgstr ""
+"Project-Id-Version: Foreman\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2013-11-20 17:47+0100\n"
+"PO-Revision-Date: 2013-11-22 15:40+0000\n"
+"Last-Translator: francisvm <hackgo@gmail.com>\n"
+"Language-Team: Spanish (http://www.transifex.com/projects/p/foreman/language/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "%s - The following hosts are about to be changed"
+msgstr "%s - Los siguientes equipos están a punto de ser modificados"
+
+msgid "%s ago"
+msgstr "Hace %s"
+
+msgid "Are you sure?"
+msgstr "¿Estás seguro?"
+
+msgid "Assign Location"
+msgstr "Asignar Lugar"
+
+msgid "Assign Organization"
+msgstr "Asignar Organización"
+
+msgid "Cancel"
+msgstr "Cancelar"
+
+msgid "Could not get facts from proxy: %s"
+msgstr "No se pueden obtener datos del proxy: %s"
+
+msgid "Delete"
+msgstr "Borrar"
+
+msgid "Delete %s?"
+msgstr "¿Borrar %s?"
+
+msgid "Delete hosts"
+msgstr "Borrar Equipos"
+
+msgid "Destroyed selected hosts"
+msgstr "Eliminados equipos seleccionados"
+
+msgid "Discovered Hosts"
+msgstr "Equipos descubiertos"
+
+msgid "Discovered host: %s"
+msgstr "Equipo descubierto: %s"
+
+msgid "Discovered hosts"
+msgstr "Equipos descubiertos"
+
+msgid "Fact"
+msgstr "Dato"
+
+msgid "Facts discovered on this host"
+msgstr "Datos descubiertos en este equipo"
+
+msgid "Facts refreshed for %s"
+msgstr "Datos actualizados para %s"
+
+msgid "Failed to import facts for Host::Discovered"
+msgstr "No se pudo importar datos para Host :: Descubierto"
+
+msgid "Failed to import facts for Host::Discovered: %s"
+msgstr "No se pudo importar datos para Host :: Descubierto %s"
+
+msgid "Failed to reboot: %s"
+msgstr "Fallo al reiniciar: %s"
+
+msgid "Failed to refresh facts for %s"
+msgstr "Fallo al refrescar datos para %s"
+
+msgid "Host Pool"
+msgstr "Conjunto de equipos"
+
+msgid "Imported Host::Discovered"
+msgstr "Importado Host::Descubierto"
+
+msgid "Last facts upload"
+msgstr "Últimos datos subidos"
+
+msgid "Location"
+msgstr "Lugares"
+
+msgid "Model"
+msgstr "Modelo"
+
+msgid "Name"
+msgstr "Nombre"
+
+msgid "No hosts selected"
+msgstr "Ningún equipo seleccionado"
+
+msgid "No hosts were found with that id or name"
+msgstr "No se han encontrado equipos con ese id o nombre"
+
+msgid "Organization"
+msgstr "Organización"
+
+msgid "Please Confirm"
+msgstr "Confirme, por favor"
+
+msgid "Provision"
+msgstr "Aprovisionamiento"
+
+msgid "Rebooting %s"
+msgstr "Reiniciando %s"
+
+msgid "Refresh facts"
+msgstr "Refrescar datos"
+
+msgid "Select action"
+msgstr "Seleccionar acción"
+
+msgid "Select all items in this page"
+msgstr "Seleccionar todos los objetos de esta página"
+
+msgid "Select location"
+msgstr "Seleccionar localización"
+
+msgid "Select organization"
+msgstr "Seleccionar organización"
+
+msgid "Something went wrong while selecting hosts - %s"
+msgstr "Algo ha fallado al seleccionar equipos - %s"
+
+msgid "Submit"
+msgstr "Introducir"
+
+msgid "Subnet"
+msgstr "Subred"
+
+msgid "The default location to place discovered hosts in"
+msgstr "La ubicación predeterminada para colocar hosts descubiertos "
+
+msgid "The default organization to place discovered hosts in"
+msgstr "La ubicación predeterminada para colocar organizaciones descubiertas "
+
+msgid "The following hosts were not deleted: %s"
+msgstr "Los siguientes equipos no han sido eliminados: %s"
+
+msgid ""
+"This might take a while, as all hosts, facts and reports will be destroyed "
+"as well"
+msgstr "Esta acción puede tardar un rato, ya que se eliminarán todos los equipos, datos e informes."
+
+msgid "Unassigned hosts"
+msgstr "Equipos sin asignar"
+
+msgid "Value"
+msgstr "Valor"
+
+msgid "Warning"
+msgstr "Aviso"
+
+msgid "items selected. Uncheck to Clear"
+msgstr "objetos seleccionados. Desactivar para limpiar"

--- a/locale/fr/discovery.po
+++ b/locale/fr/discovery.po
@@ -1,0 +1,169 @@
+# Template file for strings which can be localized in the Foreman Application.
+# 
+# This file is distributed under the same license as the Foreman.
+# 
+# 
+# Translators:
+# Claer <transiblu@claer.hammock.fr>, 2013
+msgid ""
+msgstr ""
+"Project-Id-Version: Foreman\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2013-11-20 17:47+0100\n"
+"PO-Revision-Date: 2013-11-27 14:30+0000\n"
+"Last-Translator: Claer <transiblu@claer.hammock.fr>\n"
+"Language-Team: French (http://www.transifex.com/projects/p/foreman/language/fr/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: fr\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+msgid "%s - The following hosts are about to be changed"
+msgstr "%s - les hôtes suivants vont être changés"
+
+msgid "%s ago"
+msgstr "Il y a %s"
+
+msgid "Are you sure?"
+msgstr "Êtes vous sûr ?"
+
+msgid "Assign Location"
+msgstr "Assigner une Localisation"
+
+msgid "Assign Organization"
+msgstr "Assigner une Organisation"
+
+msgid "Cancel"
+msgstr "Annuler"
+
+msgid "Could not get facts from proxy: %s"
+msgstr "Impossible de récupérer les facts depuis le proxy : %s"
+
+msgid "Delete"
+msgstr "Supprimer"
+
+msgid "Delete %s?"
+msgstr "Supprimer %s ?"
+
+msgid "Delete hosts"
+msgstr "Supprimer ces Hôtes"
+
+msgid "Destroyed selected hosts"
+msgstr "Hôtes sélectionnés détruits"
+
+msgid "Discovered Hosts"
+msgstr "Hôtes détectés"
+
+msgid "Discovered host: %s"
+msgstr "Hôtes détectés : %s"
+
+msgid "Discovered hosts"
+msgstr "Hôtes détectés"
+
+msgid "Fact"
+msgstr "Fact"
+
+msgid "Facts discovered on this host"
+msgstr "Facts détectés pour cet hôte"
+
+msgid "Facts refreshed for %s"
+msgstr "Facts rafraichis pour %s"
+
+msgid "Failed to import facts for Host::Discovered"
+msgstr "Échec d'import des facts pour Host::Discovered"
+
+msgid "Failed to import facts for Host::Discovered: %s"
+msgstr "Échec d'import des facts pour Host::Discovered: %s"
+
+msgid "Failed to reboot: %s"
+msgstr "Erreur de redémarrage : %s"
+
+msgid "Failed to refresh facts for %s"
+msgstr "Échec de rafraichissement des facts pour %s"
+
+msgid "Host Pool"
+msgstr "Regrouppement d'hôtes"
+
+msgid "Imported Host::Discovered"
+msgstr "Host::Discovered importé"
+
+msgid "Last facts upload"
+msgstr "Derniers facts téléchargés"
+
+msgid "Location"
+msgstr "Localisation"
+
+msgid "Model"
+msgstr "Modèle"
+
+msgid "Name"
+msgstr "Nom"
+
+msgid "No hosts selected"
+msgstr "Aucun hôte sélectionné"
+
+msgid "No hosts were found with that id or name"
+msgstr "Aucun Hôte trouvé avec cet id ou ce nom"
+
+msgid "Organization"
+msgstr "Organisation"
+
+msgid "Please Confirm"
+msgstr "Merci de confirmer"
+
+msgid "Provision"
+msgstr "Provisionner"
+
+msgid "Rebooting %s"
+msgstr "Redémarrage %s"
+
+msgid "Refresh facts"
+msgstr "Rafraichir les facts"
+
+msgid "Select action"
+msgstr "Choisir l'action"
+
+msgid "Select all items in this page"
+msgstr "Sélectionner tous les éléments de cette page"
+
+msgid "Select location"
+msgstr "Sélectionner une localisation"
+
+msgid "Select organization"
+msgstr "Choisir une organisation"
+
+msgid "Something went wrong while selecting hosts - %s"
+msgstr "Quelque chose s'est mal passé lors de la sélection des hôtes - %s"
+
+msgid "Submit"
+msgstr "Soumettre"
+
+msgid "Subnet"
+msgstr "Sous-Réseau"
+
+msgid "The default location to place discovered hosts in"
+msgstr "Attribution de la localisation par défaut pour les hôtes détectés"
+
+msgid "The default organization to place discovered hosts in"
+msgstr "Attribution de l'organisation par défaut pour les hôtes détectés"
+
+msgid "The following hosts were not deleted: %s"
+msgstr "Les hôtes suivants n'ont pas été supprimés : %s"
+
+msgid ""
+"This might take a while, as all hosts, facts and reports will be destroyed "
+"as well"
+msgstr "Cette action peut prendre un certain temps, pour tous les hôtes, les rapports et facts vont aussi être supprimés"
+
+msgid "Unassigned hosts"
+msgstr "Hôtes non assignés"
+
+msgid "Value"
+msgstr "Valeur"
+
+msgid "Warning"
+msgstr "Attention"
+
+msgid "items selected. Uncheck to Clear"
+msgstr "items sélectionnés. Décocher pour Effacer"

--- a/locale/sv_SE/discovery.po
+++ b/locale/sv_SE/discovery.po
@@ -1,0 +1,169 @@
+# Template file for strings which can be localized in the Foreman Application.
+# 
+# This file is distributed under the same license as the Foreman.
+# 
+# 
+# Translators:
+# johnny Westerlund <johnny.westerlund@gmail.com>, 2014
+msgid ""
+msgstr ""
+"Project-Id-Version: Foreman\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2013-11-20 17:47+0100\n"
+"PO-Revision-Date: 2014-01-14 14:34+0000\n"
+"Last-Translator: johnny Westerlund <johnny.westerlund@gmail.com>\n"
+"Language-Team: Swedish (Sweden) (http://www.transifex.com/projects/p/foreman/language/sv_SE/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: sv_SE\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "%s - The following hosts are about to be changed"
+msgstr "%s - Följande värdar kommer att ändras"
+
+msgid "%s ago"
+msgstr "%s sedan"
+
+msgid "Are you sure?"
+msgstr "Är du säker?"
+
+msgid "Assign Location"
+msgstr "Tilldela Plats"
+
+msgid "Assign Organization"
+msgstr "Tilldela Organisation"
+
+msgid "Cancel"
+msgstr "Avbryt"
+
+msgid "Could not get facts from proxy: %s"
+msgstr "Kunde inte hämta fakta från proxy: %s"
+
+msgid "Delete"
+msgstr "Radera"
+
+msgid "Delete %s?"
+msgstr "Radera %s"
+
+msgid "Delete hosts"
+msgstr "Radera värdar"
+
+msgid "Destroyed selected hosts"
+msgstr "Förstör markerade värdar"
+
+msgid "Discovered Hosts"
+msgstr "Hittade värdar"
+
+msgid "Discovered host: %s"
+msgstr "Hittade värdar: %s"
+
+msgid "Discovered hosts"
+msgstr "Hittade värdar"
+
+msgid "Fact"
+msgstr "Fakta"
+
+msgid "Facts discovered on this host"
+msgstr "Fakta hittade för denna värd"
+
+msgid "Facts refreshed for %s"
+msgstr "Fakta uppdaterade för %s"
+
+msgid "Failed to import facts for Host::Discovered"
+msgstr "Misslyckades att importera fakta för Host::Discovered"
+
+msgid "Failed to import facts for Host::Discovered: %s"
+msgstr "Misslyckades att importera fakta för Host::Discovered: %s"
+
+msgid "Failed to reboot: %s"
+msgstr "Misslyckades att starta om: %s"
+
+msgid "Failed to refresh facts for %s"
+msgstr "Misslyckades med att uppdatera fakta för %s"
+
+msgid "Host Pool"
+msgstr "Värdpool"
+
+msgid "Imported Host::Discovered"
+msgstr "Importerade Host::Discovered"
+
+msgid "Last facts upload"
+msgstr "Sista faktauppladdning"
+
+msgid "Location"
+msgstr "Lokation"
+
+msgid "Model"
+msgstr "Modell"
+
+msgid "Name"
+msgstr "Namn"
+
+msgid "No hosts selected"
+msgstr "Inga värdar markerade"
+
+msgid "No hosts were found with that id or name"
+msgstr "Inga värdar med det idt eller namnet hittades"
+
+msgid "Organization"
+msgstr "Organisation"
+
+msgid "Please Confirm"
+msgstr "Var god, bekräfta"
+
+msgid "Provision"
+msgstr "Provisionera"
+
+msgid "Rebooting %s"
+msgstr "Startar om %s"
+
+msgid "Refresh facts"
+msgstr "Uppdatera fakta"
+
+msgid "Select action"
+msgstr "Välj åtgärd"
+
+msgid "Select all items in this page"
+msgstr "Markera alla valbara på denna sida"
+
+msgid "Select location"
+msgstr "Välj lokation"
+
+msgid "Select organization"
+msgstr "Välj organisation"
+
+msgid "Something went wrong while selecting hosts - %s"
+msgstr "Något blev fel vid markering av värdar - %s"
+
+msgid "Submit"
+msgstr "Sänd"
+
+msgid "Subnet"
+msgstr "Subnät"
+
+msgid "The default location to place discovered hosts in"
+msgstr "Standardplatsen att placera värdar i"
+
+msgid "The default organization to place discovered hosts in"
+msgstr "Standardorganisationen att placera hittade värdar i"
+
+msgid "The following hosts were not deleted: %s"
+msgstr "Följande värdar raderades inte: %s"
+
+msgid ""
+"This might take a while, as all hosts, facts and reports will be destroyed "
+"as well"
+msgstr "Detta kan dröja då alla värdar, fakta och rapporter också kommer bli förstörda"
+
+msgid "Unassigned hosts"
+msgstr "Otilldelade värdar"
+
+msgid "Value"
+msgstr "Värde"
+
+msgid "Warning"
+msgstr "Varning"
+
+msgid "items selected. Uncheck to Clear"
+msgstr "poster markerade. Avmarkera för att rensa"


### PR DESCRIPTION
Two issues from RC1 resolved plus i18n support is fully working now. Although
i18n plugin support does not support javascript and model localization, we do
not use these in Discovery.

Also, there is a PR coming to Foreman with minor changes in the Makefile script
to better support plugin extraction.

Packagers note: Please do this command during package build to prepare MO
files:

```
make -C locale all-mo
```

That should create locale/*/LC_MESSAGES/discovery.mo files.
