### PR TITLE
Fixes #9857 - facter extensions now compatible with 1.8+

### DIFF
--- a/app/lib/facter_utils.rb
+++ b/app/lib/facter_utils.rb
@@ -1,0 +1,18 @@
+module FacterUtils
+  class << self
+    # booted interface fact name
+    def bootif_name
+      Setting[:discovery_fact] || 'discovery_bootif'
+    end
+
+    # booted interface fact is present
+    def bootif_present(facts)
+      ! bootif_mac(facts).nil?
+    end
+
+    # booted interface MAC address (nil when not present)
+    def bootif_mac(facts)
+      facts[bootif_name]
+    end
+  end
+end

--- a/app/models/setting/discovered.rb
+++ b/app/models/setting/discovered.rb
@@ -9,7 +9,7 @@ class Setting::Discovered < ::Setting
 
     Setting.transaction do
       [
-        self.set('discovery_fact', _("The default fact name to use for the MAC of the system"), "discovery_bootif"),
+        self.set('discovery_fact', _("Fact name to use for primary interface detection and hostname"), "discovery_bootif"),
         self.set('discovery_auto', _("Automatically provision newly discovered hosts, according to the provisioning rules"), false),
       ].compact.each { |s| self.create s.update(:category => "Setting::Discovered")}
     end

--- a/app/services/foreman_discovery/host_converter.rb
+++ b/app/services/foreman_discovery/host_converter.rb
@@ -14,6 +14,7 @@ class ForemanDiscovery::HostConverter
       host.managed = set_managed
       host.primary_interface.managed = set_managed
     end
+    # set build only and only on final save (otherwise interfaces are not being identified)
     host.build = set_build if set_build
     host
   end


### PR DESCRIPTION
Because of this patch that is in core develop and 1.8:

https://github.com/theforeman/foreman/commit/43c4bd72e4646cc9b2b4cb0533e84e08825eadda

Our facter extensions were no longer called. Since we had poor test coverage,
we found out too late. Puppet extensions were no longer active essentially.

This patch corrects this and fails early when extensions are not properly
included. Also test coverage is now better with more edge cases. We raise more
failures and also if `discovery_bootif` fact is missing/incorrect, we
explicitly error out instead of trying to fallback. This fact is now burnt into
the image and required to successfully discover a host.

Tests will fail because of:
https://github.com/theforeman/foreman_discovery/pull/191
