### PR TITLE
Refs #8831 - Reverts two-pane forms

### DIFF
--- a/app/assets/javascripts/discovery-two-pane.js
+++ b/app/assets/javascripts/discovery-two-pane.js
@@ -1,6 +1,0 @@
-$(document).on('click', ".table-two-pane .display-two-pane a", function (e) {
-  if ($('.table-two-pane').length) {
-    e.preventDefault();
-    two_pane_open(this);
-  }
-});

--- a/app/assets/stylesheets/discovery-two-pane.scss
+++ b/app/assets/stylesheets/discovery-two-pane.scss
@@ -1,3 +1,0 @@
-.btn-group {
-  margin-right: 10px;
-}

--- a/app/controllers/discovered_hosts_controller.rb
+++ b/app/controllers/discovered_hosts_controller.rb
@@ -13,6 +13,8 @@ class DiscoveredHostsController < ::ApplicationController
 
   helper :hosts
 
+  layout 'layouts/application'
+
   def index
     search = resource_base.search_for(params[:search], :order => params[:order])
     respond_to do |format|

--- a/app/helpers/discovered_hosts_helper.rb
+++ b/app/helpers/discovered_hosts_helper.rb
@@ -4,19 +4,22 @@ module DiscoveredHostsHelper
     record.last_report? ? (_("%s ago") % time_ago_in_words(record.last_report.getlocal)) : ""
   end
 
-  def discovered_hosts_actions(host)
-    actions = [[_('Refresh facts'), hash_for_refresh_facts_discovered_host_path(:id => host)],
-               [_('Reboot'), hash_for_reboot_discovered_host_path(:id => host), :method => :put]]
-    button_group(
-        link_to(_("Provision"), hash_for_edit_discovered_host_path(:id => host), :class => 'btn btn-primary btn-group'),
-        link_to(_("Auto Provision"), hash_for_auto_provision_discovered_host_path(:id => host), :class => 'btn btn-default btn-group', :method => :post),
-        select_action_button(_("Select Action"), {:class => 'btn-group' },
-                             actions.map do |action|
-                               method = action[2] if action.size > 1
-                               link_to(action[0], action[1], method)
-                             end.flatten),
+  def discovered_hosts_title_actions(host)
+    actions = [[_('Provision'),  hash_for_edit_discovered_host_path(:id => host)]]
+    actions <<  [_('Auto Provision'), hash_for_auto_provision_discovered_host_path(:id => host), :method => :post]
+    actions <<  [_('Refresh facts') ,hash_for_refresh_facts_discovered_host_path(:id => host)]
+    actions <<  [_('Reboot') ,hash_for_reboot_discovered_host_path(:id => host), :method => :put]
+    title_actions(
+        select_action_button( _("Select Action"), {},
+                              actions.map do |action|
+                                method = action[2] if action.size > 1
+                                link_to(action[0] , action[1], method)
+                              end.flatten
+        ),
+      button_group(
         link_to(_("Delete"), hash_for_discovered_host_path(:id => host),
-                :class => 'btn btn-danger', :confirm => _('Are you sure?'), :method => :delete)
+                :class => "btn btn-danger", :confirm => _('Are you sure?'), :method => :delete)
+      )
     )
   end
 

--- a/app/views/discovered_hosts/_discovered_host.html.erb
+++ b/app/views/discovered_hosts/_discovered_host.html.erb
@@ -1,12 +1,12 @@
-<td class="hidden-tablet hidden-xs display-two-pane"><%= link_to h(host.name), discovered_host_path(host) %></td>
-<td><%= model_name host %></td>
-<td><%= host.ip %></td>
-<td><%= discovery_attribute(host, :cpu_count) %></td>
-<td><%= number_to_human_size(discovery_attribute(host, :memory, 0) * 1024 * 1024) %></td>
+<td><%= link_to h(host.name), discovered_host_path(host) %></td>
+<td class="hidden-tablet hidden-xs"><%= model_name host %></td>
+<td class="hidden-tablet hidden-xs"><%= host.ip %></td>
+<td class="hidden-tablet hidden-xs"><%= discovery_attribute(host, :cpu_count) %></td>
+<td class="hidden-tablet hidden-xs"><%= number_to_human_size(discovery_attribute(host, :memory, 0) * 1024 * 1024) %></td>
 <% unless defined? hide_disk %>
