### PR TITLE
Fixes #3860 - automated discovery provisioning

### DIFF
--- a/app/controllers/api/v2/discovered_hosts_controller.rb
+++ b/app/controllers/api/v2/discovered_hosts_controller.rb
@@ -95,6 +95,11 @@ module Api
 
       def facts
         @discovered_host, state = Host::Discovered.import_host_and_facts(params[:facts])
+        if state && Setting['discovery_auto']
+          state = ForemanDiscovery.execute_auto_provisioning(@discovered_host)
+        else
+          Rails.logger.warn "Discovered facts import unsuccessful, skipping auto provisioning"
+        end
         process_response state
       rescue ::Foreman::Exception => e
         render :json => {'message'=>e.to_s}, :status => :unprocessable_entity

--- a/app/controllers/api/v2/discovery_rules_controller.rb
+++ b/app/controllers/api/v2/discovery_rules_controller.rb
@@ -1,0 +1,88 @@
+module Api
+  module V2
+    class DiscoveryRulesController < ::Api::V2::BaseController
+
+      before_filter :find_resource, :except => %w{index create facts}
+
+      resource_description do
+        resource_id 'discovery_rules'
+        api_version 'v2'
+        api_base_url "/api/v2"
+      end
+
+      api :GET, "/discovery_rules/", N_("List all discovery rules")
+      param :search, String, :desc => N_("filter results")
+      param :order, String, :desc => N_("sort results")
+      param :page, String, :desc => N_("paginate results")
+      param :per_page, String, :desc => N_("number of entries per request")
+
+      def index
+        @discovery_rules = resource_scope.search_for(*search_options).paginate(paginate_options)
+      end
+
+      api :GET, "/discovery_rules/:id/", N_("Show a discovery rule")
+      param :id, :identifier_dottable, :required => true
+
+      def show
+      end
+
+      def_param_group :discovery_rule do
+        param :discovery_rule, Hash, :action_aware => true do
+          param :name, String, :required => true
+          param :query, String, :required => true
+          param :hostgroup_id, Integer, :required => true
+          param :hostname, String, :required => true
+          param :max_count, Integer
+          param :priority, Integer
+          param :enabled, Boolean
+        end
+      end
+
+      api :POST, "/discovery_rules/", N_("Create a discovery rule")
+      param_group :discovery_rule, :as => :create
+
+      def create
+        @discovery_rule = DiscoveryRule.new(params[:discovery_rule])
+        process_response @discovery_rule.save
+      end
+
+      api :PUT, "/discovery_rules/:id/", N_("Update a rule")
+      param :id, :identifier, :required => true
+      param :discovery_rule, Hash, :action_aware => true do
+          param :name, String, :required => true
+          param :query, String, :required => true
+          param :hostgroup_id, Integer, :required => true
+          param :hostname, String, :required => true
+          param :max_count, Integer
+          param :priority, Integer
+          param :enabled, Boolean
+      end
+
+      def update
+        process_response @discovery_rule.update_attributes(params[:discovery_rule])
+      end
+
+      api :DELETE, "/discovery_rules/:id/", N_("Delete a rule")
+      param :id, :identifier, :required => true
+
+      def destroy
+        process_response @discovery_rule.destroy
+      end
+
+      api :POST, "/discovery_rules/execute", N_("Execute rules against currently discovered hosts")
+
+      def execute
+        ForemanDiscovery.execute_auto_provisioning
+      rescue ::Foreman::Exception => e
+        render :json => {'message'=>e.to_s}, :status => :unprocessable_entity
+      end
+
+      private
+
+      def resource_class
+        DiscoveryRule
+      end
+
+    end
+  end
+end

--- a/app/models/discovery_rule.rb
+++ b/app/models/discovery_rule.rb
@@ -1,0 +1,6 @@
+class DiscoveryRule < ActiveRecord::Base
+  attr_accessible :enabled, :hostgroup_id, :hostname, :max_count, :name, :priority, :query
+
+  belongs_to :hostgroup
+  has_many :hosts
+end

