### PR TITLE
Fixes #9023 - discovery_fact_column global setting added

### DIFF
--- a/app/models/setting/discovered.rb
+++ b/app/models/setting/discovered.rb
@@ -1,6 +1,7 @@
 class Setting::Discovered < ::Setting
   BLANK_ATTRS << "discovery_location"
   BLANK_ATTRS << "discovery_organization"
+  BLANK_ATTRS << "discovery_fact_column"
 
   def self.load_defaults
     # Check the table exists
@@ -15,7 +16,13 @@ class Setting::Discovered < ::Setting
 
     Setting.transaction do
       [
-          self.set('discovery_prefix', _("The default prefix to use for the host name, must start with a letter"), "mac"),
+        self.set('discovery_prefix', _("The default prefix to use for the host name, must start with a letter"), "mac"),
+      ].compact.each { |s| self.create s.update(:category => "Setting::Discovered")}
+    end
+
+    Setting.transaction do
+      [
+        self.set('discovery_fact_column', _("Show fact as an extra column in the discovered hosts list"), ""),
       ].compact.each { |s| self.create s.update(:category => "Setting::Discovered")}
     end
 

--- a/app/views/discovered_hosts/_discovered_host.html.erb
+++ b/app/views/discovered_hosts/_discovered_host.html.erb
@@ -6,4 +6,7 @@
 <% unless defined? hide_disk %>
 <td><%= discovery_attribute(host, :disk_count) %></td>
 <td><%= number_to_human_size(discovery_attribute(host, :disks_size, 0)) %></td>
+<% if Setting['discovery_fact_column'].present? %>
+  <td><%= host.facts_hash[Setting['discovery_fact_column']] || 'N/A' %></td>
+<% end %>
 <% end %>

--- a/app/views/discovered_hosts/_discovered_hosts_list.html.erb
+++ b/app/views/discovered_hosts/_discovered_hosts_list.html.erb
@@ -12,6 +12,9 @@
     <th><%= sort :memory, :as => _('Memory') %></th>
     <th><%= sort :disk_count, :as => _('Disk count') %></th>
     <th><%= sort :disks_size, :as => _('Disks size') %></th>
+    <% if Setting['discovery_fact_column'].present? %>
+      <th><%= Setting['discovery_fact_column'].capitalize %></th>
+    <% end %>
     <% if SETTINGS[:locations_enabled] -%>
       <th><%= sort :location, :as => _('Location') %></th>
     <% end -%>

--- a/test/functional/discovered_hosts_controller_test.rb
+++ b/test/functional/discovered_hosts_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_plugin_helper'
 
 class DiscoveredHostsControllerTest < ActionController::TestCase
   setup :initialize_host
-  
+
   setup do
     @request.env['HTTP_REFERER'] = '/discovery_rules'
     @facts = {
@@ -14,6 +14,18 @@ class DiscoveredHostsControllerTest < ActionController::TestCase
 
   def test_index
     get :index, {}, set_session_user
+    assert_response :success
+  end
+
+  def test_index_with_custom_column
+    FactoryGirl.create(:setting,
+                       :name => 'discovery_fact_column',
+                       :value => "bios_vendor",
+                       :category => 'Setting::Discovered')
+    facts = @facts.merge({"bios_vendor" => "QEMU"})
+    Host::Discovered.import_host_and_facts(facts).first
+    get :index, {}, set_session_user
+    assert_select "td", /QEMU/
     assert_response :success
   end
 


### PR DESCRIPTION
Looks like this:

![](http://www.clipular.com/c/5633611208327168.png?k=zKY4cYNBUnCH_Wc-kXKIOVP9LZM)

Set to blank to remove the column (default).

Set to any fact name to show it e.g. `bios_vendor`.

When fact is not present for particular host, it's blank.
