### PR TITLE
Fixes #9895 - user in Discovery Reader role should see discovery rules

### DIFF
--- a/db/migrate/20150512150432_remove_old_discovery_reader_permissions.rb
+++ b/db/migrate/20150512150432_remove_old_discovery_reader_permissions.rb
@@ -1,0 +1,9 @@
+class RemoveOldDiscoveryReaderPermissions < ActiveRecord::Migration
+  def up
+    Permission.where("name like '%_discovery_rules' and resource_type is null").destroy_all
+  end
+
+  def down
+  end
+end
+

--- a/lib/foreman_discovery/engine.rb
+++ b/lib/foreman_discovery/engine.rb
@@ -67,23 +67,23 @@ module ForemanDiscovery
           permission :view_discovery_rules, {
             :discovery_rules => [:index, :show, :auto_complete_search],
             :"api/v2/discovery_rules" => [:index, :show]
-          }
+          }, :resource_type => 'DiscoveryRule'
           permission :new_discovery_rules, {
             :discovery_rules => [:new, :create],
             :"api/v2/discovery_rules" => [:create]
-          }
+          }, :resource_type => 'DiscoveryRule'
           permission :edit_discovery_rules, {
             :discovery_rules => [:edit, :update, :enable, :disable],
             :"api/v2/discovery_rules" => [:create, :update]
-          }
+          }, :resource_type => 'DiscoveryRule'
           permission :execute_discovery_rules, {
             :discovery_rules => [:auto_provision, :auto_provision_all],
             :"api/v2/discovery_rules" => [:auto_provision, :auto_provision_all]
-          }
+          }, :resource_type => 'DiscoveryRule'
           permission :delete_discovery_rules, {
             :discovery_rules => [:destroy],
             :"api/v2/discovery_rules" => [:destroy]
-          }
+          }, :resource_type => 'DiscoveryRule'
         end
 
         # roles (only added if they don't exist)


### PR DESCRIPTION
after adding this I needed to re-add the filters with the correct resource and then the role started working for me.
