### PR TITLE
Fixes #10898 - review auto provisioning and rules permissions

### DIFF
--- a/app/controllers/api/v2/discovered_hosts_controller.rb
+++ b/app/controllers/api/v2/discovered_hosts_controller.rb
@@ -100,7 +100,7 @@ module Api
           @discovered_host, state = Host::Discovered.import_host_and_facts(params[:facts])
         end
         if Setting['discovery_auto']
-          @discovered_host.transaction do
+          Host.transaction do
             if state && rule = find_discovery_rule(@discovered_host)
               state = perform_auto_provision(@discovered_host, rule)
             else
@@ -119,7 +119,7 @@ module Api
       param :id, :identifier, :required => true
 
       def auto_provision
-        @discovered_host.transaction do
+        Host.transaction do
           if rule = find_discovery_rule(@discovered_host)
             msg = _("Host %{host} was provisioned with rule %{rule}") % {:host => @discovered_host.name, :rule => rule.name}
             process_response perform_auto_provision(@discovered_host, rule), msg
@@ -217,12 +217,12 @@ module Api
 
       def action_permission
         case params[:action]
-          when 'auto_provision'
+          when 'auto_provision', 'auto_provision_all'
             :auto_provision
-          when 'auto_provision_all'
-            :auto_provision_all
           when 'refresh_facts', 'reboot', 'reboot_all'
             :edit
+          when 'facts', 'create'
+            :submit
           else
             super
         end

--- a/app/controllers/concerns/foreman/controller/discovered_extensions.rb
+++ b/app/controllers/concerns/foreman/controller/discovered_extensions.rb
@@ -3,6 +3,7 @@ module Foreman::Controller::DiscoveredExtensions
 
   # return auto provision rule or false when not present
   def find_discovery_rule host
+    raise(::Foreman::Exception.new(N_("Unable to find a discovery rule, no host provided (check permissions)"))) if host.nil?
     Rails.logger.debug "Finding auto discovery rule for host #{host.name} (#{host.id})"
     # for each discovery rule ordered by priority
     DiscoveryRule.where(:enabled => true).order(:priority).each do |rule|
@@ -29,17 +30,17 @@ module Foreman::Controller::DiscoveredExtensions
       end
     end
     return false
-    end
+  end
 
-    def validate_rule_by_taxonomy rule, host
-      if SETTINGS[:organizations_enabled]
-        return false unless rule.organizations.include?(host.organization)
-      end
-      if SETTINGS[:locations_enabled]
-        return false unless rule.locations.include?(host.location)
-      end
-      true
+  def validate_rule_by_taxonomy rule, host
+    if SETTINGS[:organizations_enabled]
+      return false unless rule.organizations.include?(host.organization)
     end
+    if SETTINGS[:locations_enabled]
+      return false unless rule.locations.include?(host.location)
+    end
+    true
+  end
 
   # trigger the provisioning
   def perform_auto_provision original_host, rule

--- a/app/controllers/discovered_hosts_controller.rb
+++ b/app/controllers/discovered_hosts_controller.rb
@@ -125,7 +125,7 @@ class DiscoveredHostsController < ::ApplicationController
   end
 
   def auto_provision
-    @host.transaction do
+    Host.transaction do
       if rule = find_discovery_rule(@host)
         if perform_auto_provision(@host, rule)
           process_success :success_msg => _("Host %{host} was provisioned with rule %{rule}") % {:host => @host.name, :rule => rule.name}, :success_redirect => discovered_hosts_path
@@ -202,16 +202,12 @@ class DiscoveredHostsController < ::ApplicationController
 
   def action_permission
     case params[:action]
-      when 'refresh_facts', 'reboot', 'reboot_all'
-        :view
-      when 'update_multiple_location', 'select_multiple_organization', 'update_multiple_organization', 'select_multiple_location'
+      when 'refresh_facts', 'reboot', 'reboot_all', 'update_multiple_location', 'select_multiple_organization', 'update_multiple_organization', 'select_multiple_location'
         :edit
       when 'submit_multiple_destroy', 'multiple_destroy'
         :destroy
-      when 'auto_provision'
+      when 'auto_provision', 'auto_provision_all'
         :auto_provision
-      when 'auto_provision_all'
-        :auto_provision_all
       else
         super
     end

--- a/app/controllers/discovery_rules_controller.rb
+++ b/app/controllers/discovery_rules_controller.rb
@@ -53,10 +53,8 @@ class DiscoveryRulesController < ApplicationController
 
   def action_permission
     case params[:action]
-    when 'enable'
-      :enable
-    when 'disable'
-      :disable
+    when 'enable', 'disable'
+      :edit
     else
       super
     end

--- a/app/helpers/discovered_hosts_helper.rb
+++ b/app/helpers/discovered_hosts_helper.rb
@@ -24,16 +24,15 @@ module DiscoveredHostsHelper
   end
 
   def multiple_discovered_hosts_actions_select
