### PR TITLE
Check for jenkins:unit task to enhance

### DIFF
--- a/app/controllers/discovered_hosts_controller.rb
+++ b/app/controllers/discovered_hosts_controller.rb
@@ -20,7 +20,7 @@ class DiscoveredHostsController < ::ApplicationController
       format.html do
         @hosts = search.paginate(:page => params[:page])
       end
-      format.json { render :json => hosts }
+      format.json { render :json => search }
     end
   end
 

--- a/extra/ovirt-node-build/Vagrantfile
+++ b/extra/ovirt-node-build/Vagrantfile
@@ -7,7 +7,7 @@ if ENV['box']
 end
 
 Vagrant.configure("2") do |config|
-  config.vm.define box[:name], primary: box[:default] do |machine|
+  config.vm.define box[:name], :primary => box[:default] do |machine|
     machine.vm.box = box[:name]
     machine.vm.hostname = "foreman-#{box[:name]}.bulder.theforeman.org"
     machine.vm.provision :shell, :path => 'build_image.sh', :args => [

--- a/lib/discovery.rake
+++ b/lib/discovery.rake
@@ -95,7 +95,7 @@ Rake::Task[:test].enhance do
 end
 
 load 'tasks/jenkins.rake'
-if Rake::Task.task_defined?(:'jenkins:setup')
+if Rake::Task.task_defined?(:'jenkins:unit')
   Rake::Task["jenkins:unit"].enhance do
     Rake::Task['test:discovery'].invoke
   end

--- a/test/unit/host_discovered_test.rb
+++ b/test/unit/host_discovered_test.rb
@@ -4,9 +4,9 @@ class HostDiscoveredTest < ActiveSupport::TestCase
   setup do
     User.current = User.find_by_login "admin"
     FactoryGirl.create(:setting,
-                       name: 'discovery_fact',
-                       value: 'macaddress',
-                       category: 'Setting::Discovered')
+                       :name     => 'discovery_fact',
+                       :value    => 'macaddress',
+                       :category => 'Setting::Discovered')
   end
 
   test "should be able to create Host::Discovered objects" do


### PR DESCRIPTION
Checking for jenkins:setup (a namespace) was not allowing this to run the tests, plus, the key task we have to check is jenkins:unit, which is the one we want to append our job.
