### PR TITLE
refs #9044 - Fixes broken mac tests

### DIFF
--- a/app/models/host/discovered.rb
+++ b/app/models/host/discovered.rb
@@ -54,7 +54,16 @@ class Host::Discovered < ::Host::Base
     h = ::Host::Discovered.find_by_name hostname
     h ||= Host.new :name => hostname, :type => "Host::Discovered"
     h.type = "Host::Discovered"
-    h.mac = facts[fact_name].try(:downcase)
+
+    macfact = facts[fact_name].try(:downcase)
+    begin
+      macfact = Net::Validations.normalize_mac(macfact)
+    rescue ArgumentError => e
+      macfact = facts['discovery_bootif'].try(:downcase)
+      h.name = facts['discovery_bootif'].try(:downcase).try(:gsub,/:/,'').try(:sub,/^/, hostname_prefix)
+    end
+    h.mac = macfact
+
 
     if SETTINGS[:locations_enabled]
       begin

--- a/test/unit/facts.json
+++ b/test/unit/facts.json
@@ -88,7 +88,7 @@
     "lsbmajdistrelease": "6",
     "swapfree": "16.72 GB",
     "netmask": "255.255.255.192",
-    "discovery_bootif": "AA:BB:CC:DD:EE:FF",
+    "discovery_bootif": "AA:BB:CC:DD:EE:F5",
     "memorysize_mb": "742.13",
     "blockdevice_sda_size": "214749184"
   }


### PR DESCRIPTION
Tests for discovery were broken: http://ci.theforeman.org/job/test_plugin/4906/#showFailuresLink
since https://github.com/theforeman/foreman/commit/ee1f56de6b2bdca4dfd104b99ec25340bfb51aaa was committed.
