### PR TITLE
discovery taxonomies and interactive hostname

### DIFF
--- a/app/models/setting/discovered.rb
+++ b/app/models/setting/discovered.rb
@@ -1,6 +1,8 @@
 class Setting::Discovered < ::Setting
   BLANK_ATTRS << "discovery_location"
+  BLANK_ATTRS << "discovery_location_fact"
   BLANK_ATTRS << "discovery_organization"
+  BLANK_ATTRS << "discovery_organization_fact"
 
   def self.load_defaults
     # Check the table exists
@@ -9,6 +11,7 @@ class Setting::Discovered < ::Setting
     Setting.transaction do
       [
         self.set('discovery_fact', _("The default fact name to use for the MAC of the system"), "macaddress"),
+        self.set('discovery_hostname_fact', _("The default fact name to use for the hostname of the system"), "macaddress"),
       ].compact.each { |s| self.create s.update(:category => "Setting::Discovered")}
     end
 
@@ -16,6 +19,7 @@ class Setting::Discovered < ::Setting
       Setting.transaction do
         [
           self.set('discovery_location', _("The default location to place discovered hosts in"), ""),
+          self.set('discovery_location_fact', _("The default location fact name to use for the Location of the system"), ""),
         ].compact.each { |s| self.create s.update(:category => "Setting::Discovered")}
       end
     end
@@ -23,6 +27,7 @@ class Setting::Discovered < ::Setting
       Setting.transaction do
         [
           self.set('discovery_organization', _("The default organization to place discovered hosts in"), "" ),
+          self.set('discovery_organization_fact', _("The default organization fact name to use for the Organization of the system"), "" ),
         ].compact.each { |s| self.create s.update(:category => "Setting::Discovered")}
       end
     end

--- a/extra/discovery_init.sh.example
+++ b/extra/discovery_init.sh.example
@@ -5,6 +5,27 @@ echo "Starting custom discovery script"
 GEMS="facter json_pure rack rack-protection tilt sinatra"
 for n in $GEMS ; do gem install --no-ri --no-rdoc -l `ls /opt/gems/*$n-[0-9]*.gem` ; done
 
+set -- `cat /proc/cmdline`
+for I in $*; do case "$I" in *=*) eval $I;; esac; done
+
+mkdir -p /etc/facter/facts.d
+if [ -n "$discovery_organization" ]; then
+  echo discovery_organization=$discovery_organization >/etc/facter/facts.d/discovery.txt
+fi
+
+if [ "$discovery_mode" == 'interactive' ]; then
+  chvt 2
+  (
+    echo Foreman interactive mode activated...
+    echo
+    read -p "Hostname: " discovery_hostname
+    if [ -n "$discovery_hostname" ]; then
+      echo discovery_hostname=$discovery_hostname >>/etc/facter/facts.d/discovery.txt
+    fi
+  )  </dev/tty2 >/dev/tty2 2>&1
+  chvt 1
+fi
+
 /usr/share/foreman-proxy/bin/smart-proxy
 /usr/share/foreman-proxy/bin/discover_host
 


### PR DESCRIPTION
patch to allow taxonomies to be assigned in PXE menu or predetermined in discovery_init.sh and to allow interactive host name to be provided for discovered hosts
