### PR TITLE
Fix mac address validation

### DIFF
--- a/app/models/host/discovered.rb
+++ b/app/models/host/discovered.rb
@@ -7,7 +7,7 @@ class Host::Discovered < ::Host::Base
   belongs_to :subnet
   belongs_to :hostgroup
 
-  validates :mac, :uniqueness => true, :format => {:with => Net::Validations::MAC_REGEXP}, :presence => true
+  validates :mac, :uniqueness => true, :mac_address => true, :presence => true
   validates :ip, :format => {:with => Net::Validations::IP_REGEXP}, :uniqueness => true
 
   scoped_search :on => :name, :complete_value => true, :default_order => true


### PR DESCRIPTION
Foreman has mac address valdiator since 1.6. Regexp does not exist
anymore.
