### PR TITLE
Changed the discovery_fact to discovery_bootif

### DIFF
--- a/app/models/setting/discovered.rb
+++ b/app/models/setting/discovered.rb
@@ -8,7 +8,7 @@ class Setting::Discovered < ::Setting
 
     Setting.transaction do
       [
-        self.set('discovery_fact', _("The default fact name to use for the MAC of the system"), "macaddress"),
+        self.set('discovery_fact', _("The default fact name to use for the MAC of the system"), "discovery_bootif"),
       ].compact.each { |s| self.create s.update(:category => "Setting::Discovered")}
     end
 


### PR DESCRIPTION
_Warning_: You need discovery image 0.5.0+ for this (nightly build). Also make
sure you have `IPAPPEND 2` PXEBoot setting. More info at:

https://github.com/theforeman/ovirt-node-plugin-foreman

This improves the discovery workflow a lot. Recent changes in discovery image
added one extra fact `discovery_bootif` which contains MAC address of the
interface the system booted from.