--- a/app/models/host/managed_extensions.rb
+++ b/app/models/host/managed_extensions.rb
@@ -4,6 +4,8 @@ module Host::ManagedExtensions
   included do
     # execute standard callbacks
     after_validation :queue_reboot
+
+    belongs_to :discovery_rule
   end
 
   def queue_reboot

--- a/app/models/hostgroup_extensions.rb
+++ b/app/models/hostgroup_extensions.rb
@@ -1,0 +1,7 @@
+module HostgroupExtensions
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :discovery_rules
+  end
+end

--- a/app/models/setting/discovered.rb
+++ b/app/models/setting/discovered.rb
@@ -9,6 +9,7 @@ class Setting::Discovered < ::Setting
     Setting.transaction do
       [
         self.set('discovery_fact', _("The default fact name to use for the MAC of the system"), "discovery_bootif"),
+        self.set('discovery_auto', _("Initiate auto provision rule processing for incoming hosts"), false),
       ].compact.each { |s| self.create s.update(:category => "Setting::Discovered")}
     end
 

--- a/db/migrate/20141107091416_create_discovery_rules.rb
+++ b/db/migrate/20141107091416_create_discovery_rules.rb
@@ -1,0 +1,15 @@
+class CreateDiscoveryRules < ActiveRecord::Migration
+  def change
+    create_table :discovery_rules do |t|
+      t.string :name, :length => 254
+      t.string :query, :length => 254
+      t.integer :hostgroup_id, :null => false
+      t.string :hostname, :length => 254
+      t.integer :max_count, :default => 0
+      t.integer :priority, :default => 0
+      t.boolean :enabled, :default => true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20141107091417_add_discovery_rule_to_host.rb
+++ b/db/migrate/20141107091417_add_discovery_rule_to_host.rb
@@ -1,0 +1,9 @@
+class AddDiscoveryRuleToHost < ActiveRecord::Migration
+  def self.up
+    add_column :hosts, :discovery_rule_id, :integer
+  end
+
+  def self.down
+    remove_column :hosts, :discovery_rule_id, :integer
+  end
+end

--- a/lib/foreman_discovery.rb
+++ b/lib/foreman_discovery.rb
@@ -1,4 +1,39 @@
 require 'foreman_discovery/engine'
 
 module ForemanDiscovery
+  def self.execute_auto_provisioning dhost=nil
+    if dhost
+      Rails.logger.debug "Executing discovery rules for host #{dhost.name} (#{dhost.id})"
+      # for each discovery rule ordered by priority
+      DiscoveryRule.where(:enabled => true).order(:priority).each do |rule|
+        max = rule.max_count
+        usage = rule.hosts.size
+        Rails.logger.debug "Applying rule #{rule.name} (#{rule.id}) [#{usage}/#{max}]"
+        # if the rule has free slots
+        if max == 0 || usage < max
+          # try to match the query
+          if Host::Discovered.where(:id => dhost.id).search_for(rule.query).size > 0
+            Rails.logger.info "Match found for host #{dhost.name} (#{dhost.id}) rule #{rule.name} (#{rule.id})"
+            dhost = dhost.becomes(::Host::Managed)
+            dhost.type = 'Host::Managed'
+            dhost.managed = true
+            dhost.build = true
+            #dhost.name = XXX
+            dhost.hostgroup_id = rule.hostgroup_id
+            dhost.comment = "Auto-discovered and provisioned via rule '#{rule.name}'"
+            dhost.save!
+            break
+          end
+        else
+          Rails.logger.info "Skipping drained rule #{rule.name} (#{rule.id}) with max set to #{rule.max_count}"
+        end
+      end
+      return true
+    else
+      # For each discovered host
+      Host::Discovered.order(:last_report).each do |discovered_host|
+        execute_auto_provisioning discovered_host
+      end
+    end
+  end
 end

