### PR TITLE
fixes #6382 - use correct 48bit mac address regex

### DIFF
--- a/app/models/host/discovered.rb
+++ b/app/models/host/discovered.rb
@@ -7,7 +7,7 @@ class Host::Discovered < ::Host::Base
   belongs_to :subnet
   belongs_to :hostgroup
 
-  validates :mac, :uniqueness => true, :format => {:with => Net::Validations::MAC_REGEXP}, :presence => true
+  validates :mac, :uniqueness => true, :format => {:with => Net::Validations::MAC_REGEXP_48BIT}, :presence => true
   validates :ip, :format => {:with => Net::Validations::IP_REGEXP}, :uniqueness => true
 
   scoped_search :on => :name, :complete_value => true, :default_order => true


### PR DESCRIPTION
Opened http://projects.theforeman.org/issues/6388 for proper 64bit mac address support.