-<td><%= discovery_attribute(host, :disk_count) %></td>
-<td><%= number_to_human_size(discovery_attribute(host, :disks_size, 0)) %></td>
+<td class="hidden-tablet hidden-xs"><%= discovery_attribute(host, :disk_count) %></td>
+<td class="hidden-tablet hidden-xs"><%= number_to_human_size(discovery_attribute(host, :disks_size, 0)) %></td>
 <% if Setting['discovery_fact_column'].present? %>
-  <td><%= host.facts_hash[Setting['discovery_fact_column']] || 'N/A' %></td>
+  <td class="hidden-tablet hidden-xs"><%= host.facts_hash[Setting['discovery_fact_column']] || 'N/A' %></td>
 <% end %>
 <% end %>

--- a/app/views/discovered_hosts/_discovered_hosts_list.html.erb
+++ b/app/views/discovered_hosts/_discovered_hosts_list.html.erb
@@ -1,28 +1,26 @@
-<%= javascript "jquery.cookie", "host_checkbox", "discovery-two-pane" %>
+<%= javascript "jquery.cookie", "host_checkbox" %>
 <% title _('Discovered hosts') %>
-<% stylesheet("discovery-two-pane") %>
-
-<table class="table table-bordered table-striped table-condensed table-two-pane" >
+<table class="table table-bordered table-striped table-condensed" >
   <tr>
     <th class="ca"><%= check_box_tag "check_all", "", false, { :onclick => "toggleCheck()", :'check-title' => _("Select all items in this page"), :'uncheck-title'=> _("items selected. Uncheck to Clear") } %></th>
-    <th class='hidden-tablet hidden-xs'><%= sort :name, :as => _('Name') %></th>
-    <th><%= sort :model, :as => _('Model') %></th>
-    <th><%= sort :ip, :as => _('IP Address') %></th>
-    <th><%= sort :cpu_count, :as => _('CPU') %></th>
-    <th><%= sort :memory, :as => _('Memory') %></th>
-    <th><%= sort :disk_count, :as => _('Disk count') %></th>
-    <th><%= sort :disks_size, :as => _('Disks size') %></th>
+    <th class=''><%= sort :name, :as => _('Name') %></th>
+    <th class="hidden-tablet hidden-xs"><%= sort :model, :as => _('Model') %></th>
+    <th class="hidden-tablet hidden-xs"><%= sort :ip, :as => _('IP Address') %></th>
+    <th class="hidden-tablet hidden-xs"><%= sort :cpu_count, :as => _('CPU') %></th>
+    <th class="hidden-tablet hidden-xs"><%= sort :memory, :as => _('Memory') %></th>
+    <th class="hidden-tablet hidden-xs"><%= sort :disk_count, :as => _('Disk count') %></th>
+    <th class="hidden-tablet hidden-xs"><%= sort :disks_size, :as => _('Disks size') %></th>
     <% if Setting['discovery_fact_column'].present? %>
-      <th><%= Setting['discovery_fact_column'].capitalize %></th>
+      <th class="hidden-tablet hidden-xs"><%= Setting['discovery_fact_column'].capitalize %></th>
     <% end %>
     <% if SETTINGS[:locations_enabled] -%>
-      <th><%= sort :location, :as => _('Location') %></th>
+      <th class="hidden-tablet hidden-xs"><%= sort :location, :as => _('Location') %></th>
     <% end -%>
     <% if SETTINGS[:organizations_enabled] -%>
-      <th><%= sort :organization, :as => _('Organization') %></th>
+      <th class="hidden-tablet hidden-xs"><%= sort :organization, :as => _('Organization') %></th>
     <% end -%>
-    <th><%= sort :subnet, :as => _("Subnet") %></th>
-    <th><%= sort :last_report, :as => _("Last facts upload") %></th>
+    <th class="hidden-tablet hidden-xs"><%= sort :subnet, :as => _("Subnet") %></th>
+    <th class="hidden-tablet hidden-xs"><%= sort :last_report, :as => _("Last facts upload") %></th>
     <th></th>
   </tr>
   <% @hosts.each do |host| -%>
@@ -32,13 +30,13 @@
       </td>
       <%= render :partial => "discovered_host", :locals => {:host => host} %>
       <% if SETTINGS[:locations_enabled] -%>
-        <td><%= host.location.try(:name) %></td>
+        <td class="hidden-tablet hidden-xs"><%= host.location.try(:name) %></td>
       <% end -%>
       <% if SETTINGS[:organizations_enabled] -%>
