### PR TITLE
Fixes #10864 - remove N+1 queries

### DIFF
--- a/app/views/dashboard/_discovery_widget.html.erb
+++ b/app/views/dashboard/_discovery_widget.html.erb
@@ -1,5 +1,5 @@
 <h4 class="ca"><%= _('Discovered Host Pool') %> - <%= @current_permission %></h4>
-<% all_hosts = Host::Discovered.includes(:model).includes(:discovery_attribute_set).scoped %>
+<% all_hosts = Host::Discovered.includes(:model, :interfaces).includes(:discovery_attribute_set).scoped %>
 <% hosts = all_hosts.limit(5) %>
 <% if hosts.empty? %>
    <p class="ca"><%= _("No discovered hosts available") %></p>


### PR DESCRIPTION
Hopefully all of them are gone now. Had to disable N+1 gem for provisioning
/edit/ form, because we load Host::Discovered, then change the STI to
Host::Managed and then it fires with lots of warnings. But we are unable to
include this when loading the record since discovered type does not have all of
these flags.
