### PR TITLE
Fixes #9488 - migration to delete discovery_attribute_set from managed hosts

### DIFF
--- a/db/migrate/20150310153859_remove_discovery_attribute_sets_from_managed_hosts.rb
+++ b/db/migrate/20150310153859_remove_discovery_attribute_sets_from_managed_hosts.rb
@@ -1,0 +1,8 @@
+class RemoveDiscoveryAttributeSetsFromManagedHosts < ActiveRecord::Migration
+  def up
+    DiscoveryAttributeSet.where(:id => DiscoveryAttributeSet.joins(:host).where(:'hosts.managed' => true).pluck(:id)).delete_all
+  end
+
+  def down
+  end
+end


### PR DESCRIPTION
The problems with deleting `discovery_attribute_set` when provisioning a host should be fixed by: https://github.com/theforeman/foreman_discovery/pull/161.
This PR is to fix the existing managed hosts that can't be deleted because they are still attached to a `discovery_attribute_set`
