### PR TITLE
Fixes #10195 - discovered node is no longer rebooted on error

### DIFF
--- a/app/models/host/managed_extensions.rb
+++ b/app/models/host/managed_extensions.rb
@@ -10,19 +10,22 @@ module Host::ManagedExtensions
   end
 
   def queue_reboot
+    return unless errors.empty? && Setting[:discovery_reboot]
     return if new_record? # Discovered Hosts already exist, and new_records will break `find`
     return unless type_changed? and ::Host::Base.find(self.id).type == "Host::Discovered"
+    # reboot task must be high priority and there is no compensation action apparently
     post_queue.create(:name => _("Rebooting %s") % self, :priority => 10000,
                       :action => [self, :setReboot])
   end
 
   def setReboot
     old.becomes(Host::Discovered).reboot
-  end
-
-  def delReboot
-    # nothing to do here, in reality we should never hit this method since this should be the
-    # last action in the queue.
+    # It is too late to report error in the post_queue, we catch them and
+    # continue. If flash is implemented for new hosts (http://projects.theforeman.org/issues/10559)
+    # we can report the error to the user perhaps.
+    true
+  rescue ::Foreman::Exception
+    true
   end
 
   def delete_discovery_attribute_set

--- a/app/models/setting/discovered.rb
+++ b/app/models/setting/discovered.rb
@@ -9,14 +9,15 @@ class Setting::Discovered < ::Setting
 
     Setting.transaction do
       [
-        self.set('discovery_fact', _("Fact name to use for primary interface detection and hostname"), "discovery_bootif"),
-        self.set('discovery_auto', _("Automatically provision newly discovered hosts, according to the provisioning rules"), false),
+        self.set('discovery_fact', N_("Fact name to use for primary interface detection and hostname"), "discovery_bootif"),
+        self.set('discovery_auto', N_("Automatically provision newly discovered hosts, according to the provisioning rules"), false),
+        self.set('discovery_reboot', N_("Automatically reboot discovered host during provisioning"), true),
       ].compact.each { |s| self.create s.update(:category => "Setting::Discovered")}
     end
 
     Setting.transaction do
       [
-        self.set('discovery_prefix', _("The default prefix to use for the host name, must start with a letter"), "mac"),
+        self.set('discovery_prefix', N_("The default prefix to use for the host name, must start with a letter"), "mac"),
       ].compact.each { |s| self.create s.update(:category => "Setting::Discovered")}
     end
 
@@ -29,14 +30,14 @@ class Setting::Discovered < ::Setting
     if SETTINGS[:locations_enabled]
       Setting.transaction do
         [
-          self.set('discovery_location', _("The default location to place discovered hosts in"), ""),
+          self.set('discovery_location', N_("The default location to place discovered hosts in"), ""),
         ].compact.each { |s| self.create s.update(:category => "Setting::Discovered")}
       end
     end
     if SETTINGS[:organizations_enabled]
       Setting.transaction do
         [
-          self.set('discovery_organization', _("The default organization to place discovered hosts in"), "" ),
+          self.set('discovery_organization', N_("The default organization to place discovered hosts in"), "" ),
         ].compact.each { |s| self.create s.update(:category => "Setting::Discovered")}
       end
     end

--- a/test/functional/discovered_hosts_controller_test.rb
+++ b/test/functional/discovered_hosts_controller_test.rb
@@ -13,6 +13,10 @@ class DiscoveredHostsControllerTest < ActionController::TestCase
       "discovery_bootif"       => "AA:BB:CC:DD:EE:FF",
       "physicalprocessorcount" => "42",
     }
+    FactoryGirl.create(:setting,
+                       :name => 'discovery_reboot',
+                       :value => true,
+                       :category => 'Setting::Discovered')
   end
 
   def test_index
@@ -84,10 +88,10 @@ class DiscoveredHostsControllerTest < ActionController::TestCase
     host = FactoryGirl.create(:host,
                               :ip   => '1.2.3.4',
                               :type => "Host::Discovered")
-    ::ProxyAPI::BMC.any_instance.expects(:power).raises("request must fail")
+    ::ProxyAPI::BMC.any_instance.expects(:power).raises("request failed")
     post "reboot", { :id => host.id }, set_session_user
     assert_redirected_to discovered_hosts_url
-    assert_equal "Failed to reboot host #{host.name} with error request must fail", flash[:error]
+    assert_match(/ERF50-6734/, flash[:error])
   end
 
   def test_auto_provision_success
@@ -153,13 +157,13 @@ class DiscoveredHostsControllerTest < ActionController::TestCase
 
   def test_reboot_all_error
     @request.env["HTTP_REFERER"] = discovered_hosts_url
-    host = FactoryGirl.create(:host,
-                              :ip   => '1.2.3.4',
-                              :type => "Host::Discovered")
+    FactoryGirl.create(:host,
+                       :ip   => '1.2.3.4',
+                       :type => "Host::Discovered")
     ::ProxyAPI::BMC.any_instance.expects(:power).raises("request must fail")
     post "reboot_all", { }, set_session_user
     assert_redirected_to discovered_hosts_url
-    assert_equal "Errors during reboot: #{host.name}: request must fail", flash[:error]
+    assert_match(/ERF50-6734/, flash[:error])
   end
 
   private


### PR DESCRIPTION
Also made sure that failure during reboot does not rollback. In future, we can
inform the user to initiate the reboot manually (in case there was a connection
issue or something).
