### PR TITLE
longer fact values are truncated in host detail

### DIFF
--- a/app/views/discovers/show.html.erb
+++ b/app/views/discovers/show.html.erb
@@ -10,7 +10,7 @@
   <% @host.facts_hash.sort.each do |fact| -%>
     <tr>
       <td><%= fact[0] %></td>
-      <td><%= fact[1] %></td>
+      <td><%= truncate(fact[1], :length => 100) %></td>
     </tr>
   <% end -%>
 </table>


### PR DESCRIPTION
This was bugging me all the time, fixing this for my talk. Long fact values
(like ssh public keys) are long and ruining the screen. I am putting 100 as a
sane default there.
