### PR TITLE
Fixes #10828 - facts are logged when discovery fails

### DIFF
--- a/app/controllers/api/v2/discovered_hosts_controller.rb
+++ b/app/controllers/api/v2/discovered_hosts_controller.rb
@@ -109,7 +109,9 @@ module Api
           end
         end
         process_response state
-      rescue ::Foreman::Exception => e
+      rescue Exception => e
+        logger.warn "Host discovery failed, facts: #{params[:facts]}"
+        logger.debug e.message + "\n" + e.backtrace.join("\n")
         render :json => {'message'=>e.to_s}, :status => :unprocessable_entity
       end
 


### PR DESCRIPTION
This is WIP patch to improve our logging and make use of our new logging
capabilities. I will do this work in two separate patches, the first one will
improve logging in a compatible way with older versions (can be cherry picked)
and the latter will introduce support for plugin logger via logger gem.