--- a/lib/foreman_discovery/engine.rb
+++ b/lib/foreman_discovery/engine.rb
@@ -64,6 +64,11 @@ module ForemanDiscovery
 
       end
     end
+
+    initializer "foreman_discovery.load_app_instance_data" do |app|
+      app.config.paths['db/migrate'] += ForemanDiscovery::Engine.paths['db/migrate'].existent
+    end
+
     initializer "foreman_discovery.apipie" do
       # this condition is here for compatibility reason to work with Foreman 1.4.x
       if Apipie.configuration.api_controllers_matcher.is_a?(Array) && Apipie.configuration.respond_to?(:checksum_path)
@@ -71,6 +76,7 @@ module ForemanDiscovery
         Apipie.configuration.checksum_path += ['/discovered_hosts/']
       end
     end
+
     # Include extensions to models in this config.to_prepare block
     config.to_prepare do
 
@@ -81,8 +87,9 @@ module ForemanDiscovery
         Rails.logger.warn 'PuppetFactParser not found, not loading Parser extensions'
       end
 
-      # Include host extensions
+      # Model extensions
       ::Host::Managed.send :include, Host::ManagedExtensions
+      ::Hostgroup.send :include, HostgroupExtensions
     end
 
     rake_tasks do


### PR DESCRIPTION
This is a WIP.

This implements simple rule engine which allows to assign host groups according
to scoped_search queries. Currently all our facts are strings, so searching is
little bit limited, but it works just fine.

Good testing query is something like `facts.architecture = x86_64` which is
likely to be true. Here are some rules to start with which can be created via
rails console:

```
=> [#<DiscoveryRule id: 1, name: "Database server rule", query: "facts.architecture = i386", hostgroup_id: 4, hostname: "test<%= facts['macaddress'] %>", max_count: 0, priority: 10, enabled: true, created_at: "2014-11-07 11:37:18", updated_at: "2014-11-07 11:37:18">,
 #<DiscoveryRule id: 2, name: "Web server rule", query: "facts.architecture = x86_64", hostgroup_id: 3, hostname: "test<%= facts['macaddress'] %>", max_count: 5, priority: 20, enabled: true, created_at: "2014-11-07 11:37:52", updated_at: "2014-11-07 11:37:52">,
 #<DiscoveryRule id: 3, name: "Web server drained rule", query: "facts.architecture = x86_64", hostgroup_id: 3, hostname: "test<%= facts['macaddress'] %>", max_count: 2, priority: 15, enabled: true, created_at: "2014-11-07 13:13:02", updated_at: "2014-11-07 13:13:02">,
 #<DiscoveryRule id: 4, name: "Disabled dummy rule", query: "facts.architecture = x86_64", hostgroup_id: 3, hostname: "test<%= facts['macaddress'] %>", max_count: 0, priority: 50, enabled: false, created_at: "2014-11-07 13:20:59", updated_at: "2014-11-07 13:20:59">]
```

There is no UI support yet, I am providing (untested) V2 API for rules CRUD. To
get this working in real-world scenario with Discovery 2.0, you need this patch
because systemd is too quick with shutdown:
https://github.com/theforeman/smart-proxy/pull/235

To test this, checkout the branch and do migration. Then create some rules via
V2 API. Once a discovery node is found, it should automaticaly start
provisioning (reboot can fail rolling back the transaction because of the shell
API provider issue). You can re-initiate auto-provisioning using an API call
(PUT discovery_rules/execute action).

Make sure the discovery_auto option is set to true when you want new nodes to
be automatically picked up for provisioning.

Also we need to make sure the host group has _everything_ set for provisioning,
otherwise the provisioning will fail (and possibly can end up in a loop). You
need to make sure root password is set as well. I think we need some kind of
check somewhere (in the Foreman core perhaps)?

TODO items:
- hammer CLI
- UI
- hostname setting via safe_mode
- validation of hostgroups
- testing
