### PR TITLE
Fixes #11101 - relaxed deface dependency

### DIFF
--- a/foreman_discovery.gemspec
+++ b/foreman_discovery.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |s|
   s.licenses = ["GPL-3"]
   s.summary = %q{MaaS Discovery Plugin for Foreman}
 
-  s.add_dependency 'deface', '< 1.0'
+  s.add_dependency 'deface', '< 2.0'
 end


### PR DESCRIPTION
The only use is in `app/overrides/subnet_form_with_discovery_proxy.rb` which
does seem to work fine.