-    actions = [[_('Delete hosts'), multiple_destroy_discovered_hosts_path]]
-    actions <<  [_('Assign Organization'), select_multiple_organization_discovered_hosts_path] if SETTINGS[:organizations_enabled]
-    actions <<  [_('Assign Location'), select_multiple_location_discovered_hosts_path] if SETTINGS[:locations_enabled]
+    actions = [[_('Delete hosts'), multiple_destroy_discovered_hosts_path, hash_for_multiple_destroy_discovered_hosts_path]]
+    actions <<  [_('Assign Organization'), select_multiple_organization_discovered_hosts_path,  hash_for_select_multiple_organization_discovered_hosts_path] if SETTINGS[:organizations_enabled]
+    actions <<  [_('Assign Location'), select_multiple_location_discovered_hosts_path,  hash_for_select_multiple_location_discovered_hosts_path] if SETTINGS[:locations_enabled]
 
     select_action_button( _("Select Action"), {:id => 'submit_multiple'},
       actions.map do |action|
-        link_to_function(action[0], "build_modal(this, '#{action[1]}')", :'data-dialog-title' => _("%s - The following hosts are about to be changed") % action[0])
+        link_to_function(action[0], "build_modal(this, '#{action[1]}')", :'data-dialog-title' => _("%s - The following hosts are about to be changed") % action[0]) if authorized_for(action[2])
       end.flatten
     )
-
   end
 
   def turn_zero_to_not_available(value)
@@ -44,4 +43,8 @@ module DiscoveredHostsHelper
     host.try(:discovery_attribute_set).try(attr) || default_value
   end
 
+  def authorized_for_edit_destroy?
+    authorized_for(:controller => :discovered_hosts, :action => :edit) or
+        authorized_for(:controller => :discovered_hosts, :action => :destroy)
+  end
 end

--- a/app/models/host/discovered.rb
+++ b/app/models/host/discovered.rb
@@ -38,7 +38,6 @@ class Host::Discovered < ::Host::Base
     hostname_prefix = prefix_from_settings if prefix_from_settings.present? && prefix_from_settings.match(/^[a-zA-Z].*/)
     hostname_prefix ||= 'mac'
     hostname = FacterUtils::bootif_mac(facts).try(:downcase).try(:gsub,/:/,'').try(:sub,/^/, hostname_prefix)
-    binding.pry if hostname.nil?
 
     # create new host record
     h = ::Host::Discovered.find_by_name hostname

--- a/app/views/discovered_hosts/_discovered_hosts_list.html.erb
+++ b/app/views/discovered_hosts/_discovered_hosts_list.html.erb
@@ -26,7 +26,7 @@
   <% @hosts.each do |host| -%>
     <tr>
       <td class="ca">
-        <%= check_box_tag "host_ids[]", nil, false, :id => "host_ids_#{host.id}", :disabled => !authorized?, :class => 'host_select_boxes', :onclick => 'hostChecked(this)' -%>
+        <%= check_box_tag "host_ids[]", nil, false, :id => "host_ids_#{host.id}", :disabled => !authorized_for_edit_destroy?, :class => 'host_select_boxes', :onclick => 'hostChecked(this)' -%>
       </td>
       <%= render :partial => "discovered_host", :locals => {:host => host} %>
       <% if SETTINGS[:locations_enabled] -%>
@@ -39,10 +39,10 @@
       <td class="hidden-tablet hidden-xs"><%= disc_report_column(host) %></td>
       <td>
         <%= action_buttons(
-          link_to(_("Provision"), hash_for_edit_discovered_host_path(:id => host)),
-          link_to(_("Auto Provision"), hash_for_auto_provision_discovered_host_path(:id => host), :method => :post),
-          link_to(_("Refresh facts"), hash_for_refresh_facts_discovered_host_path(:id => host)),
-          link_to(_("Reboot"), hash_for_reboot_discovered_host_path(:id => host), :method => :put),
+          display_link_if_authorized(_("Provision"), hash_for_edit_discovered_host_path(:id => host)),
+          display_link_if_authorized(_("Auto Provision"), hash_for_auto_provision_discovered_host_path(:id => host), :method => :post),
+          display_link_if_authorized(_("Refresh facts"), hash_for_refresh_facts_discovered_host_path(:id => host)),
+          display_link_if_authorized(_("Reboot"), hash_for_reboot_discovered_host_path(:id => host), :method => :put),
           display_delete_if_authorized(hash_for_discovered_host_path(:id => host), :confirm => _("Delete %s?") % host.name, :action => :destroy))%>
         </td>
       </tr>

--- a/db/migrate/20150714144500_review_discovery_permissions.rb
+++ b/db/migrate/20150714144500_review_discovery_permissions.rb
@@ -1,0 +1,17 @@
+class ReviewDiscoveryPermissions < ActiveRecord::Migration
+  def up
+    if (mgr = Role.find_by_name("Discovery Manager"))
+      perms = []
+      perms << "submit_discovered_hosts" if Permission.find_by_name("edit_discovered_hosts")
+      perms << "auto_provision_discovered_hosts" if Permission.find_by_name("provision_discovered_hosts")
+      perms << "create_discovery_rules" if Permission.find_by_name("new_discovery_rules")
+      perms << "destroy_discovery_rules" if Permission.find_by_name("delete_discovery_rules")
+      mgr.add_permissions!(perms)
+    end
+    Permission.find_by_name("new_discovery_rules").try(:destroy)
+  end
+
+  def down
+    # rollback is not supported
+  end
+end

