### PR TITLE
refs #9881 - discovery_rules works when organizations and locations are disabled

### DIFF
--- a/app/controllers/concerns/foreman/controller/discovered_extensions.rb
+++ b/app/controllers/concerns/foreman/controller/discovered_extensions.rb
@@ -14,7 +14,7 @@ module Foreman::Controller::DiscoveredExtensions
         # try to match the search
         begin
           if Host::Discovered.where(:id => host.id).search_for(rule.search).size > 0
-            if rule.organizations.include?(host.organization) && rule.locations.include?(host.location)
+            if validate_rule_by_taxonomy(rule, host)
               Rails.logger.info "Match found for host #{host.name} (#{host.id}) rule #{rule.name} (#{rule.id})"
               return rule
             else
@@ -29,7 +29,17 @@ module Foreman::Controller::DiscoveredExtensions
       end
     end
     return false
-  end
+    end
+
+    def validate_rule_by_taxonomy rule, host
+      if SETTINGS[:organizations_enabled]
+        return false unless rule.organizations.include?(host.organization)
+      end
+      if SETTINGS[:locations_enabled]
+        return false unless rule.locations.include?(host.location)
+      end
+      true
+    end
 
   # trigger the provisioning
   def perform_auto_provision original_host, rule

--- a/app/views/discovery_rules/_form.html.erb
+++ b/app/views/discovery_rules/_form.html.erb
@@ -1,7 +1,6 @@
 <%= form_for @discovery_rule, :url => (@discovery_rule.new_record? ? discovery_rules_path : discovery_rule_path(:id => @discovery_rule.id)) do |f| %>
     <%= base_errors_for @discovery_rule %>
 
-    <% if show_taxonomy_tabs? %>
         <ul class="nav nav-tabs" data-tabs="tabs">
           <li class="active"><a href="#primary" data-toggle="tab"><%= _('Primary') %></a></li>
           <% if show_location_tab? %>
@@ -46,13 +45,9 @@
             <%= text_f f, :priority, :help_inline => _('Rule priority (lower integer means higher priority)') %>
             <%= checkbox_f f, :enabled %>
           </div>
-
-          <%= render 'taxonomies/loc_org_tabs', :f => f, :obj => @discovery_rule %>
+          <% if show_taxonomy_tabs? %>
+            <%= render 'taxonomies/loc_org_tabs', :f => f, :obj => @discovery_rule %>
+          <% end %>
         </div>
-
-    <% else %>
-        <%= text_f f, :name %>
-    <% end %>
-
     <%= submit_or_cancel f %>
 <% end %>


### PR DESCRIPTION
This PR fixed @domcleal's comments on https://github.com/theforeman/foreman_discovery/pull/172

@lzap - this isn't completely ready yet. I opened this so we can test using it and decide what to do when discovery_rules doesn't have a organization/location (when they are enabled and disabled)? when the host doesn't have them? when neither have them?
I will write tests according to the conclusions to these questions.
