### PR TITLE
Refs #5701 - provided functional tests for edit html ids

### DIFF
--- a/test/functional/discovered_hosts_controller_test.rb
+++ b/test/functional/discovered_hosts_controller_test.rb
@@ -31,6 +31,17 @@ class DiscoveredHostsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  def test_edit_form
+    host = Host::Discovered.import_host_and_facts(@facts).first
+    get :edit, {:id => host.id}, set_session_user
+    assert_select "select" do |elements|
+      elements.each do |element|
+        assert_match(/^host_/, element.attributes['id'])
+        assert_match(/^host\[/, element.attributes['name'])
+      end
+    end
+  end
+
   def test_index_json
     get :index, {:format => "json"}, set_session_user
     assert_response :success


### PR DESCRIPTION
This is a test for https://github.com/theforeman/foreman/pull/2120

Due to bug in core, three edit fields/selects receive incorrect form names,
thus discovery edit form does not work properly. The patch in core is ready and
this is a test for the behavior we expect in discovery.
