### PR TITLE
Fixes #8422 - primary detection for non-discovered

### DIFF
--- a/app/lib/puppet_fact_parser_extensions.rb
+++ b/app/lib/puppet_fact_parser_extensions.rb
@@ -8,16 +8,18 @@ module PuppetFactParserExtensions
 
   # we prefer discovery_bootif fact to choose right primary interface (interface used to boot the image)
   def primary_interface_with_discovery_fact
-    mac = facts[discovery_mac_fact_name]
-    interfaces.each do |int, values|
-      return int.to_s if (values[:macaddress] == mac)
+    if facts.has_key?(discovery_mac_fact_name)
+      mac = facts[discovery_mac_fact_name]
+      interfaces.each do |int, values|
+        return int.to_s if (values[:macaddress].try(:downcase) == mac.try(:downcase))
+      end
     end
     primary_interface_without_discovery_fact # fallback if we didn't find interface with such macaddress
   end
 
   # search for IP of interface with primary interface macaddress (ipaddress fact does not have to be interface used for boot)
   def ip_with_discovery_fact
-    if facts[:interfaces]
+    if facts[:interfaces] && facts.has_key?(discovery_mac_fact_name)
       facts[:interfaces].split(',').each do |interface|
         if facts["macaddress_#{interface}"].try(:downcase) == facts[discovery_mac_fact_name].try(:downcase)
           return facts["ipaddress_#{interface}"]

--- a/test/unit/puppet_fact_parser_extensions_test.rb
+++ b/test/unit/puppet_fact_parser_extensions_test.rb
@@ -1,0 +1,63 @@
+require 'test_helper'
+
+class DummyPuppetFactParser
+  def ip
+    '192.168.0.30'
+  end
+
+  def primary_interface
+    'eth1'
+  end
+
+  def interfaces
+    {
+      'eth0' => {'macaddress' => 'aa:00:00:00:00:01', 'ipaddress' => '192.168.0.2'},
+      'eth3' => {'ipaddress' => '192.168.2.2'},
+      'eth2' => {'macaddress' => 'bb:00:00:00:00:01', 'ipaddress' => '192.168.1.2'}
+    }.with_indifferent_access
+  end
+
+  def facts
+    {
+      :ipaddress => '192.168.0.2', :macaddress => 'bb:00:00:00:00:01', :interfaces => 'eth0,eth1,lo',
+      :macaddress_eth1 => 'bb:00:00:00:00:01', :ipaddress_eth1 => '192.168.1.2',
+      :macaddress_eth0 => 'aa:00:00:00:00:01', :ipaddress_eth0 => '192.168.0.2',
+      :macaddress_lo => '', :ipaddress_lo => '127.0.0.1',
+      :mac_fact => 'AA:00:00:00:00:01'
+    }.with_indifferent_access
+  end
+
+  include PuppetFactParserExtensions
+end
+
+class PuppetFactParserTest < ActiveSupport::TestCase
+  setup do
+    @parser = DummyPuppetFactParser.new
+  end
+
+  test '#ip_with_discovery_fact ignores discovery part completely if discovery facts are not present' do
+    @parser.stubs(:discovery_mac_fact_name).returns('fact_that_does_not_exist')
+    assert_equal '192.168.0.30', @parser.ip
+  end
+
+  test '#ip_with_discovery_fact finds primary interface based on discovery facts and returns it\'s ip' do
+    @parser.stubs(:discovery_mac_fact_name).returns('mac_fact')
+    assert_equal '192.168.0.2', @parser.ip
+  end
+
+  test '#primary_interface_with_discovery_fact finds primary interface based on discovery facts' do
+    @parser.stubs(:discovery_mac_fact_name).returns('mac_fact')
+    assert_equal 'eth0', @parser.primary_interface
+  end
+
+  test '#primary_interface_with_discovery_fact falls back if no interface can be found by discovery mac' do
+    @parser.facts[:mac_fact] = 'cc:00:00:00:00:01'
+    @parser.stubs(:discovery_mac_fact_name).returns('mac_fact')
+    assert_equal 'eth0', @parser.primary_interface
+  end
+
+  test '#primary_interface_with_discovery_fact uses macaddress fact if discovery facts not available' do
+    @parser.stubs(:discovery_mac_fact_name).returns('fact_that_does_not_exist')
+    assert_equal 'eth1', @parser.primary_interface
+  end
+end


### PR DESCRIPTION
We injected discovery way to chose primary interface to puppet fact
parser that is used also for not discovered host which are missing
discovery specific facts. Mac for such value was evaluated to nil
which matched also macaddress_lo so lo was chosen as primary
interface.
