### PR TITLE
Some fixes for the Tiny Core Image

### DIFF
--- a/extra/build_iso.sh
+++ b/extra/build_iso.sh
@@ -88,7 +88,7 @@ fi
 
 # Build the init script
 echo "" >> opt/bootlocal.sh
-echo "sleep 20" >> opt/bootlocal.sh # network can be slow to come up, and we're not in a rush
+echo "/opt/wait_for_network.sh" >> opt/bootlocal.sh # network can be slow to come up
 echo "/opt/foreman_startup.rb" >> opt/bootlocal.sh
 echo "/opt/discovery_init.sh" >> opt/bootlocal.sh
 
@@ -96,9 +96,19 @@ echo "/opt/discovery_init.sh" >> opt/bootlocal.sh
 cp $SCRIPT_DIR/foreman_startup.rb opt/foreman_startup.rb
 chmod 755 opt/foreman_startup.rb
 
+# Copy the script that wait for network before trying to use it
+cp $SCRIPT_DIR/wait_for_network.sh opt/wait_for_network.sh
+chmod 755 opt/wait_for_network.sh
+
 # Get the gems
 mkdir opt/gems && cd opt/gems
-for n in $GEMS ; do gem fetch $n ; done
+gem fetch facter
+gem fetch json_pure
+gem fetch rack
+gem fetch rack-protection
+# Explicit version for tilt or it brakes sinatra (actual tilt version >= 2.0.0) :
+gem fetch --version 1.3.4 tilt
+gem fetch sinatra
 
 # Build the fallback script
 echo "#!/bin/sh" >> ../discovery_init.sh

--- a/extra/wait_for_network.sh
+++ b/extra/wait_for_network.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+n=1
+
+for x in `cat /proc/cmdline`
+do
+    case $x in
+        foreman.ip=*)
+            server="${x//foreman.ip=}"
+        ;;
+        foreman.server=*)
+            server="${x//foreman.server=}"
+        ;;
+    esac
+done
+
+echo "Testing ping to $server to see if network is up..."
+
+until ping -w 1 -c 1 "$server" &>/dev/null ;do
+    sleep 1
+    n=$(( n+1 ))
+    [ $n -eq 180 ] && break
+done
+


### PR DESCRIPTION
Hi,

2 little patches to :
- Replace the sleep (for network) by a script which actually check the network (20 seconds was not enough in my case)
- Explicitly fetch the 1.3.4 version of the tilt gem because the one that was fetched by default (2.0.0) was breaking the sinatra gem.

The network check script will try to ping the foreman server (based on the kernel boot command line) every second for 3 minutes, perhaps not the better way to handle that (a better failure system if network is still down ?) but still better than the basic "sleep 20".

Regards,
