### PR TITLE
refs #8963 - remove trunc from discovery_rules index

### DIFF
--- a/app/views/discovery_rules/index.html.erb
+++ b/app/views/discovery_rules/index.html.erb
@@ -13,7 +13,7 @@
   </tr>
   <% for rule in @discovery_rules %>
     <tr>
-      <td class='col-md-3'><%= link_to_if_authorized(trunc(rule.name), hash_for_edit_discovery_rule_path(:id => rule).merge(:auth_object => rule, :authorizer => authorizer)) %></td>
+      <td class='col-md-3'><%= link_to_if_authorized(rule.name, hash_for_edit_discovery_rule_path(:id => rule).merge(:auth_object => rule, :authorizer => authorizer)) %></td>
       <td><%= rule.priority %></td>
       <td><%= rule.search %></td>
       <td><%= rule.hostgroup.name %></td>


### PR DESCRIPTION
DO NOT MERGE before discovery works with foreman 1.8
