### PR TITLE
Refs #9044 - disabled MAC validation test for 1.7

### DIFF
--- a/test/unit/host_discovered_test.rb
+++ b/test/unit/host_discovered_test.rb
@@ -49,6 +49,7 @@ class HostDiscoveredTest < ActiveSupport::TestCase
   end
 
   test "should create discovered host with default name if fact_name isn't a valid mac" do
+    skip "until http://projects.theforeman.org/issues/9044 is fixed in 1.7.3"
     raw = parse_json_fixture('/facts.json')
     Setting[:discovery_fact] = 'lsbdistcodename'
     host = Host::Discovered.import_host_and_facts(raw['facts']).first


### PR DESCRIPTION
This goes into _2.0-stable_ only!
