### PR TITLE
Fixes #10005 - removed unused default scope and added tax tests

### DIFF
--- a/app/models/host/discovered.rb
+++ b/app/models/host/discovered.rb
@@ -3,8 +3,6 @@ require 'foreman_discovery/proxy_operations'
 class Host::Discovered < ::Host::Base
   include ScopedSearchExtensions
 
-  belongs_to :location
-  belongs_to :organization
   belongs_to :subnet
   belongs_to :hostgroup
   has_one    :discovery_attribute_set, :foreign_key => :host_id, :dependent => :destroy
@@ -26,15 +24,6 @@ class Host::Discovered < ::Host::Base
   scoped_search :in => :discovery_attribute_set, :on => :memory, :rename => :memory, :complete_value => true, :only_explicit => true
   scoped_search :in => :discovery_attribute_set, :on => :disk_count, :rename => :disk_count, :complete_value => true, :only_explicit => true
   scoped_search :in => :discovery_attribute_set, :on => :disks_size, :rename => :disks_size, :complete_value => true, :only_explicit => true
-
-  default_scope lambda {
-    org = Organization.current
-    loc = Location.current
-    conditions = {}
-    conditions[:organization_id] = org.subtree_ids if org
-    conditions[:location_id]     = loc.subtree_ids if loc
-    where(conditions)
-  }
 
   def self.import_host_and_facts facts
     raise(::Foreman::Exception.new(N_("Invalid facts, must be a Hash"))) unless facts.is_a?(Hash)

--- a/test/unit/host_discovered_test.rb
+++ b/test/unit/host_discovered_test.rb
@@ -84,8 +84,33 @@ class HostDiscoveredTest < ActiveSupport::TestCase
     assert host.name.start_with?('mac')
   end
 
+  test 'discovered host can be searched in multiple taxonomies' do
+    org1 = FactoryGirl.create(:organization)
+    org2 = FactoryGirl.create(:organization)
+    org3 = FactoryGirl.create(:organization)
+    user = FactoryGirl.create(:user, :organizations => [org1, org2])
+    host1 = FactoryGirl.create(:host, :type => "Host::Discovered", :organization => org1)
+    host2 = FactoryGirl.create(:host, :type => "Host::Discovered", :organization => org2)
+    host3 = FactoryGirl.create(:host, :type => "Host::Discovered", :organization => org3)
+    hosts = nil
+
+    assert_nil Organization.current
+    as_user(user) do
+      hosts = Host::Discovered.all
+    end
+    assert_includes hosts, host1
+    assert_includes hosts, host2
+    refute_includes hosts, host3
+
+    as_user(:one) do
+      hosts = Host::Discovered.all
+    end
+    assert_includes hosts, host1
+    assert_includes hosts, host2
+    assert_includes hosts, host3
+  end
+
   def parse_json_fixture(relative_path)
     return JSON.parse(File.read(File.expand_path(File.dirname(__FILE__) + relative_path)))
   end
-
 end


### PR DESCRIPTION
Since the patch #2273 already fixed the problem with taxanomies and patch #2287
moved default scoped search to Host::Base, I am removing the unnecessary scope
from Host::Discovered and adding extra test to cover taxanomies.

The patch #2287 fixes the problem for discovery and this patch is not
necessary. It's rather cleanup patch, therefore this is not going to be
released in 3.0.1 for now.
