### PR TITLE
Fixes #10892 - Multiple columns support for discovery_fact_column

### DIFF
--- a/app/models/setting/discovered.rb
+++ b/app/models/setting/discovered.rb
@@ -45,4 +45,15 @@ class Setting::Discovered < ::Setting
 
   end
 
+  def self.discovery_fact_column_array
+    return [] if !Setting['discovery_fact_column'].present?
+    list = []
+    Setting['discovery_fact_column'].to_s.split(",").each do |value|
+      list << value.strip
+    end
+  rescue => error
+    logger.warn "Failed to parse comma delimited list [%s] into array. Error: %s" % [list,error]
+  ensure
+    list
+  end
 end

--- a/app/views/discovered_hosts/_discovered_host.html.erb
+++ b/app/views/discovered_hosts/_discovered_host.html.erb
@@ -6,7 +6,7 @@
 <% unless defined? hide_disk %>
 <td class="hidden-tablet hidden-xs"><%= discovery_attribute(host, :disk_count) %></td>
 <td class="hidden-tablet hidden-xs"><%= number_to_human_size(discovery_attribute(host, :disks_size, 0) * 1024 * 1024) %></td>
-<% if Setting['discovery_fact_column'].present? %>
-  <td class="hidden-tablet hidden-xs"><%= host.facts_hash[Setting['discovery_fact_column']] || 'N/A' %></td>
+<% Setting::Discovered.discovery_fact_column_array.each do |fact_column| %>
+<td class="hidden-tablet hidden-xs"><%= host.facts_hash[fact_column.strip] || 'N/A' %></td>
 <% end %>
 <% end %>

--- a/app/views/discovered_hosts/_discovered_hosts_list.html.erb
+++ b/app/views/discovered_hosts/_discovered_hosts_list.html.erb
@@ -10,8 +10,8 @@
     <th class="hidden-tablet hidden-xs"><%= sort :memory, :as => _('Memory') %></th>
     <th class="hidden-tablet hidden-xs"><%= sort :disk_count, :as => _('Disk count') %></th>
     <th class="hidden-tablet hidden-xs"><%= sort :disks_size, :as => _('Disks size') %></th>
-    <% if Setting['discovery_fact_column'].present? %>
-      <th class="hidden-tablet hidden-xs"><%= Setting['discovery_fact_column'].capitalize %></th>
+    <% Setting::Discovered.discovery_fact_column_array.each do |fact_column| %>
+      <th class="hidden-tablet hidden-xs"><%= fact_column.strip.capitalize %></th>
     <% end %>
     <% if SETTINGS[:locations_enabled] -%>
       <th class="hidden-tablet hidden-xs"><%= sort :location, :as => _('Location') %></th>


### PR DESCRIPTION
This is a minor change to allow users to add multiple facts to the discovery table.
I find it useful, maybe you will too :)