-        <td><%= host.organization.try(:name) %></td>
+        <td class="hidden-tablet hidden-xs"><%= host.organization.try(:name) %></td>
       <% end -%>
-      <td><%= host.subnet %></td>
-      <td><%= disc_report_column(host) %></td>
+      <td class="hidden-tablet hidden-xs"><%= host.subnet %></td>
+      <td class="hidden-tablet hidden-xs"><%= disc_report_column(host) %></td>
       <td>
         <%= action_buttons(
           link_to(_("Provision"), hash_for_edit_discovered_host_path(:id => host)),

--- a/app/views/discovered_hosts/show.html.erb
+++ b/app/views/discovered_hosts/show.html.erb
@@ -1,24 +1,16 @@
-<%= form_for @host do |f| %>
-    <div class="tab-content">
-      <div class="display-tab-pane" id="primary">
-        <%= discovered_hosts_actions(@host) %>
-        <h3><%= _('Facts discovered on this host') -%></h3>
-        <table class="table table-bordered table-striped table-condensed">
-          <thead>
-            <tr>
-                <th><%= _('Fact') -%></th>
-                <th><%= _('Value') -%></th>
-            </tr>
-          </thead>
-          <tbody>
-            <% f.object.facts_hash.sort.each do |fact| -%>
-              <tr>
-                <td><%= fact[0] %></td>
-                <td><%= trunc(fact[1], 80) %></td>
-              </tr>
-            <% end -%>
-          </tbody>
-        </table>
-      </div>
-    </div>
-<% end %>
+<% title(_("Discovered host: %s") % @host.to_label) %>
+
+<%= discovered_hosts_title_actions(@host) %>
+
+<h3><%= _('Facts discovered on this host') -%></h3>
+<table class="table table-bordered table-striped table-condensed">
+  <tr>
+    <th><%= _('Fact') -%></th>
+    <th><%= _('Value') -%></th>
+  <% @host.facts_hash.sort.each do |fact| -%>
+    <tr>
+      <td><%= fact[0] %></td>
+      <td><%= truncate(fact[1], :length => 100) %></td>
+    </tr>
+  <% end -%>
+</table>

--- a/app/views/discovery_rules/index.html.erb
+++ b/app/views/discovery_rules/index.html.erb
@@ -13,7 +13,7 @@
   </tr>
   <% for rule in @discovery_rules %>
     <tr>
-      <td class='col-md-3 display-two-pane'><%= link_to_if_authorized(trunc(rule.name), hash_for_edit_discovery_rule_path(:id => rule).merge(:auth_object => rule, :authorizer => authorizer)) %></td>
+      <td class='col-md-3'><%= link_to_if_authorized(trunc(rule.name), hash_for_edit_discovery_rule_path(:id => rule).merge(:auth_object => rule, :authorizer => authorizer)) %></td>
       <td><%= rule.priority %></td>
       <td><%= rule.search %></td>
       <td><%= rule.hostgroup.name %></td>

--- a/lib/foreman_discovery/engine.rb
+++ b/lib/foreman_discovery/engine.rb
@@ -22,16 +22,6 @@ module ForemanDiscovery
       ActionView::Base.send :include, DiscoveredHostsHelper
     end
 
-    initializer "foreman_discovery.assets.precompile" do |app|
-      app.config.assets.precompile += %w(foreman_discovery/discovery-two-pane.js
-                                         foreman_discovery/discovery-two-pane.scss)
-    end
-
-    initializer 'foreman_discovery.configure_assets', :group => :assets do
-      SETTINGS[:foreman_discovery] =
-          { :assets => { :precompile => ['foreman_discovery/discovery-two-pane.js', 'foreman_discovery/discovery-two-pane.scss'] } }
-    end
-
     initializer 'foreman_discovery.register_gettext', :after => :load_config_initializers do |app|
       locale_dir = File.join(File.expand_path('../../..', __FILE__), 'locale')
       locale_domain = 'foreman_discovery'


### PR DESCRIPTION
We are pulling two-pane patch off the 2.0 for now. It's too complicated for 
now. Let's do proper implementation for Foreman 1.8 later on.

This reverts commit 7a6454704cf87f712d9f32fae584245c41f24fa1.

Conflicts:
app/views/discovered_hosts/_discovered_host.html.erb
app/views/discovered_hosts/_discovered_hosts_list.html.erb
