### PR TITLE
Fixes #9077 - added tests for safemode

### DIFF
--- a/app/controllers/concerns/foreman/controller/discovered_extensions.rb
+++ b/app/controllers/concerns/foreman/controller/discovered_extensions.rb
@@ -33,10 +33,14 @@ module Foreman::Controller::DiscoveredExtensions
     host.type = 'Host::Managed'
     host.managed = true
     host.build = true
-    host.name = host.render_template(rule.hostname) unless rule.hostname.empty?
     host.hostgroup_id = rule.hostgroup_id
     host.comment = "Auto-discovered and provisioned via rule '#{rule.name}'"
     host.discovery_rule = rule
+    # render hostname only when all other fields are set
+    original_name = host.name
+    host.name = host.render_template(rule.hostname) unless rule.hostname.empty?
+    # fallback to the original if template did not expand
+    host.name = original_name if host.name.empty?
     Host.transaction do
       if host.save #save! does not work here
         delete_discovery_attribute_set(host.id)

--- a/lib/foreman_discovery/engine.rb
+++ b/lib/foreman_discovery/engine.rb
@@ -104,7 +104,7 @@ module ForemanDiscovery
         widget 'discovery_widget', :name=>N_('Discovery widget'), :sizex => 7, :sizey =>1
 
         # add template helpers
-        allowed_template_helpers :rand, :facts_hash
+        allowed_template_helpers :rand
 
         # apipie API documentation
         # Only available in 1.8, otherwise it has to be in the initializer below


### PR DESCRIPTION
This patch basically adds tests for safemode (and also both non-safemode tests)
and it slightly improve hostname rendering (when it renders to empty string it
falls back to the original name `macMACADDRESS`.

Also I removed the `facts_hash` from allowed helpers because this is not a
helper but method. It will be allowed (together with alias `facts`) in a
different patch in core: https://github.com/theforeman/foreman/pull/2102

One test is set to be skipped - it won't be green until the above patch is
applied.
