### PR TITLE
Fixes #10375 - entering edit form deletes attributes

### DIFF
--- a/app/controllers/discovered_hosts_controller.rb
+++ b/app/controllers/discovered_hosts_controller.rb
@@ -29,7 +29,7 @@ class DiscoveredHostsController < ::ApplicationController
   # as a parameter and use refresh_facts to get the rest
   def create
     Taxonomy.no_taxonomy_scope do
-      host, imported = Host::Discovered.new(:ip => get_ip_from_env).refresh_facts
+      _, imported = Host::Discovered.new(:ip => get_ip_from_env).refresh_facts
       respond_to do |format|
         format.yml {
           if imported
@@ -60,14 +60,14 @@ class DiscoveredHostsController < ::ApplicationController
 
   def edit
     Host.transaction do
-      @host = ::ForemanDiscovery::HostConverter.to_managed(@host) unless @host.nil?
+      @host = ::ForemanDiscovery::HostConverter.to_managed(@host, true, false) unless @host.nil?
       render :template => 'hosts/edit'
     end
   end
 
   def update
     Host.transaction do
-      @host = ::ForemanDiscovery::HostConverter.to_managed(@host, false, false)
+      @host = ::ForemanDiscovery::HostConverter.to_managed(@host)
       forward_url_options
       Taxonomy.no_taxonomy_scope do
         if @host.update_attributes(params[:host])

--- a/app/models/host/managed_extensions.rb
+++ b/app/models/host/managed_extensions.rb
@@ -4,6 +4,7 @@ module Host::ManagedExtensions
   included do
     # execute standard callbacks
     after_validation :queue_reboot
+    after_save :delete_discovery_attribute_set
 
     belongs_to :discovery_rule
   end
@@ -22,6 +23,11 @@ module Host::ManagedExtensions
   def delReboot
     # nothing to do here, in reality we should never hit this method since this should be the
     # last action in the queue.
+  end
+
+  def delete_discovery_attribute_set
+    return if new_record?
+    DiscoveryAttributeSet.destroy_all(:host_id => self.id) if type_changed?
   end
 
 end

--- a/test/functional/discovered_hosts_controller_test.rb
+++ b/test/functional/discovered_hosts_controller_test.rb
@@ -6,11 +6,12 @@ class DiscoveredHostsControllerTest < ActionController::TestCase
   setup do
     @request.env['HTTP_REFERER'] = '/discovery_rules'
     @facts = {
-      "interfaces"       => "lo,eth0",
-      "ipaddress"        => "192.168.100.42",
-      "ipaddress_eth0"   => "192.168.100.42",
-      "macaddress_eth0"  => "AA:BB:CC:DD:EE:FF",
-      "discovery_bootif" => "AA:BB:CC:DD:EE:FF",
+      "interfaces"             => "lo,eth0",
+      "ipaddress"              => "192.168.100.42",
+      "ipaddress_eth0"         => "192.168.100.42",
+      "macaddress_eth0"        => "AA:BB:CC:DD:EE:FF",
+      "discovery_bootif"       => "AA:BB:CC:DD:EE:FF",
+      "physicalprocessorcount" => "42",
     }
   end
 
@@ -31,7 +32,7 @@ class DiscoveredHostsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  def test_edit_form
+  def test_edit_form_elements
     host = Host::Discovered.import_host_and_facts(@facts).first
     get :edit, {:id => host.id}, set_session_user
     assert_select "select" do |elements|
@@ -40,6 +41,14 @@ class DiscoveredHostsControllerTest < ActionController::TestCase
         assert_match(/^host\[/, element.attributes['name'])
       end
     end
+  end
+
+  def test_edit_form_attributes
+    host = Host::Discovered.import_host_and_facts(@facts).first
+    Host.transaction do
+      get :edit, {:id => host.id}, set_session_user
+    end
+    assert_not_nil host.cpu_count
   end
 
   def test_index_json


### PR DESCRIPTION
We simply deleted attributes on edit form render. I added a comment explaining
the method and how it should be used.