--- a/lib/foreman_discovery/engine.rb
+++ b/lib/foreman_discovery/engine.rb
@@ -45,16 +45,23 @@ module ForemanDiscovery
             :discovered_hosts          => [:index, :show, :auto_complete_search],
             :"api/v2/discovered_hosts" => [:index, :show]
           }, :resource_type => 'Host'
-          permission :provision_discovered_hosts, {
+          permission :submit_discovered_hosts, {
+            :"api/v2/discovered_hosts" => [:facts, :create]
+          }, :resource_type => 'Host'
+          permission :auto_provision_discovered_hosts, {
             :discovered_hosts          => [:auto_provision, :auto_provision_all],
-            :"api/v2/discovered_hosts" => [:create, :auto_provision, :auto_provision_all]
+            :"api/v2/discovered_hosts" => [:auto_provision, :auto_provision_all]
+          }, :resource_type => 'Host'
+          permission :provision_discovered_hosts, {
+            :discovered_hosts          => [:edit, :update],
+            :"api/v2/discovered_hosts" => [:update]
           }, :resource_type => 'Host'
           permission :edit_discovered_hosts, {
-            :discovered_hosts          => [:edit, :update, :update_multiple_location,
+            :discovered_hosts          => [:update_multiple_location,
                                            :select_multiple_organization,
                                            :update_multiple_organization,
                                            :select_multiple_location, :refresh_facts, :reboot, :reboot_all],
-            :"api/v2/discovered_hosts" => [:update, :facts, :refresh_facts, :reboot, :reboot_all]
+            :"api/v2/discovered_hosts" => [:refresh_facts, :reboot, :reboot_all]
           }, :resource_type => 'Host'
           permission :destroy_discovered_hosts, {
             :discovered_hosts          => [:destroy, :submit_multiple_destroy, :multiple_destroy],
@@ -68,7 +75,7 @@ module ForemanDiscovery
             :discovery_rules => [:index, :show, :auto_complete_search],
             :"api/v2/discovery_rules" => [:index, :show]
           }, :resource_type => 'DiscoveryRule'
-          permission :new_discovery_rules, {
+          permission :create_discovery_rules, {
             :discovery_rules => [:new, :create],
             :"api/v2/discovery_rules" => [:create]
           }, :resource_type => 'DiscoveryRule'
@@ -80,15 +87,35 @@ module ForemanDiscovery
             :discovery_rules => [:auto_provision, :auto_provision_all],
             :"api/v2/discovery_rules" => [:auto_provision, :auto_provision_all]
           }, :resource_type => 'DiscoveryRule'
-          permission :delete_discovery_rules, {
+          permission :destroy_discovery_rules, {
             :discovery_rules => [:destroy],
             :"api/v2/discovery_rules" => [:destroy]
           }, :resource_type => 'DiscoveryRule'
         end
 
-        # roles (only added if they don't exist)
-        role "Discovery Manager", [:view_discovered_hosts, :provision_discovered_hosts, :edit_discovered_hosts, :destroy_discovered_hosts, :view_discovery_rules, :new_discovery_rules, :edit_discovery_rules, :execute_discovery_rules, :delete_discovery_rules]
-        role "Discovery Reader", [:view_discovered_hosts, :view_discovery_rules]
+        READER = [
+          :view_discovered_hosts,
+          :view_discovery_rules,
+          :view_organizations,
+          :view_locations,
+        ]
+        MANAGER = READER + [
+          :assign_organizations,
+          :assign_locations,
+          # discovered_hosts
+          :submit_discovered_hosts,
+          :provision_discovered_hosts,
+          :auto_provision_discovered_hosts,
+          :edit_discovered_hosts,
+          :destroy_discovered_hosts,
+          # discovered_rules
+          :create_discovery_rules,
+          :execute_discovery_rules,
+          :edit_discovery_rules,
+          :destroy_discovery_rules,
+        ]
+        role "Discovery Reader", READER
+        role "Discovery Manager", MANAGER
 
         # menu entries
         menu :top_menu, :discovered_hosts, :url_hash => {:controller => :discovered_hosts, :action => :index},


### PR DESCRIPTION
This patch fixes auto provisioning permissions and also aligns
action_permission strings with what is expected in security blocks. I
basically reviewed all our permissions and introduced
`submit_discovered_hosts` and `auto_provision_discovered_hosts`. Also,
permission `new_discovery_rules` was renamed to `create_*` because this was
never working (our permission stack expects `create_` prefix by default).

Since existing roles are never changed via the `role` DSL, I am attaching a
migration that adds new permissions (they are all new so we can do this
without security considerations) and deletes the renamed one.

We must add this to release notes for the next release, users need to update
their own roles.

@orrabin this needs extensive testing. We should consider some testing
scenarios similar to core I think.
