### PR TITLE
Bumped Foreman dependency in engine.rb, extracted strings

### DIFF
--- a/lib/foreman_discovery/engine.rb
+++ b/lib/foreman_discovery/engine.rb
@@ -37,7 +37,7 @@ module ForemanDiscovery
 
     initializer 'foreman_discovery.register_plugin', :after=> :finisher_hook do |app|
       Foreman::Plugin.register :foreman_discovery do
-        requires_foreman '>= 1.8.0'
+        requires_foreman '>= 1.9.0'
 
         # discovered hosts permissions
         security_block :discovery do

--- a/locale/Makefile
+++ b/locale/Makefile
@@ -7,7 +7,7 @@
 # make clean - clean everything
 #
 DOMAIN = foreman_discovery
-VERSION = $(shell ruby -e 'require "rubygems";spec = Gem::Specification::load(Dir.glob("../*.gemspec")[0]);puts spec.version')
+VERSION = $(shell git describe --abbrev=0 --tags)
 POTFILE = $(DOMAIN).pot
 MOFILE = $(DOMAIN).mo
 POFILES = $(shell find . -name '*.po')
@@ -35,7 +35,7 @@ check: $(POXFILES)
 # Merge PO files
 update-po:
 	for f in $(shell find ./ -name "*.po") ; do \
-		msgmerge -N --backup=none -U $$f ${POTFILE} ; \
+		msgmerge -sNU --backup=none --no-location --no-wrap $$f ${POTFILE} ; \
 	done
 
 # Unify duplicate translations
@@ -60,3 +60,17 @@ tx-update: tx-pull reset-po $(MOFILES)
 	git add ../locale/*/LC_MESSAGES
 	git commit -a --amend -m "i18n - pulling from tx"
 	-echo Changes commited!
+
+extract:
+	rxgettext \
+		--sort-output \
+		--sort-by-msgid \
+		--no-wrap \
+		--no-location \
+		-o ${DOMAIN}.pot \
+		--package-name=${DOMAIN} \
+		--package-version="${VERSION}" \
+		--msgid-bugs-address=foreman-dev@googlegroups.com \
+		--copyright-holder="Foreman developers" \
+		--copyright-year=$(shell date +%Y) \
+		$(shell find ../app -type f -name *.rb -o -name *.erb)

--- a/locale/de/foreman_discovery.po
+++ b/locale/de/foreman_discovery.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the foreman package.
-# 
+#
 # Translators:
 # Arnold Bechtoldt <mail@arnoldbechtoldt.com>, 2014
 # Christina Gurski <Gurski_christina@yahoo.de>, 2015
@@ -11,15 +11,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: foreman_discovery 3.0.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-01-28 17:53+0100\n"
+"Report-Msgid-Bugs-To: foreman-dev@googlegroups.com\n"
+"POT-Creation-Date: 2015-08-13 16:23+0200\n"
 "PO-Revision-Date: 2015-08-10 10:06+0000\n"
 "Last-Translator: Lukáš Zapletal\n"
 "Language-Team: German (http://www.transifex.com/foreman/foreman/language/de/)\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "%s - The following hosts are about to be changed"
@@ -43,10 +43,11 @@ msgstr "Automatische Bereitstellung"
 msgid "Auto Provision All"
 msgstr "Alle automatisch bereitstellen"
 
-msgid ""
-"Automatically provision newly discovered hosts, according to the "
-"provisioning rules"
+msgid "Automatically provision newly discovered hosts, according to the provisioning rules"
 msgstr "Automatisch neu entdeckte Hosts gemäß den Bereitstellungsregeln bereitstellen"
+
+msgid "Automatically reboot discovered host during provisioning"
+msgstr ""
 
 msgid "CPUs"
 msgstr "CPUs"
@@ -57,8 +58,8 @@ msgstr "Abbrechen"
 msgid "Could not get facts from proxy %{url}: %{error}"
 msgstr "Konnte keine Facts von Proxy %{url} empfangen: %{error}"
 
-msgid "Create a discovered host"
-msgstr "Einen entdeckten Host erstellen"
+msgid "Create a discovered host for testing (use /facts to create new hosts)"
+msgstr ""
 
 msgid "Create a discovery rule"
 msgstr "Eine Entdeckungsregel erstellen"
@@ -87,9 +88,6 @@ msgstr "Deaktivieren"
 msgid "Disable rule?"
 msgstr "Regel deaktivieren?"
 
-msgid "Discovered Host Pool"
-msgstr "Entdeckter Host-Pool"
-
 msgid "Discovered host: %s"
 msgstr "Entdeckter Host: %s"
 
@@ -99,14 +97,11 @@ msgstr "Entdeckte Hosts"
 msgid "Discovered hosts are provisioning now"
 msgstr "Entdeckte Hosts werden jetzt bereitgestellt"
 
+msgid "Discovered hosts are rebooting now"
+msgstr ""
+
 msgid "Discovery Rules"
 msgstr "Entdeckungsregeln"
-
-msgid "Discovery rules"
-msgstr "Entdeckungsregeln"
-
-msgid "Discovery widget"
-msgstr "Entdeckungs-Widget"
 
 msgid "DiscoveryRule|Enabled"
 msgstr "Aktiviert"
@@ -126,10 +121,7 @@ msgstr "Festplattenanzahl"
 msgid "Disks size"
 msgstr "Festplattengröße"
 
-msgid ""
-"Domain will be appended automatically. A hostname based on MAC address will "
-"be used when left blank. In addition to @host attribute function rand for "
-"random integers is available. Examples:"
+msgid "Domain will be appended automatically. A hostname based on MAC address will be used when left blank. In addition to @host attribute function rand for random integers is available. Examples:"
 msgstr "Domäne wird automatisch angefügt. Bei Freilassung wird ein auf einer MAC-Adresse basierender Hostname verwendet. Zusätzlich zum @host-Attribut ist die Funktion \"rand\" für Random Integers verfügbar. Beispiele:"
 
 msgid "Edit Discovery Rule"
@@ -144,14 +136,26 @@ msgstr "Regel aktivieren?"
 msgid "Errors during auto provisioning: %s"
 msgstr "Fehler bei der automatischen Bereitstellung: %s"
 
+msgid "Errors during reboot: %s"
+msgstr ""
+
 msgid "Execute rules against a discovered host"
 msgstr "Anwenden der Regeln auf alle entdeckten Hosts"
 
 msgid "Execute rules against all currently discovered hosts"
 msgstr "Anwenden der Regeln auf alle gegenwärtig entdeckten Hosts"
 
+msgid "Expected discovery_fact '%s' is missing, unable to detect primary interface and set hostname"
+msgstr ""
+
+msgid "Extra facter columns to show in host lists (separate by comma)"
+msgstr ""
+
 msgid "Fact"
 msgstr "Fakt"
+
+msgid "Fact name to use for primary interface detection and hostname"
+msgstr ""
 
 msgid "Facts discovered on this host"
 msgstr "Auf diesem Host entdeckte Fakten"
@@ -161,12 +165,6 @@ msgstr "Fakten für %s erneuert"
 
 msgid "Failed to auto provision host %s: %s"
 msgstr "Fehler bei der automatischen Bereitstellung von Host %s: %s"
-
-msgid "Failed to import facts for discovered host"
-msgstr "Importieren von Fakten für entdeckten Host fehlgeschlagen"
-
-msgid "Failed to import facts for discovered host: %s"
-msgstr "Importieren von Fakten für entdeckten Host fehlgeschlagen: %s"
 
 msgid "Failed to reboot host %s"
 msgstr "Neustart von Host %s fehlgeschlagen"
@@ -186,6 +184,16 @@ msgstr "Host %{host} wurde mit Regel %{rule} bereitgestellt"
 msgid "Host group"
 msgstr "Hostgruppe"
 
+msgid "Host group location %s must also be associated to the discovery rule"
+msgid_plural "Host group locations %s must also be associated to the discovery rule"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "Host group organization %s must also be associated to the discovery rule"
+msgid_plural "Host group organizations %s must also be associated to the discovery rule"
+msgstr[0] ""
+msgstr[1] ""
+
 msgid "Host of type %s can not be rebooted"
 msgstr "Host vom Typ %s kann nicht neu gestartet werden"
 
@@ -201,17 +209,11 @@ msgstr "Hosts/Limit"
 msgid "IP Address"
 msgstr "IP-Adresse"
 
-msgid "Imported discovered host"
-msgstr "Entdeckter Host importiert"
+msgid "Incompatible version of puppet fact parser"
+msgstr ""
 
 msgid "Invalid facts, must be a Hash"
 msgstr "Ungültige Fakten, es muss sich um einen Hash handeln"
-
-msgid "Invalid facts: hash does not contain IP address"
-msgstr "Ungültige Fakten: Hash enthält keine IP-Adresse"
-
-msgid "Invalid facts: hash does not contain the required fact '%s'"
-msgstr "Ungültige Fakten: Der Hash enthält den benötigten Fakt nicht: %s"
 
 msgid "Last facts upload"
 msgstr "Letzter Fakten-Upload"
@@ -224,6 +226,9 @@ msgstr "Alle Entdeckungsregeln auflisten"
 
 msgid "Location"
 msgstr "Ort"
+
+msgid "Locations"
+msgstr ""
 
 msgid "Maximum hosts provisioned with this rule (0 = unlimited)"
 msgstr "Maximale Anzahl Hosts, die mit dieser Regel bereitgestellt werden (0 = unendlich)"
@@ -246,11 +251,17 @@ msgstr "Neue Entdeckungsregel"
 msgid "New Rule"
 msgstr "Neue Regel"
 
+msgid "New in the last 24 hours"
+msgstr ""
+
 msgid "No discovered hosts available"
 msgstr "Keine entdeckten Hosts verfügbar"
 
 msgid "No discovered hosts to provision"
 msgstr "Keine entdeckten Hosts bereitzustellen"
+
+msgid "No discovered hosts to reboot"
+msgstr ""
 
 msgid "No hosts selected"
 msgstr "Keine Hosts ausgewählt"
@@ -261,11 +272,20 @@ msgstr "Es wurden keine Systeme mit dieser Kennung oder diesem Namen gefunden"
 msgid "No rule found for host %s"
 msgstr "Keine Regel gefunden für Host %s"
 
+msgid "Not reported in more than 7 days"
+msgstr ""
+
 msgid "Organization"
 msgstr "Organisation"
 
+msgid "Organizations"
+msgstr ""
+
 msgid "Please Confirm"
 msgstr "Bitte bestätigen"
+
+msgid "Primary"
+msgstr ""
 
 msgid "Provision"
 msgstr "Bereitstellen"
@@ -276,11 +296,17 @@ msgstr "Einen entdeckten Host bereitstellen"
 msgid "Reboot"
 msgstr "Neustart"
 
+msgid "Reboot All"
+msgstr ""
+
 msgid "Rebooting %s"
 msgstr "%s wird neu gestartet"
 
 msgid "Rebooting a discovered host"
 msgstr "Neustart eine entdeckten Hosts"
+
+msgid "Rebooting all discovered hosts"
+msgstr ""
 
 msgid "Rebooting host %s"
 msgstr "Starte Host %s neu"
@@ -290,6 +316,9 @@ msgstr "Fakten aktualisieren"
 
 msgid "Refreshing the facts of a discovered host"
 msgstr "Aktualisiere Fakten eines entdeckten Hosts"
+
+msgid "Reported in the last 7 days"
+msgstr ""
 
 msgid "Rule disabled"
 msgstr "Regel deaktiviert"
@@ -318,15 +347,10 @@ msgstr "Einen entdeckten Host anzeigen"
 msgid "Show a discovery rule"
 msgstr "Einen Entdeckungsregel anzeigen"
 
-msgid "Show fact as an extra column in the discovered hosts list"
-msgstr "Fakt als zusätzliche Spalte in der Liste entdeckter Hosts anzeigen"
-
 msgid "Something went wrong while selecting hosts - %s"
 msgstr "Beim Auswählen der Hosts ist ein Fehler aufgetreten - %s"
 
-msgid ""
-"Specify target hostname template pattern in the same syntax as in "
-"Provisioning Templates (ERB)."
+msgid "Specify target hostname template pattern in the same syntax as in Provisioning Templates (ERB)."
 msgstr "Spezifizieren Sie die Ziel-Hostnamen-Bereitstellungsvorlage in derselben Syntax wie in Bereitstellungstabellen (ERB). "
 
 msgid "Submit"
@@ -341,9 +365,6 @@ msgstr "Ziel-Hostgruppe für diese Regel mit allen gesetzten Eigenschaften"
 msgid "Template"
 msgstr "Vorlage"
 
-msgid "The default fact name to use for the MAC of the system"
-msgstr "Der Standard-Faktenname zum Verwenden für die MAC des Systems"
-
 msgid "The default location to place discovered hosts in"
 msgstr "Standard-Ort zum Platzieren entdeckter Hosts"
 
@@ -356,19 +377,23 @@ msgstr "Das für den Hostnamen zu verwendende Standard-Präfix, muss mit einem B
 msgid "The following hosts were not deleted: %s"
 msgstr "Die folgenden Systeme wurden nicht gelöscht: %s"
 
-msgid ""
-"This might take a while, as all hosts, facts and reports will be destroyed "
-"as well"
+msgid "This might take a while, as all hosts, facts and reports will be destroyed as well"
 msgstr "Dies kann eine Weile dauern, weil alle Systeme, Fakten und Reporte auch gelöscht werden"
 
-msgid "Total pool size"
-msgid_plural "Total pool size"
-msgstr[0] "Gesamt-Pool-Größe"
-msgstr[1] "Gesamt-Pool-Größe"
-
-msgid ""
-"UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks"
+msgid "UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks"
 msgstr "UUID zum Tracken des Status der Orchestrierungsaufgaben, GET /api/orchestration/:UUID/tasks"
+
+msgid "Unable to assign subnet, primary interface is missing IP address"
+msgstr ""
+
+msgid "Unable to detect primary interface using MAC '%{mac}' specified by discovery_fact '%{fact}'"
+msgstr ""
+
+msgid "Unable to find a discovery rule, no host provided (check permissions)"
+msgstr ""
+
+msgid "Unable to reboot %{name}: %{msg}"
+msgstr ""
 
 msgid "Update a rule"
 msgstr "Regel aktualisieren"
@@ -382,20 +407,26 @@ msgstr "Wert"
 msgid "Warning"
 msgstr "Warnung"
 
-msgid ""
-"When creating hostname patterns, make sure the resulting host names are "
-"unique. Hostnames must not start with numbers. A good approach is to use "
-"unique information provided by facter (MAC address, BIOS or serial ID)."
+msgid "When creating hostname patterns, make sure the resulting host names are unique. Hostnames must not start with numbers. A good approach is to use unique information provided by facter (MAC address, BIOS or serial ID)."
 msgstr "Versichern Sie sich beim Erstellen von Hostnamen-Patterns, dass die resultierenden Hostnamen eindeutig sind. Hostnamen dürfen nicht mit Zahlen beginnen. Ein guter Ansatz besteht darin, eindeutige vom Facter gelieferte Informationen (MAC-Adresse, BIOS oder serielle Kennung) zu verwenden."
 
 msgid "can't contain white spaces."
 msgstr "kann keine Leerzeichen enthalten"
 
+msgid "defines a pattern to assign human-readable hostnames to the matching hosts"
+msgstr ""
+
+msgid "enables to limit maximum amount of provisioned hosts per rule"
+msgstr ""
+
 msgid "filter results"
 msgstr "Ergebnisse filtern"
 
-msgid "hash containing facts for the host"
-msgstr "Hash, der Fakten für den Host enthält"
+msgid "flag is used for temporary shutdown of rules"
+msgstr ""
+
+msgid "hash containing facts for the host with minimum set of facts: discovery_bootif, macaddress_eth0, ipaddress, ipaddress_eth0, interfaces: eth0 (example in case primary interface is named eth0)"
+msgstr ""
 
 msgid "items selected. Uncheck to Clear"
 msgstr "Elemente ausgewählt. Zum Leeren abwählen"
@@ -415,10 +446,61 @@ msgstr "Anzahl der Einträge pro Anfrage"
 msgid "paginate results"
 msgstr "Ergebnisse nummerieren"
 
-msgid ""
-"required if value is not inherited from host group or default password in "
-"settings"
+msgid "puts the rules in order, low numbers go first. Must be greater then zero"
+msgstr ""
+
+msgid "query to match discovered hosts for the particular rule"
+msgstr ""
+
+msgid "represents rule name shown to the users"
+msgstr ""
+
+msgid "required if value is not inherited from host group or default password in settings"
 msgstr "erforderlich, wenn der Wert nicht von einer Hostgruppe oder einem Standardpasswort in den Einstellungen vererbt ist"
 
 msgid "sort results"
 msgstr "Ergebnisse sortieren"
+
+msgid "the hostgroup that is used to auto provision a host"
+msgstr ""
+
+#~ msgid "Create a discovered host"
+#~ msgstr "Einen entdeckten Host erstellen"
+
+#~ msgid "Discovered Host Pool"
+#~ msgstr "Entdeckter Host-Pool"
+
+#~ msgid "Discovery rules"
+#~ msgstr "Entdeckungsregeln"
+
+#~ msgid "Discovery widget"
+#~ msgstr "Entdeckungs-Widget"
+
+#~ msgid "Failed to import facts for discovered host"
+#~ msgstr "Importieren von Fakten für entdeckten Host fehlgeschlagen"
+
+#~ msgid "Failed to import facts for discovered host: %s"
+#~ msgstr "Importieren von Fakten für entdeckten Host fehlgeschlagen: %s"
+
+#~ msgid "Imported discovered host"
+#~ msgstr "Entdeckter Host importiert"
+
+#~ msgid "Invalid facts: hash does not contain IP address"
+#~ msgstr "Ungültige Fakten: Hash enthält keine IP-Adresse"
+
+#~ msgid "Invalid facts: hash does not contain the required fact '%s'"
+#~ msgstr "Ungültige Fakten: Der Hash enthält den benötigten Fakt nicht: %s"
+
+#~ msgid "Show fact as an extra column in the discovered hosts list"
+#~ msgstr "Fakt als zusätzliche Spalte in der Liste entdeckter Hosts anzeigen"
+
+#~ msgid "The default fact name to use for the MAC of the system"
+#~ msgstr "Der Standard-Faktenname zum Verwenden für die MAC des Systems"
+
+#~ msgid "Total pool size"
+#~ msgid_plural "Total pool size"
+#~ msgstr[0] "Gesamt-Pool-Größe"
+#~ msgstr[1] "Gesamt-Pool-Größe"
+
+#~ msgid "hash containing facts for the host"
+#~ msgstr "Hash, der Fakten für den Host enthält"

--- a/locale/en_GB/foreman_discovery.po
+++ b/locale/en_GB/foreman_discovery.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the foreman package.
-# 
+#
 # Translators:
 # Andi Chandler <andi@gowling.com>, 2015
 # Dominic Cleal <dcleal@redhat.com>, 2013-2014
@@ -9,15 +9,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: foreman_discovery 3.0.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-01-28 17:53+0100\n"
+"Report-Msgid-Bugs-To: foreman-dev@googlegroups.com\n"
+"POT-Creation-Date: 2015-08-13 16:23+0200\n"
 "PO-Revision-Date: 2015-08-10 10:09+0000\n"
 "Last-Translator: Lukáš Zapletal\n"
 "Language-Team: English (United Kingdom) (http://www.transifex.com/foreman/foreman/language/en_GB/)\n"
+"Language: en_GB\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en_GB\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "%s - The following hosts are about to be changed"
@@ -41,10 +41,11 @@ msgstr "Auto Provision"
 msgid "Auto Provision All"
 msgstr "Auto Provision All"
 
-msgid ""
-"Automatically provision newly discovered hosts, according to the "
-"provisioning rules"
+msgid "Automatically provision newly discovered hosts, according to the provisioning rules"
 msgstr "Automatically provision newly discovered hosts, according to the provisioning rules"
+
+msgid "Automatically reboot discovered host during provisioning"
+msgstr ""
 
 msgid "CPUs"
 msgstr "CPUs"
@@ -55,8 +56,8 @@ msgstr "Cancel"
 msgid "Could not get facts from proxy %{url}: %{error}"
 msgstr "Could not get facts from proxy %{url}: %{error}"
 
-msgid "Create a discovered host"
-msgstr "Create a discovered host"
+msgid "Create a discovered host for testing (use /facts to create new hosts)"
+msgstr ""
 
 msgid "Create a discovery rule"
 msgstr "Create a discovery rule"
@@ -85,9 +86,6 @@ msgstr "Disable"
 msgid "Disable rule?"
 msgstr "Disable rule?"
 
-msgid "Discovered Host Pool"
-msgstr "Discovered Host Pool"
-
 msgid "Discovered host: %s"
 msgstr "Discovered host: %s"
 
@@ -97,14 +95,11 @@ msgstr "Discovered hosts"
 msgid "Discovered hosts are provisioning now"
 msgstr "Discovered hosts are provisioning now"
 
+msgid "Discovered hosts are rebooting now"
+msgstr ""
+
 msgid "Discovery Rules"
 msgstr "Discovery Rules"
-
-msgid "Discovery rules"
-msgstr "Discovery rules"
-
-msgid "Discovery widget"
-msgstr "Discovery widget"
 
 msgid "DiscoveryRule|Enabled"
 msgstr "Enabled"
@@ -124,10 +119,7 @@ msgstr "Disk count"
 msgid "Disks size"
 msgstr "Disks size"
 
-msgid ""
-"Domain will be appended automatically. A hostname based on MAC address will "
-"be used when left blank. In addition to @host attribute function rand for "
-"random integers is available. Examples:"
+msgid "Domain will be appended automatically. A hostname based on MAC address will be used when left blank. In addition to @host attribute function rand for random integers is available. Examples:"
 msgstr "Domain will be appended automatically. A hostname based on MAC address will be used when left blank. In addition to @host attribute function rand for random integers is available. Examples:"
 
 msgid "Edit Discovery Rule"
@@ -142,14 +134,26 @@ msgstr "Enable rule?"
 msgid "Errors during auto provisioning: %s"
 msgstr "Errors during auto provisioning: %s"
 
+msgid "Errors during reboot: %s"
+msgstr ""
+
 msgid "Execute rules against a discovered host"
 msgstr "Execute rules against a discovered host"
 
 msgid "Execute rules against all currently discovered hosts"
 msgstr "Execute rules against all currently discovered hosts"
 
+msgid "Expected discovery_fact '%s' is missing, unable to detect primary interface and set hostname"
+msgstr ""
+
+msgid "Extra facter columns to show in host lists (separate by comma)"
+msgstr ""
+
 msgid "Fact"
 msgstr "Fact"
+
+msgid "Fact name to use for primary interface detection and hostname"
+msgstr ""
 
 msgid "Facts discovered on this host"
 msgstr "Facts discovered on this host"
@@ -159,12 +163,6 @@ msgstr "Facts refreshed for %s"
 
 msgid "Failed to auto provision host %s: %s"
 msgstr "Failed to auto provision host %s: %s"
-
-msgid "Failed to import facts for discovered host"
-msgstr "Failed to import facts for discovered host"
-
-msgid "Failed to import facts for discovered host: %s"
-msgstr "Failed to import facts for discovered host: %s"
 
 msgid "Failed to reboot host %s"
 msgstr "Failed to reboot host %s"
@@ -184,6 +182,16 @@ msgstr "Host %{host} was provisioned with rule %{rule}"
 msgid "Host group"
 msgstr "Host group"
 
+msgid "Host group location %s must also be associated to the discovery rule"
+msgid_plural "Host group locations %s must also be associated to the discovery rule"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "Host group organization %s must also be associated to the discovery rule"
+msgid_plural "Host group organizations %s must also be associated to the discovery rule"
+msgstr[0] ""
+msgstr[1] ""
+
 msgid "Host of type %s can not be rebooted"
 msgstr "Host of type %s can not be rebooted"
 
@@ -199,17 +207,11 @@ msgstr "Hosts/limit"
 msgid "IP Address"
 msgstr "IP Address"
 
-msgid "Imported discovered host"
-msgstr "Imported discovered host"
+msgid "Incompatible version of puppet fact parser"
+msgstr ""
 
 msgid "Invalid facts, must be a Hash"
 msgstr "Invalid facts, must be a Hash"
-
-msgid "Invalid facts: hash does not contain IP address"
-msgstr "Invalid facts: hash does not contain IP address"
-
-msgid "Invalid facts: hash does not contain the required fact '%s'"
-msgstr "Invalid facts: hash does not contain the required fact '%s'"
 
 msgid "Last facts upload"
 msgstr "Last facts upload"
@@ -222,6 +224,9 @@ msgstr "List all discovery rules"
 
 msgid "Location"
 msgstr "Location"
+
+msgid "Locations"
+msgstr ""
 
 msgid "Maximum hosts provisioned with this rule (0 = unlimited)"
 msgstr "Maximum hosts provisioned with this rule (0 = unlimited)"
@@ -244,11 +249,17 @@ msgstr "New Discovery Rule"
 msgid "New Rule"
 msgstr "New Rule"
 
+msgid "New in the last 24 hours"
+msgstr ""
+
 msgid "No discovered hosts available"
 msgstr "No discovered hosts available"
 
 msgid "No discovered hosts to provision"
 msgstr "No discovered hosts to provision"
+
+msgid "No discovered hosts to reboot"
+msgstr ""
 
 msgid "No hosts selected"
 msgstr "No hosts selected"
@@ -259,11 +270,20 @@ msgstr "No hosts were found with that id or name"
 msgid "No rule found for host %s"
 msgstr "No rule found for host %s"
 
+msgid "Not reported in more than 7 days"
+msgstr ""
+
 msgid "Organization"
 msgstr "Organisation"
 
+msgid "Organizations"
+msgstr ""
+
 msgid "Please Confirm"
 msgstr "Please Confirm"
+
+msgid "Primary"
+msgstr ""
 
 msgid "Provision"
 msgstr "Provision"
@@ -274,11 +294,17 @@ msgstr "Provision a discovered host"
 msgid "Reboot"
 msgstr "Reboot"
 
+msgid "Reboot All"
+msgstr ""
+
 msgid "Rebooting %s"
 msgstr "Rebooting %s"
 
 msgid "Rebooting a discovered host"
 msgstr "Rebooting a discovered host"
+
+msgid "Rebooting all discovered hosts"
+msgstr ""
 
 msgid "Rebooting host %s"
 msgstr "Rebooting host %s"
@@ -288,6 +314,9 @@ msgstr "Refresh facts"
 
 msgid "Refreshing the facts of a discovered host"
 msgstr "Refreshing the facts of a discovered host"
+
+msgid "Reported in the last 7 days"
+msgstr ""
 
 msgid "Rule disabled"
 msgstr "Rule disabled"
@@ -316,15 +345,10 @@ msgstr "Show a discovered host"
 msgid "Show a discovery rule"
 msgstr "Show a discovery rule"
 
-msgid "Show fact as an extra column in the discovered hosts list"
-msgstr "Show fact as an extra column in the discovered hosts list"
-
 msgid "Something went wrong while selecting hosts - %s"
 msgstr "Something went wrong while selecting hosts - %s"
 
-msgid ""
-"Specify target hostname template pattern in the same syntax as in "
-"Provisioning Templates (ERB)."
+msgid "Specify target hostname template pattern in the same syntax as in Provisioning Templates (ERB)."
 msgstr "Specify target hostname template pattern in the same syntax as in Provisioning Templates (ERB)."
 
 msgid "Submit"
@@ -339,9 +363,6 @@ msgstr "Target host group for this rule with all properties set"
 msgid "Template"
 msgstr "Template"
 
-msgid "The default fact name to use for the MAC of the system"
-msgstr "The default fact name to use for the MAC of the system"
-
 msgid "The default location to place discovered hosts in"
 msgstr "The default location to place discovered hosts in"
 
@@ -354,19 +375,23 @@ msgstr "The default prefix to use for the host name, must start with a letter"
 msgid "The following hosts were not deleted: %s"
 msgstr "The following hosts were not deleted: %s"
 
-msgid ""
-"This might take a while, as all hosts, facts and reports will be destroyed "
-"as well"
+msgid "This might take a while, as all hosts, facts and reports will be destroyed as well"
 msgstr "This might take a while, as all hosts, facts and reports will be destroyed as well"
 
-msgid "Total pool size"
-msgid_plural "Total pool size"
-msgstr[0] "Total pool size"
-msgstr[1] "Total pool size"
-
-msgid ""
-"UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks"
+msgid "UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks"
 msgstr "UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks"
+
+msgid "Unable to assign subnet, primary interface is missing IP address"
+msgstr ""
+
+msgid "Unable to detect primary interface using MAC '%{mac}' specified by discovery_fact '%{fact}'"
+msgstr ""
+
+msgid "Unable to find a discovery rule, no host provided (check permissions)"
+msgstr ""
+
+msgid "Unable to reboot %{name}: %{msg}"
+msgstr ""
 
 msgid "Update a rule"
 msgstr "Update a rule"
@@ -380,20 +405,26 @@ msgstr "Value"
 msgid "Warning"
 msgstr "Warning"
 
-msgid ""
-"When creating hostname patterns, make sure the resulting host names are "
-"unique. Hostnames must not start with numbers. A good approach is to use "
-"unique information provided by facter (MAC address, BIOS or serial ID)."
+msgid "When creating hostname patterns, make sure the resulting host names are unique. Hostnames must not start with numbers. A good approach is to use unique information provided by facter (MAC address, BIOS or serial ID)."
 msgstr "When creating hostname patterns, make sure the resulting host names are unique. Hostnames must not start with numbers. A good approach is to use unique information provided by facter (MAC address, BIOS or serial ID)."
 
 msgid "can't contain white spaces."
 msgstr "can't contain white spaces."
 
+msgid "defines a pattern to assign human-readable hostnames to the matching hosts"
+msgstr ""
+
+msgid "enables to limit maximum amount of provisioned hosts per rule"
+msgstr ""
+
 msgid "filter results"
 msgstr "filter results"
 
-msgid "hash containing facts for the host"
-msgstr "hash containing facts for the host"
+msgid "flag is used for temporary shutdown of rules"
+msgstr ""
+
+msgid "hash containing facts for the host with minimum set of facts: discovery_bootif, macaddress_eth0, ipaddress, ipaddress_eth0, interfaces: eth0 (example in case primary interface is named eth0)"
+msgstr ""
 
 msgid "items selected. Uncheck to Clear"
 msgstr "items selected. Uncheck to Clear"
@@ -413,10 +444,61 @@ msgstr "number of entries per request"
 msgid "paginate results"
 msgstr "paginate results"
 
-msgid ""
-"required if value is not inherited from host group or default password in "
-"settings"
+msgid "puts the rules in order, low numbers go first. Must be greater then zero"
+msgstr ""
+
+msgid "query to match discovered hosts for the particular rule"
+msgstr ""
+
+msgid "represents rule name shown to the users"
+msgstr ""
+
+msgid "required if value is not inherited from host group or default password in settings"
 msgstr "required if value is not inherited from host group or default password in settings"
 
 msgid "sort results"
 msgstr "sort results"
+
+msgid "the hostgroup that is used to auto provision a host"
+msgstr ""
+
+#~ msgid "Create a discovered host"
+#~ msgstr "Create a discovered host"
+
+#~ msgid "Discovered Host Pool"
+#~ msgstr "Discovered Host Pool"
+
+#~ msgid "Discovery rules"
+#~ msgstr "Discovery rules"
+
+#~ msgid "Discovery widget"
+#~ msgstr "Discovery widget"
+
+#~ msgid "Failed to import facts for discovered host"
+#~ msgstr "Failed to import facts for discovered host"
+
+#~ msgid "Failed to import facts for discovered host: %s"
+#~ msgstr "Failed to import facts for discovered host: %s"
+
+#~ msgid "Imported discovered host"
+#~ msgstr "Imported discovered host"
+
+#~ msgid "Invalid facts: hash does not contain IP address"
+#~ msgstr "Invalid facts: hash does not contain IP address"
+
+#~ msgid "Invalid facts: hash does not contain the required fact '%s'"
+#~ msgstr "Invalid facts: hash does not contain the required fact '%s'"
+
+#~ msgid "Show fact as an extra column in the discovered hosts list"
+#~ msgstr "Show fact as an extra column in the discovered hosts list"
+
+#~ msgid "The default fact name to use for the MAC of the system"
+#~ msgstr "The default fact name to use for the MAC of the system"
+
+#~ msgid "Total pool size"
+#~ msgid_plural "Total pool size"
+#~ msgstr[0] "Total pool size"
+#~ msgstr[1] "Total pool size"
+
+#~ msgid "hash containing facts for the host"
+#~ msgstr "hash containing facts for the host"

--- a/locale/es/foreman_discovery.po
+++ b/locale/es/foreman_discovery.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the foreman package.
-# 
+#
 # Translators:
 # elobato <elobatocs@gmail.com>, 2015
 # francis <hackgo@gmail.com>, 2013-2014
@@ -10,15 +10,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: foreman_discovery 3.0.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-01-28 17:53+0100\n"
+"Report-Msgid-Bugs-To: foreman-dev@googlegroups.com\n"
+"POT-Creation-Date: 2015-08-13 16:23+0200\n"
 "PO-Revision-Date: 2015-03-21 22:53+0000\n"
 "Last-Translator: Sergio Ocón <sergio.ocon@redhat.com>\n"
 "Language-Team: Spanish (http://www.transifex.com/foreman/foreman/language/es/)\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: es\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "%s - The following hosts are about to be changed"
@@ -42,10 +42,11 @@ msgstr "Auto Provisionamiento"
 msgid "Auto Provision All"
 msgstr "Auto provisionar todos"
 
-msgid ""
-"Automatically provision newly discovered hosts, according to the "
-"provisioning rules"
+msgid "Automatically provision newly discovered hosts, according to the provisioning rules"
 msgstr "Provisionar automáticamente los hosts descubiertos, de acuerdo con las pautas de provisión"
+
+msgid "Automatically reboot discovered host during provisioning"
+msgstr ""
 
 msgid "CPUs"
 msgstr "Procesadores"
@@ -56,8 +57,8 @@ msgstr "Cancelar"
 msgid "Could not get facts from proxy %{url}: %{error}"
 msgstr "No se pudo obtener los detalles del proxy %{url}: %{error}"
 
-msgid "Create a discovered host"
-msgstr "Crear descubriendo un host"
+msgid "Create a discovered host for testing (use /facts to create new hosts)"
+msgstr ""
 
 msgid "Create a discovery rule"
 msgstr "Crear una pauta de descubrimiento"
@@ -86,9 +87,6 @@ msgstr "Deshabilitar"
 msgid "Disable rule?"
 msgstr "¿Deshabilitar la pauta?"
 
-msgid "Discovered Host Pool"
-msgstr "Pool de hosts descubierto"
-
 msgid "Discovered host: %s"
 msgstr "Equipo descubierto: %s"
 
@@ -98,14 +96,11 @@ msgstr "Equipos descubiertos"
 msgid "Discovered hosts are provisioning now"
 msgstr "Los hosts descubiertos se están provisionando"
 
+msgid "Discovered hosts are rebooting now"
+msgstr ""
+
 msgid "Discovery Rules"
 msgstr "Pautas de detección"
-
-msgid "Discovery rules"
-msgstr "Pautas de descubrimiento"
-
-msgid "Discovery widget"
-msgstr "Widget de descubrimiento"
 
 msgid "DiscoveryRule|Enabled"
 msgstr "Activada"
@@ -125,10 +120,7 @@ msgstr "Número de discos"
 msgid "Disks size"
 msgstr "Tamaño de discos"
 
-msgid ""
-"Domain will be appended automatically. A hostname based on MAC address will "
-"be used when left blank. In addition to @host attribute function rand for "
-"random integers is available. Examples:"
+msgid "Domain will be appended automatically. A hostname based on MAC address will be used when left blank. In addition to @host attribute function rand for random integers is available. Examples:"
 msgstr "Se añadirá el dominio automáticamente. Si se deja vacío, se utiliza un nombre de host basado en la dirección MAC. Además del atributo @host dispone de la función rand para números aleatorios. Ejemplos:"
 
 msgid "Edit Discovery Rule"
@@ -143,14 +135,26 @@ msgstr "¿Activar la pauta?"
 msgid "Errors during auto provisioning: %s"
 msgstr "Errores en la provisión automática: %s"
 
+msgid "Errors during reboot: %s"
+msgstr ""
+
 msgid "Execute rules against a discovered host"
 msgstr "Ejecutar las pautas relativas al host descubierto"
 
 msgid "Execute rules against all currently discovered hosts"
 msgstr "Ejecutar la pautas en todos los hosts descubiertos actualmente"
 
+msgid "Expected discovery_fact '%s' is missing, unable to detect primary interface and set hostname"
+msgstr ""
+
+msgid "Extra facter columns to show in host lists (separate by comma)"
+msgstr ""
+
 msgid "Fact"
 msgstr "Dato"
+
+msgid "Fact name to use for primary interface detection and hostname"
+msgstr ""
 
 msgid "Facts discovered on this host"
 msgstr "Datos descubiertos en este equipo"
@@ -160,12 +164,6 @@ msgstr "Datos actualizados para %s"
 
 msgid "Failed to auto provision host %s: %s"
 msgstr "Error al provisionar el host automáticamente: %s"
-
-msgid "Failed to import facts for discovered host"
-msgstr "Error al importar detalles del host descubierto"
-
-msgid "Failed to import facts for discovered host: %s"
-msgstr "Error al Error al importar detalles del host descubierto: %s"
 
 msgid "Failed to reboot host %s"
 msgstr "No se pudo reinicar el host %s"
@@ -185,6 +183,16 @@ msgstr "El host %{host} se provisión con la pauta %{rule}"
 msgid "Host group"
 msgstr "Grupo del host"
 
+msgid "Host group location %s must also be associated to the discovery rule"
+msgid_plural "Host group locations %s must also be associated to the discovery rule"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "Host group organization %s must also be associated to the discovery rule"
+msgid_plural "Host group organizations %s must also be associated to the discovery rule"
+msgstr[0] ""
+msgstr[1] ""
+
 msgid "Host of type %s can not be rebooted"
 msgstr "No se puede reiniciar un host de tipo %s"
 
@@ -200,17 +208,11 @@ msgstr "Hosts/límite"
 msgid "IP Address"
 msgstr "Dirección IP"
 
-msgid "Imported discovered host"
-msgstr "Se importó el host descubierto"
+msgid "Incompatible version of puppet fact parser"
+msgstr ""
 
 msgid "Invalid facts, must be a Hash"
 msgstr "Datos no válidos, debe ser un Hash"
-
-msgid "Invalid facts: hash does not contain IP address"
-msgstr "Detalles inválidiso: el hash no contiene una dirección IP"
-
-msgid "Invalid facts: hash does not contain the required fact '%s'"
-msgstr "Datos no válidos: el hash debe contener '%s'"
 
 msgid "Last facts upload"
 msgstr "Últimos datos subidos"
@@ -223,6 +225,9 @@ msgstr "Enumerar todas las pautas de descubrimiento"
 
 msgid "Location"
 msgstr "Lugares"
+
+msgid "Locations"
+msgstr ""
 
 msgid "Maximum hosts provisioned with this rule (0 = unlimited)"
 msgstr "Número máximo de hosts provisionados con esta pauta (0 = ilimitado)"
@@ -245,11 +250,17 @@ msgstr "Nueva pauta de descubrimiento"
 msgid "New Rule"
 msgstr "Nueva pauta"
 
+msgid "New in the last 24 hours"
+msgstr ""
+
 msgid "No discovered hosts available"
 msgstr "No hay hosts descubiertos disponibles"
 
 msgid "No discovered hosts to provision"
 msgstr "No se han descubierto hosts para provisionar"
+
+msgid "No discovered hosts to reboot"
+msgstr ""
 
 msgid "No hosts selected"
 msgstr "Ningún equipo seleccionado"
@@ -260,11 +271,20 @@ msgstr "No se han encontrado equipos con ese id o nombre"
 msgid "No rule found for host %s"
 msgstr "No se han encontrado pautas para el host %s"
 
+msgid "Not reported in more than 7 days"
+msgstr ""
+
 msgid "Organization"
 msgstr "Organización"
 
+msgid "Organizations"
+msgstr ""
+
 msgid "Please Confirm"
 msgstr "Confirme, por favor"
+
+msgid "Primary"
+msgstr ""
 
 msgid "Provision"
 msgstr "Aprovisionamiento"
@@ -275,11 +295,17 @@ msgstr "Provisionar un host descubierto"
 msgid "Reboot"
 msgstr "Reiniciar"
 
+msgid "Reboot All"
+msgstr ""
+
 msgid "Rebooting %s"
 msgstr "Reiniciando %s"
 
 msgid "Rebooting a discovered host"
 msgstr "Reiniciando un host descubierto"
+
+msgid "Rebooting all discovered hosts"
+msgstr ""
 
 msgid "Rebooting host %s"
 msgstr "Reiniciando host %s"
@@ -289,6 +315,9 @@ msgstr "Refrescar datos"
 
 msgid "Refreshing the facts of a discovered host"
 msgstr "Actualizando los detalles de un host descubierto"
+
+msgid "Reported in the last 7 days"
+msgstr ""
 
 msgid "Rule disabled"
 msgstr "Pauta deshabiltada"
@@ -317,15 +346,10 @@ msgstr "Mostrar un host descubierto"
 msgid "Show a discovery rule"
 msgstr "Mostrar una pauta de descubrimiento"
 
-msgid "Show fact as an extra column in the discovered hosts list"
-msgstr "Mostrar detalle como una columna adicional en la lista de hosts descubiertos"
-
 msgid "Something went wrong while selecting hosts - %s"
 msgstr "Algo ha fallado al seleccionar equipos - %s"
 
-msgid ""
-"Specify target hostname template pattern in the same syntax as in "
-"Provisioning Templates (ERB)."
+msgid "Specify target hostname template pattern in the same syntax as in Provisioning Templates (ERB)."
 msgstr "Especifique el patrón de nombres objetivo con la misma sintaxis que las Plantillas de provisión (ERB)."
 
 msgid "Submit"
@@ -340,9 +364,6 @@ msgstr "Seleccione el grupo de hosts para esta pauta con todas las propiedades a
 msgid "Template"
 msgstr "Plantilla"
 
-msgid "The default fact name to use for the MAC of the system"
-msgstr "El nombre de dato por defecto a usar para la MAC del sistema"
-
 msgid "The default location to place discovered hosts in"
 msgstr "La ubicación predeterminada para colocar hosts descubiertos "
 
@@ -355,19 +376,23 @@ msgstr "Prefijo por defecto para el nombre de hosts, debe comenzar por una letra
 msgid "The following hosts were not deleted: %s"
 msgstr "Los siguientes equipos no han sido eliminados: %s"
 
-msgid ""
-"This might take a while, as all hosts, facts and reports will be destroyed "
-"as well"
+msgid "This might take a while, as all hosts, facts and reports will be destroyed as well"
 msgstr "Esta acción puede tardar un rato, ya que se eliminarán todos los equipos, datos e informes."
 
-msgid "Total pool size"
-msgid_plural "Total pool size"
-msgstr[0] "Tamaño total del pool"
-msgstr[1] "Tamaño total del pool"
-
-msgid ""
-"UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks"
+msgid "UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks"
 msgstr "UUID para seguir el estado de la tarea de orquestación, GET /api/orchestration/:UUID/tasks"
+
+msgid "Unable to assign subnet, primary interface is missing IP address"
+msgstr ""
+
+msgid "Unable to detect primary interface using MAC '%{mac}' specified by discovery_fact '%{fact}'"
+msgstr ""
+
+msgid "Unable to find a discovery rule, no host provided (check permissions)"
+msgstr ""
+
+msgid "Unable to reboot %{name}: %{msg}"
+msgstr ""
 
 msgid "Update a rule"
 msgstr "Actualizar una pauta"
@@ -381,20 +406,26 @@ msgstr "Valor"
 msgid "Warning"
 msgstr "Aviso"
 
-msgid ""
-"When creating hostname patterns, make sure the resulting host names are "
-"unique. Hostnames must not start with numbers. A good approach is to use "
-"unique information provided by facter (MAC address, BIOS or serial ID)."
+msgid "When creating hostname patterns, make sure the resulting host names are unique. Hostnames must not start with numbers. A good approach is to use unique information provided by facter (MAC address, BIOS or serial ID)."
 msgstr "Cuando cree patrones para nombres, asegúrese de que los nombre de host resultantes son únicos. Los nombres de host no deben comenzar por números. Una buena técnica es usar información única del facter (dirección MAC, BIOS o ID)"
 
 msgid "can't contain white spaces."
 msgstr "no puede contener espacios en blanco."
 
+msgid "defines a pattern to assign human-readable hostnames to the matching hosts"
+msgstr ""
+
+msgid "enables to limit maximum amount of provisioned hosts per rule"
+msgstr ""
+
 msgid "filter results"
 msgstr "filtrar resultados"
 
-msgid "hash containing facts for the host"
-msgstr "hash que contiene detalles del host"
+msgid "flag is used for temporary shutdown of rules"
+msgstr ""
+
+msgid "hash containing facts for the host with minimum set of facts: discovery_bootif, macaddress_eth0, ipaddress, ipaddress_eth0, interfaces: eth0 (example in case primary interface is named eth0)"
+msgstr ""
 
 msgid "items selected. Uncheck to Clear"
 msgstr "objetos seleccionados. Desactivar para limpiar"
@@ -414,10 +445,61 @@ msgstr "número de entradas por petición"
 msgid "paginate results"
 msgstr "paginar resultados"
 
-msgid ""
-"required if value is not inherited from host group or default password in "
-"settings"
+msgid "puts the rules in order, low numbers go first. Must be greater then zero"
+msgstr ""
+
+msgid "query to match discovered hosts for the particular rule"
+msgstr ""
+
+msgid "represents rule name shown to the users"
+msgstr ""
+
+msgid "required if value is not inherited from host group or default password in settings"
 msgstr "obligatorio si el valor no se hereda del grupo de hosts o no hay password por defecto en la configuración"
 
 msgid "sort results"
 msgstr "ordenar resultados"
+
+msgid "the hostgroup that is used to auto provision a host"
+msgstr ""
+
+#~ msgid "Create a discovered host"
+#~ msgstr "Crear descubriendo un host"
+
+#~ msgid "Discovered Host Pool"
+#~ msgstr "Pool de hosts descubierto"
+
+#~ msgid "Discovery rules"
+#~ msgstr "Pautas de descubrimiento"
+
+#~ msgid "Discovery widget"
+#~ msgstr "Widget de descubrimiento"
+
+#~ msgid "Failed to import facts for discovered host"
+#~ msgstr "Error al importar detalles del host descubierto"
+
+#~ msgid "Failed to import facts for discovered host: %s"
+#~ msgstr "Error al Error al importar detalles del host descubierto: %s"
+
+#~ msgid "Imported discovered host"
+#~ msgstr "Se importó el host descubierto"
+
+#~ msgid "Invalid facts: hash does not contain IP address"
+#~ msgstr "Detalles inválidiso: el hash no contiene una dirección IP"
+
+#~ msgid "Invalid facts: hash does not contain the required fact '%s'"
+#~ msgstr "Datos no válidos: el hash debe contener '%s'"
+
+#~ msgid "Show fact as an extra column in the discovered hosts list"
+#~ msgstr "Mostrar detalle como una columna adicional en la lista de hosts descubiertos"
+
+#~ msgid "The default fact name to use for the MAC of the system"
+#~ msgstr "El nombre de dato por defecto a usar para la MAC del sistema"
+
+#~ msgid "Total pool size"
+#~ msgid_plural "Total pool size"
+#~ msgstr[0] "Tamaño total del pool"
+#~ msgstr[1] "Tamaño total del pool"
+
+#~ msgid "hash containing facts for the host"
+#~ msgstr "hash que contiene detalles del host"

--- a/locale/foreman_discovery.pot
+++ b/locale/foreman_discovery.pot
@@ -1,15 +1,15 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the foreman package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Copyright (C) 2015 Foreman developers
+# This file is distributed under the same license as the foreman_discovery package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: foreman 1.0.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-01-28 17:53+0100\n"
-"PO-Revision-Date: 2015-01-28 17:53+0100\n"
+"Project-Id-Version: foreman_discovery 4.0.0\n"
+"Report-Msgid-Bugs-To: foreman-dev@googlegroups.com\n"
+"POT-Creation-Date: 2015-08-13 16:28+0200\n"
+"PO-Revision-Date: 2015-08-13 16:28+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -42,6 +42,9 @@ msgstr ""
 msgid "Automatically provision newly discovered hosts, according to the provisioning rules"
 msgstr ""
 
+msgid "Automatically reboot discovered host during provisioning"
+msgstr ""
+
 msgid "CPUs"
 msgstr ""
 
@@ -51,7 +54,7 @@ msgstr ""
 msgid "Could not get facts from proxy %{url}: %{error}"
 msgstr ""
 
-msgid "Create a discovered host"
+msgid "Create a discovered host for testing (use /facts to create new hosts)"
 msgstr ""
 
 msgid "Create a discovery rule"
@@ -81,9 +84,6 @@ msgstr ""
 msgid "Disable rule?"
 msgstr ""
 
-msgid "Discovered Host Pool"
-msgstr ""
-
 msgid "Discovered host: %s"
 msgstr ""
 
@@ -93,13 +93,10 @@ msgstr ""
 msgid "Discovered hosts are provisioning now"
 msgstr ""
 
+msgid "Discovered hosts are rebooting now"
+msgstr ""
+
 msgid "Discovery Rules"
-msgstr ""
-
-msgid "Discovery rules"
-msgstr ""
-
-msgid "Discovery widget"
 msgstr ""
 
 msgid "DiscoveryRule|Enabled"
@@ -135,13 +132,25 @@ msgstr ""
 msgid "Errors during auto provisioning: %s"
 msgstr ""
 
+msgid "Errors during reboot: %s"
+msgstr ""
+
 msgid "Execute rules against a discovered host"
 msgstr ""
 
 msgid "Execute rules against all currently discovered hosts"
 msgstr ""
 
+msgid "Expected discovery_fact '%s' is missing, unable to detect primary interface and set hostname"
+msgstr ""
+
+msgid "Extra facter columns to show in host lists (separate by comma)"
+msgstr ""
+
 msgid "Fact"
+msgstr ""
+
+msgid "Fact name to use for primary interface detection and hostname"
 msgstr ""
 
 msgid "Facts discovered on this host"
@@ -151,12 +160,6 @@ msgid "Facts refreshed for %s"
 msgstr ""
 
 msgid "Failed to auto provision host %s: %s"
-msgstr ""
-
-msgid "Failed to import facts for discovered host"
-msgstr ""
-
-msgid "Failed to import facts for discovered host: %s"
 msgstr ""
 
 msgid "Failed to reboot host %s"
@@ -177,6 +180,16 @@ msgstr ""
 msgid "Host group"
 msgstr ""
 
+msgid "Host group location %s must also be associated to the discovery rule"
+msgid_plural "Host group locations %s must also be associated to the discovery rule"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "Host group organization %s must also be associated to the discovery rule"
+msgid_plural "Host group organizations %s must also be associated to the discovery rule"
+msgstr[0] ""
+msgstr[1] ""
+
 msgid "Host of type %s can not be rebooted"
 msgstr ""
 
@@ -192,16 +205,10 @@ msgstr ""
 msgid "IP Address"
 msgstr ""
 
-msgid "Imported discovered host"
+msgid "Incompatible version of puppet fact parser"
 msgstr ""
 
 msgid "Invalid facts, must be a Hash"
-msgstr ""
-
-msgid "Invalid facts: hash does not contain IP address"
-msgstr ""
-
-msgid "Invalid facts: hash does not contain the required fact '%s'"
 msgstr ""
 
 msgid "Last facts upload"
@@ -214,6 +221,9 @@ msgid "List all discovery rules"
 msgstr ""
 
 msgid "Location"
+msgstr ""
+
+msgid "Locations"
 msgstr ""
 
 msgid "Maximum hosts provisioned with this rule (0 = unlimited)"
@@ -237,10 +247,16 @@ msgstr ""
 msgid "New Rule"
 msgstr ""
 
+msgid "New in the last 24 hours"
+msgstr ""
+
 msgid "No discovered hosts available"
 msgstr ""
 
 msgid "No discovered hosts to provision"
+msgstr ""
+
+msgid "No discovered hosts to reboot"
 msgstr ""
 
 msgid "No hosts selected"
@@ -252,10 +268,19 @@ msgstr ""
 msgid "No rule found for host %s"
 msgstr ""
 
+msgid "Not reported in more than 7 days"
+msgstr ""
+
 msgid "Organization"
 msgstr ""
 
+msgid "Organizations"
+msgstr ""
+
 msgid "Please Confirm"
+msgstr ""
+
+msgid "Primary"
 msgstr ""
 
 msgid "Provision"
@@ -267,10 +292,16 @@ msgstr ""
 msgid "Reboot"
 msgstr ""
 
+msgid "Reboot All"
+msgstr ""
+
 msgid "Rebooting %s"
 msgstr ""
 
 msgid "Rebooting a discovered host"
+msgstr ""
+
+msgid "Rebooting all discovered hosts"
 msgstr ""
 
 msgid "Rebooting host %s"
@@ -280,6 +311,9 @@ msgid "Refresh facts"
 msgstr ""
 
 msgid "Refreshing the facts of a discovered host"
+msgstr ""
+
+msgid "Reported in the last 7 days"
 msgstr ""
 
 msgid "Rule disabled"
@@ -309,9 +343,6 @@ msgstr ""
 msgid "Show a discovery rule"
 msgstr ""
 
-msgid "Show fact as an extra column in the discovered hosts list"
-msgstr ""
-
 msgid "Something went wrong while selecting hosts - %s"
 msgstr ""
 
@@ -330,9 +361,6 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-msgid "The default fact name to use for the MAC of the system"
-msgstr ""
-
 msgid "The default location to place discovered hosts in"
 msgstr ""
 
@@ -348,12 +376,19 @@ msgstr ""
 msgid "This might take a while, as all hosts, facts and reports will be destroyed as well"
 msgstr ""
 
-msgid "Total pool size"
-msgid_plural "Total pool size"
-msgstr[0] ""
-msgstr[1] ""
-
 msgid "UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks"
+msgstr ""
+
+msgid "Unable to assign subnet, primary interface is missing IP address"
+msgstr ""
+
+msgid "Unable to detect primary interface using MAC '%{mac}' specified by discovery_fact '%{fact}'"
+msgstr ""
+
+msgid "Unable to find a discovery rule, no host provided (check permissions)"
+msgstr ""
+
+msgid "Unable to reboot %{name}: %{msg}"
 msgstr ""
 
 msgid "Update a rule"
@@ -374,10 +409,19 @@ msgstr ""
 msgid "can't contain white spaces."
 msgstr ""
 
+msgid "defines a pattern to assign human-readable hostnames to the matching hosts"
+msgstr ""
+
+msgid "enables to limit maximum amount of provisioned hosts per rule"
+msgstr ""
+
 msgid "filter results"
 msgstr ""
 
-msgid "hash containing facts for the host"
+msgid "flag is used for temporary shutdown of rules"
+msgstr ""
+
+msgid "hash containing facts for the host with minimum set of facts: discovery_bootif, macaddress_eth0, ipaddress, ipaddress_eth0, interfaces: eth0 (example in case primary interface is named eth0)"
 msgstr ""
 
 msgid "items selected. Uncheck to Clear"
@@ -398,8 +442,20 @@ msgstr ""
 msgid "paginate results"
 msgstr ""
 
+msgid "puts the rules in order, low numbers go first. Must be greater then zero"
+msgstr ""
+
+msgid "query to match discovered hosts for the particular rule"
+msgstr ""
+
+msgid "represents rule name shown to the users"
+msgstr ""
+
 msgid "required if value is not inherited from host group or default password in settings"
 msgstr ""
 
 msgid "sort results"
+msgstr ""
+
+msgid "the hostgroup that is used to auto provision a host"
 msgstr ""

--- a/locale/fr/foreman_discovery.po
+++ b/locale/fr/foreman_discovery.po
@@ -1,22 +1,22 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the foreman package.
-# 
+#
 # Translators:
 # Claer <transiblu@claer.hammock.fr>, 2013-2015
 # Pierre-Emmanuel Dutang <dutangp@gmail.com>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: foreman_discovery 3.0.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-01-28 17:53+0100\n"
+"Report-Msgid-Bugs-To: foreman-dev@googlegroups.com\n"
+"POT-Creation-Date: 2015-08-13 16:23+0200\n"
 "PO-Revision-Date: 2015-03-21 12:54+0000\n"
 "Last-Translator: Claer <transiblu@claer.hammock.fr>\n"
 "Language-Team: French (http://www.transifex.com/foreman/foreman/language/fr/)\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fr\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 msgid "%s - The following hosts are about to be changed"
@@ -40,10 +40,11 @@ msgstr "Auto provisionnement"
 msgid "Auto Provision All"
 msgstr "Tout auto provisionner"
 
-msgid ""
-"Automatically provision newly discovered hosts, according to the "
-"provisioning rules"
+msgid "Automatically provision newly discovered hosts, according to the provisioning rules"
 msgstr "Provisionner automatiquement les nouveaux hôtes découverts, conformément aux règles de provisionnement"
+
+msgid "Automatically reboot discovered host during provisioning"
+msgstr ""
 
 msgid "CPUs"
 msgstr "CPUs"
@@ -54,8 +55,8 @@ msgstr "Annuler"
 msgid "Could not get facts from proxy %{url}: %{error}"
 msgstr "Impossible de récupérer les facts depuis le proxy %{url}: %{error}"
 
-msgid "Create a discovered host"
-msgstr "Créer un hôte détecté"
+msgid "Create a discovered host for testing (use /facts to create new hosts)"
+msgstr ""
 
 msgid "Create a discovery rule"
 msgstr "Créer une règle de découverte"
@@ -84,9 +85,6 @@ msgstr "Désactiver"
 msgid "Disable rule?"
 msgstr "Désactiver la règle ?"
 
-msgid "Discovered Host Pool"
-msgstr "Pool d'hôtes détecté"
-
 msgid "Discovered host: %s"
 msgstr "Hôtes détectés : %s"
 
@@ -96,14 +94,11 @@ msgstr "Hôtes détectés"
 msgid "Discovered hosts are provisioning now"
 msgstr "Les hôtes détectés sont en cours de provisionnement"
 
+msgid "Discovered hosts are rebooting now"
+msgstr ""
+
 msgid "Discovery Rules"
 msgstr "Règles de découverte"
-
-msgid "Discovery rules"
-msgstr "Règles de découverte"
-
-msgid "Discovery widget"
-msgstr "Widget de détection"
 
 msgid "DiscoveryRule|Enabled"
 msgstr "Activé"
@@ -123,10 +118,7 @@ msgstr "Nombre de disques"
 msgid "Disks size"
 msgstr "Taille des disques"
 
-msgid ""
-"Domain will be appended automatically. A hostname based on MAC address will "
-"be used when left blank. In addition to @host attribute function rand for "
-"random integers is available. Examples:"
+msgid "Domain will be appended automatically. A hostname based on MAC address will be used when left blank. In addition to @host attribute function rand for random integers is available. Examples:"
 msgstr "Le nom de domaine va être ajouté automatiquement. Un nom d'hôte basé sur l'adresse MAC va être utilisé si ce champ reste vide. En complément de l'attribut @host, la fonction rand pour des entiers aléatoires est disponible. Ex :"
 
 msgid "Edit Discovery Rule"
@@ -141,14 +133,26 @@ msgstr "Activer la règle ?"
 msgid "Errors during auto provisioning: %s"
 msgstr "Erreurs pendant l'auto provisionnement : %s"
 
+msgid "Errors during reboot: %s"
+msgstr ""
+
 msgid "Execute rules against a discovered host"
 msgstr "Exécuter les règles sur un hôte découvert"
 
 msgid "Execute rules against all currently discovered hosts"
 msgstr "Exécuter les règles sur tous les hôtes découverts"
 
+msgid "Expected discovery_fact '%s' is missing, unable to detect primary interface and set hostname"
+msgstr ""
+
+msgid "Extra facter columns to show in host lists (separate by comma)"
+msgstr ""
+
 msgid "Fact"
 msgstr "Fact"
+
+msgid "Fact name to use for primary interface detection and hostname"
+msgstr ""
 
 msgid "Facts discovered on this host"
 msgstr "Facts détectés pour cet hôte"
@@ -158,12 +162,6 @@ msgstr "Facts rafraichis pour %s"
 
 msgid "Failed to auto provision host %s: %s"
 msgstr "Échec d'auto provisionnement de l'hôte %s: %s"
-
-msgid "Failed to import facts for discovered host"
-msgstr "Échec d'import des facts pour l'hôte découvert"
-
-msgid "Failed to import facts for discovered host: %s"
-msgstr "Échec d'import des facts pour l'hôte découvert : %s"
 
 msgid "Failed to reboot host %s"
 msgstr "Erreur de redémarrage de l'hôte : %s"
@@ -183,6 +181,16 @@ msgstr "L'hôte %{host} a été  provisionné avec la règle %{rule}"
 msgid "Host group"
 msgstr "Groupe d'hôtes"
 
+msgid "Host group location %s must also be associated to the discovery rule"
+msgid_plural "Host group locations %s must also be associated to the discovery rule"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "Host group organization %s must also be associated to the discovery rule"
+msgid_plural "Host group organizations %s must also be associated to the discovery rule"
+msgstr[0] ""
+msgstr[1] ""
+
 msgid "Host of type %s can not be rebooted"
 msgstr "L'hôte du type %s ne peut pas être redémarré"
 
@@ -198,17 +206,11 @@ msgstr "Limite"
 msgid "IP Address"
 msgstr "Adresses IP"
 
-msgid "Imported discovered host"
-msgstr "Hôte découvert importé"
+msgid "Incompatible version of puppet fact parser"
+msgstr ""
 
 msgid "Invalid facts, must be a Hash"
 msgstr "Facts invalides, doit être un hash"
-
-msgid "Invalid facts: hash does not contain IP address"
-msgstr "Facts invalides : le hash ne contient pas une adresse IP"
-
-msgid "Invalid facts: hash does not contain the required fact '%s'"
-msgstr "Facts invalides : le hash ne doit pas contenir le fact requis '%s'"
 
 msgid "Last facts upload"
 msgstr "Derniers facts téléchargés"
@@ -221,6 +223,9 @@ msgstr "Lister toutes les règles de découverte"
 
 msgid "Location"
 msgstr "Localisation"
+
+msgid "Locations"
+msgstr ""
 
 msgid "Maximum hosts provisioned with this rule (0 = unlimited)"
 msgstr "Nombre maximal d'hôtes provisionnés par cette règle (0 = illimité)"
@@ -243,11 +248,17 @@ msgstr "Nouvelle règle de découverte"
 msgid "New Rule"
 msgstr "Nouvelle règle"
 
+msgid "New in the last 24 hours"
+msgstr ""
+
 msgid "No discovered hosts available"
 msgstr "Aucun hôte détecté disponible"
 
 msgid "No discovered hosts to provision"
 msgstr "Aucun hôte découvert disponible pour le provisionnement"
+
+msgid "No discovered hosts to reboot"
+msgstr ""
 
 msgid "No hosts selected"
 msgstr "Aucun hôte sélectionné"
@@ -258,11 +269,20 @@ msgstr "Aucun Hôte trouvé avec cet id ou ce nom"
 msgid "No rule found for host %s"
 msgstr "Aucune règle trouvée pour l'hôte %s"
 
+msgid "Not reported in more than 7 days"
+msgstr ""
+
 msgid "Organization"
 msgstr "Organisation"
 
+msgid "Organizations"
+msgstr ""
+
 msgid "Please Confirm"
 msgstr "Merci de confirmer"
+
+msgid "Primary"
+msgstr ""
 
 msgid "Provision"
 msgstr "Provisionner"
@@ -273,11 +293,17 @@ msgstr "Provisionner les hôtes détectés"
 msgid "Reboot"
 msgstr "Redémarrer"
 
+msgid "Reboot All"
+msgstr ""
+
 msgid "Rebooting %s"
 msgstr "Redémarrage %s"
 
 msgid "Rebooting a discovered host"
 msgstr "Redémarrer un hôte découvert"
+
+msgid "Rebooting all discovered hosts"
+msgstr ""
 
 msgid "Rebooting host %s"
 msgstr "Redémarrage de l'hôte %s"
@@ -287,6 +313,9 @@ msgstr "Rafraichir les facts"
 
 msgid "Refreshing the facts of a discovered host"
 msgstr "Rafraichir les facts d'un hôte découvert"
+
+msgid "Reported in the last 7 days"
+msgstr ""
 
 msgid "Rule disabled"
 msgstr "Règle désactivée"
@@ -315,15 +344,10 @@ msgstr "Affichier un hôte détecté"
 msgid "Show a discovery rule"
 msgstr "Voir une règle de découverte"
 
-msgid "Show fact as an extra column in the discovered hosts list"
-msgstr "Voir un fact comme colonne supplémentaire au tableau des hôtes découverts"
-
 msgid "Something went wrong while selecting hosts - %s"
 msgstr "Quelque chose s'est mal passé lors de la sélection des hôtes - %s"
 
-msgid ""
-"Specify target hostname template pattern in the same syntax as in "
-"Provisioning Templates (ERB)."
+msgid "Specify target hostname template pattern in the same syntax as in Provisioning Templates (ERB)."
 msgstr "Spécifier un modèle de nom d'hôte cible en utilisant la même syntaxe que les modèles de provisionnement (en ERB)"
 
 msgid "Submit"
@@ -338,9 +362,6 @@ msgstr "Groupe d'hôtes cible pour cette règle avec toutes ses propriétés dé
 msgid "Template"
 msgstr "Modèle"
 
-msgid "The default fact name to use for the MAC of the system"
-msgstr "Le nom du fact par défaut pour obtenir l'adresse MAC du système"
-
 msgid "The default location to place discovered hosts in"
 msgstr "Attribution de la localisation par défaut pour les hôtes détectés"
 
@@ -353,19 +374,23 @@ msgstr "Le préfixe par défaut à utiliser pour les noms d'hôtes. Le préfixe 
 msgid "The following hosts were not deleted: %s"
 msgstr "Les hôtes suivants n'ont pas été supprimés : %s"
 
-msgid ""
-"This might take a while, as all hosts, facts and reports will be destroyed "
-"as well"
+msgid "This might take a while, as all hosts, facts and reports will be destroyed as well"
 msgstr "Cette action peut prendre un certain temps, pour tous les hôtes, les rapports et facts vont aussi être supprimés"
 
-msgid "Total pool size"
-msgid_plural "Total pool size"
-msgstr[0] "Taille totale du pool"
-msgstr[1] "Taille totale du pool"
-
-msgid ""
-"UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks"
+msgid "UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks"
 msgstr "UUID pour surveiller l'état des tâches d'orchestration : GET /api/orchestration/:UUID/tasks"
+
+msgid "Unable to assign subnet, primary interface is missing IP address"
+msgstr ""
+
+msgid "Unable to detect primary interface using MAC '%{mac}' specified by discovery_fact '%{fact}'"
+msgstr ""
+
+msgid "Unable to find a discovery rule, no host provided (check permissions)"
+msgstr ""
+
+msgid "Unable to reboot %{name}: %{msg}"
+msgstr ""
 
 msgid "Update a rule"
 msgstr "Mise à jour d'une règle"
@@ -379,20 +404,26 @@ msgstr "Valeur"
 msgid "Warning"
 msgstr "Attention"
 
-msgid ""
-"When creating hostname patterns, make sure the resulting host names are "
-"unique. Hostnames must not start with numbers. A good approach is to use "
-"unique information provided by facter (MAC address, BIOS or serial ID)."
+msgid "When creating hostname patterns, make sure the resulting host names are unique. Hostnames must not start with numbers. A good approach is to use unique information provided by facter (MAC address, BIOS or serial ID)."
 msgstr "Lors de la création des modèles de nom d'hôtes, soyez sûrs que les noms résultant soient uniques. Les nom d'hôtes ne doivent pas commencer par un chiffre. Une bonne approche est d'utiliser une information propre à une machine fournie par facter (Par ex: adresse MAC, BIOS, numéro de série)"
 
 msgid "can't contain white spaces."
 msgstr "ne peut pas contenir des espaces."
 
+msgid "defines a pattern to assign human-readable hostnames to the matching hosts"
+msgstr ""
+
+msgid "enables to limit maximum amount of provisioned hosts per rule"
+msgstr ""
+
 msgid "filter results"
 msgstr "filtrer les résultats"
 
-msgid "hash containing facts for the host"
-msgstr "hash contenant les facts de cet hôte"
+msgid "flag is used for temporary shutdown of rules"
+msgstr ""
+
+msgid "hash containing facts for the host with minimum set of facts: discovery_bootif, macaddress_eth0, ipaddress, ipaddress_eth0, interfaces: eth0 (example in case primary interface is named eth0)"
+msgstr ""
 
 msgid "items selected. Uncheck to Clear"
 msgstr "items sélectionnés. Décocher pour Effacer"
@@ -412,10 +443,61 @@ msgstr "nombre d'entier par requête"
 msgid "paginate results"
 msgstr "paginer les resultats"
 
-msgid ""
-"required if value is not inherited from host group or default password in "
-"settings"
+msgid "puts the rules in order, low numbers go first. Must be greater then zero"
+msgstr ""
+
+msgid "query to match discovered hosts for the particular rule"
+msgstr ""
+
+msgid "represents rule name shown to the users"
+msgstr ""
+
+msgid "required if value is not inherited from host group or default password in settings"
 msgstr "requis si la valeur n'est pas héritée d'un groupe d'hôtes ou si le mot de passe par défaut n'est pas défini dans les paramètres généraux."
 
 msgid "sort results"
 msgstr "trier les resultats"
+
+msgid "the hostgroup that is used to auto provision a host"
+msgstr ""
+
+#~ msgid "Create a discovered host"
+#~ msgstr "Créer un hôte détecté"
+
+#~ msgid "Discovered Host Pool"
+#~ msgstr "Pool d'hôtes détecté"
+
+#~ msgid "Discovery rules"
+#~ msgstr "Règles de découverte"
+
+#~ msgid "Discovery widget"
+#~ msgstr "Widget de détection"
+
+#~ msgid "Failed to import facts for discovered host"
+#~ msgstr "Échec d'import des facts pour l'hôte découvert"
+
+#~ msgid "Failed to import facts for discovered host: %s"
+#~ msgstr "Échec d'import des facts pour l'hôte découvert : %s"
+
+#~ msgid "Imported discovered host"
+#~ msgstr "Hôte découvert importé"
+
+#~ msgid "Invalid facts: hash does not contain IP address"
+#~ msgstr "Facts invalides : le hash ne contient pas une adresse IP"
+
+#~ msgid "Invalid facts: hash does not contain the required fact '%s'"
+#~ msgstr "Facts invalides : le hash ne doit pas contenir le fact requis '%s'"
+
+#~ msgid "Show fact as an extra column in the discovered hosts list"
+#~ msgstr "Voir un fact comme colonne supplémentaire au tableau des hôtes découverts"
+
+#~ msgid "The default fact name to use for the MAC of the system"
+#~ msgstr "Le nom du fact par défaut pour obtenir l'adresse MAC du système"
+
+#~ msgid "Total pool size"
+#~ msgid_plural "Total pool size"
+#~ msgstr[0] "Taille totale du pool"
+#~ msgstr[1] "Taille totale du pool"
+
+#~ msgid "hash containing facts for the host"
+#~ msgstr "hash contenant les facts de cet hôte"

--- a/locale/gl/foreman_discovery.po
+++ b/locale/gl/foreman_discovery.po
@@ -1,20 +1,20 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the foreman package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: foreman_discovery 3.0.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-01-28 17:53+0100\n"
+"Report-Msgid-Bugs-To: foreman-dev@googlegroups.com\n"
+"POT-Creation-Date: 2015-08-13 16:23+0200\n"
 "PO-Revision-Date: 2015-03-21 22:54+0000\n"
 "Last-Translator: Lukáš Zapletal\n"
 "Language-Team: Galician (http://www.transifex.com/foreman/foreman/language/gl/)\n"
+"Language: gl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: gl\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "%s - The following hosts are about to be changed"
@@ -38,9 +38,10 @@ msgstr ""
 msgid "Auto Provision All"
 msgstr ""
 
-msgid ""
-"Automatically provision newly discovered hosts, according to the "
-"provisioning rules"
+msgid "Automatically provision newly discovered hosts, according to the provisioning rules"
+msgstr ""
+
+msgid "Automatically reboot discovered host during provisioning"
 msgstr ""
 
 msgid "CPUs"
@@ -52,7 +53,7 @@ msgstr "Cancelar"
 msgid "Could not get facts from proxy %{url}: %{error}"
 msgstr ""
 
-msgid "Create a discovered host"
+msgid "Create a discovered host for testing (use /facts to create new hosts)"
 msgstr ""
 
 msgid "Create a discovery rule"
@@ -82,9 +83,6 @@ msgstr ""
 msgid "Disable rule?"
 msgstr ""
 
-msgid "Discovered Host Pool"
-msgstr ""
-
 msgid "Discovered host: %s"
 msgstr ""
 
@@ -94,13 +92,10 @@ msgstr ""
 msgid "Discovered hosts are provisioning now"
 msgstr ""
 
+msgid "Discovered hosts are rebooting now"
+msgstr ""
+
 msgid "Discovery Rules"
-msgstr ""
-
-msgid "Discovery rules"
-msgstr ""
-
-msgid "Discovery widget"
 msgstr ""
 
 msgid "DiscoveryRule|Enabled"
@@ -121,10 +116,7 @@ msgstr ""
 msgid "Disks size"
 msgstr ""
 
-msgid ""
-"Domain will be appended automatically. A hostname based on MAC address will "
-"be used when left blank. In addition to @host attribute function rand for "
-"random integers is available. Examples:"
+msgid "Domain will be appended automatically. A hostname based on MAC address will be used when left blank. In addition to @host attribute function rand for random integers is available. Examples:"
 msgstr ""
 
 msgid "Edit Discovery Rule"
@@ -139,13 +131,25 @@ msgstr ""
 msgid "Errors during auto provisioning: %s"
 msgstr ""
 
+msgid "Errors during reboot: %s"
+msgstr ""
+
 msgid "Execute rules against a discovered host"
 msgstr ""
 
 msgid "Execute rules against all currently discovered hosts"
 msgstr ""
 
+msgid "Expected discovery_fact '%s' is missing, unable to detect primary interface and set hostname"
+msgstr ""
+
+msgid "Extra facter columns to show in host lists (separate by comma)"
+msgstr ""
+
 msgid "Fact"
+msgstr ""
+
+msgid "Fact name to use for primary interface detection and hostname"
 msgstr ""
 
 msgid "Facts discovered on this host"
@@ -155,12 +159,6 @@ msgid "Facts refreshed for %s"
 msgstr ""
 
 msgid "Failed to auto provision host %s: %s"
-msgstr ""
-
-msgid "Failed to import facts for discovered host"
-msgstr ""
-
-msgid "Failed to import facts for discovered host: %s"
 msgstr ""
 
 msgid "Failed to reboot host %s"
@@ -181,6 +179,16 @@ msgstr ""
 msgid "Host group"
 msgstr "Grupo de Equipos"
 
+msgid "Host group location %s must also be associated to the discovery rule"
+msgid_plural "Host group locations %s must also be associated to the discovery rule"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "Host group organization %s must also be associated to the discovery rule"
+msgid_plural "Host group organizations %s must also be associated to the discovery rule"
+msgstr[0] ""
+msgstr[1] ""
+
 msgid "Host of type %s can not be rebooted"
 msgstr ""
 
@@ -196,16 +204,10 @@ msgstr ""
 msgid "IP Address"
 msgstr "Dirección IP"
 
-msgid "Imported discovered host"
+msgid "Incompatible version of puppet fact parser"
 msgstr ""
 
 msgid "Invalid facts, must be a Hash"
-msgstr ""
-
-msgid "Invalid facts: hash does not contain IP address"
-msgstr ""
-
-msgid "Invalid facts: hash does not contain the required fact '%s'"
 msgstr ""
 
 msgid "Last facts upload"
@@ -219,6 +221,9 @@ msgstr ""
 
 msgid "Location"
 msgstr "Lugares"
+
+msgid "Locations"
+msgstr ""
 
 msgid "Maximum hosts provisioned with this rule (0 = unlimited)"
 msgstr ""
@@ -241,10 +246,16 @@ msgstr ""
 msgid "New Rule"
 msgstr ""
 
+msgid "New in the last 24 hours"
+msgstr ""
+
 msgid "No discovered hosts available"
 msgstr ""
 
 msgid "No discovered hosts to provision"
+msgstr ""
+
+msgid "No discovered hosts to reboot"
 msgstr ""
 
 msgid "No hosts selected"
@@ -256,11 +267,20 @@ msgstr "Non se atopou ningún equipos con ese id ou nome"
 msgid "No rule found for host %s"
 msgstr ""
 
+msgid "Not reported in more than 7 days"
+msgstr ""
+
 msgid "Organization"
 msgstr "Organización"
 
+msgid "Organizations"
+msgstr ""
+
 msgid "Please Confirm"
 msgstr "Confirme, por favor"
+
+msgid "Primary"
+msgstr ""
 
 msgid "Provision"
 msgstr "Aprovisionamento"
@@ -271,10 +291,16 @@ msgstr ""
 msgid "Reboot"
 msgstr ""
 
+msgid "Reboot All"
+msgstr ""
+
 msgid "Rebooting %s"
 msgstr ""
 
 msgid "Rebooting a discovered host"
+msgstr ""
+
+msgid "Rebooting all discovered hosts"
 msgstr ""
 
 msgid "Rebooting host %s"
@@ -284,6 +310,9 @@ msgid "Refresh facts"
 msgstr ""
 
 msgid "Refreshing the facts of a discovered host"
+msgstr ""
+
+msgid "Reported in the last 7 days"
 msgstr ""
 
 msgid "Rule disabled"
@@ -313,15 +342,10 @@ msgstr ""
 msgid "Show a discovery rule"
 msgstr ""
 
-msgid "Show fact as an extra column in the discovered hosts list"
-msgstr ""
-
 msgid "Something went wrong while selecting hosts - %s"
 msgstr "Algo fallou ao seleccionar equipos - %s"
 
-msgid ""
-"Specify target hostname template pattern in the same syntax as in "
-"Provisioning Templates (ERB)."
+msgid "Specify target hostname template pattern in the same syntax as in Provisioning Templates (ERB)."
 msgstr ""
 
 msgid "Submit"
@@ -336,9 +360,6 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-msgid "The default fact name to use for the MAC of the system"
-msgstr ""
-
 msgid "The default location to place discovered hosts in"
 msgstr ""
 
@@ -351,18 +372,22 @@ msgstr ""
 msgid "The following hosts were not deleted: %s"
 msgstr "Os seguintes equipos non foron eliminados: %s"
 
-msgid ""
-"This might take a while, as all hosts, facts and reports will be destroyed "
-"as well"
+msgid "This might take a while, as all hosts, facts and reports will be destroyed as well"
 msgstr "Esta acción pode tardar un anaco, xa que se eliminarán tódolos equipos, datos e informes."
 
-msgid "Total pool size"
-msgid_plural "Total pool size"
-msgstr[0] ""
-msgstr[1] ""
+msgid "UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks"
+msgstr ""
 
-msgid ""
-"UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks"
+msgid "Unable to assign subnet, primary interface is missing IP address"
+msgstr ""
+
+msgid "Unable to detect primary interface using MAC '%{mac}' specified by discovery_fact '%{fact}'"
+msgstr ""
+
+msgid "Unable to find a discovery rule, no host provided (check permissions)"
+msgstr ""
+
+msgid "Unable to reboot %{name}: %{msg}"
 msgstr ""
 
 msgid "Update a rule"
@@ -377,19 +402,25 @@ msgstr "Valor"
 msgid "Warning"
 msgstr "Aviso"
 
-msgid ""
-"When creating hostname patterns, make sure the resulting host names are "
-"unique. Hostnames must not start with numbers. A good approach is to use "
-"unique information provided by facter (MAC address, BIOS or serial ID)."
+msgid "When creating hostname patterns, make sure the resulting host names are unique. Hostnames must not start with numbers. A good approach is to use unique information provided by facter (MAC address, BIOS or serial ID)."
 msgstr ""
 
 msgid "can't contain white spaces."
 msgstr ""
 
+msgid "defines a pattern to assign human-readable hostnames to the matching hosts"
+msgstr ""
+
+msgid "enables to limit maximum amount of provisioned hosts per rule"
+msgstr ""
+
 msgid "filter results"
 msgstr ""
 
-msgid "hash containing facts for the host"
+msgid "flag is used for temporary shutdown of rules"
+msgstr ""
+
+msgid "hash containing facts for the host with minimum set of facts: discovery_bootif, macaddress_eth0, ipaddress, ipaddress_eth0, interfaces: eth0 (example in case primary interface is named eth0)"
 msgstr ""
 
 msgid "items selected. Uncheck to Clear"
@@ -410,10 +441,20 @@ msgstr ""
 msgid "paginate results"
 msgstr ""
 
-msgid ""
-"required if value is not inherited from host group or default password in "
-"settings"
+msgid "puts the rules in order, low numbers go first. Must be greater then zero"
+msgstr ""
+
+msgid "query to match discovered hosts for the particular rule"
+msgstr ""
+
+msgid "represents rule name shown to the users"
+msgstr ""
+
+msgid "required if value is not inherited from host group or default password in settings"
 msgstr ""
 
 msgid "sort results"
+msgstr ""
+
+msgid "the hostgroup that is used to auto provision a host"
 msgstr ""

--- a/locale/it/foreman_discovery.po
+++ b/locale/it/foreman_discovery.po
@@ -1,21 +1,21 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the foreman package.
-# 
+#
 # Translators:
 # caifti <caifti@gmail.com>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: foreman_discovery 3.0.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-01-28 17:53+0100\n"
+"Report-Msgid-Bugs-To: foreman-dev@googlegroups.com\n"
+"POT-Creation-Date: 2015-08-13 16:23+0200\n"
 "PO-Revision-Date: 2015-03-21 22:54+0000\n"
 "Last-Translator: Lukáš Zapletal\n"
 "Language-Team: Italian (http://www.transifex.com/foreman/foreman/language/it/)\n"
+"Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: it\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "%s - The following hosts are about to be changed"
@@ -39,9 +39,10 @@ msgstr ""
 msgid "Auto Provision All"
 msgstr ""
 
-msgid ""
-"Automatically provision newly discovered hosts, according to the "
-"provisioning rules"
+msgid "Automatically provision newly discovered hosts, according to the provisioning rules"
+msgstr ""
+
+msgid "Automatically reboot discovered host during provisioning"
 msgstr ""
 
 msgid "CPUs"
@@ -53,7 +54,7 @@ msgstr "Annulla"
 msgid "Could not get facts from proxy %{url}: %{error}"
 msgstr ""
 
-msgid "Create a discovered host"
+msgid "Create a discovered host for testing (use /facts to create new hosts)"
 msgstr ""
 
 msgid "Create a discovery rule"
@@ -83,9 +84,6 @@ msgstr ""
 msgid "Disable rule?"
 msgstr ""
 
-msgid "Discovered Host Pool"
-msgstr ""
-
 msgid "Discovered host: %s"
 msgstr "Host trovati: %s"
 
@@ -95,13 +93,10 @@ msgstr "Host trovati"
 msgid "Discovered hosts are provisioning now"
 msgstr ""
 
+msgid "Discovered hosts are rebooting now"
+msgstr ""
+
 msgid "Discovery Rules"
-msgstr ""
-
-msgid "Discovery rules"
-msgstr ""
-
-msgid "Discovery widget"
 msgstr ""
 
 msgid "DiscoveryRule|Enabled"
@@ -122,10 +117,7 @@ msgstr ""
 msgid "Disks size"
 msgstr ""
 
-msgid ""
-"Domain will be appended automatically. A hostname based on MAC address will "
-"be used when left blank. In addition to @host attribute function rand for "
-"random integers is available. Examples:"
+msgid "Domain will be appended automatically. A hostname based on MAC address will be used when left blank. In addition to @host attribute function rand for random integers is available. Examples:"
 msgstr ""
 
 msgid "Edit Discovery Rule"
@@ -140,14 +132,26 @@ msgstr ""
 msgid "Errors during auto provisioning: %s"
 msgstr ""
 
+msgid "Errors during reboot: %s"
+msgstr ""
+
 msgid "Execute rules against a discovered host"
 msgstr ""
 
 msgid "Execute rules against all currently discovered hosts"
 msgstr ""
 
+msgid "Expected discovery_fact '%s' is missing, unable to detect primary interface and set hostname"
+msgstr ""
+
+msgid "Extra facter columns to show in host lists (separate by comma)"
+msgstr ""
+
 msgid "Fact"
 msgstr "Evento"
+
+msgid "Fact name to use for primary interface detection and hostname"
+msgstr ""
 
 msgid "Facts discovered on this host"
 msgstr "Eventi trovati su questo host"
@@ -156,12 +160,6 @@ msgid "Facts refreshed for %s"
 msgstr "Eventi aggiornati per %s"
 
 msgid "Failed to auto provision host %s: %s"
-msgstr ""
-
-msgid "Failed to import facts for discovered host"
-msgstr ""
-
-msgid "Failed to import facts for discovered host: %s"
 msgstr ""
 
 msgid "Failed to reboot host %s"
@@ -182,6 +180,16 @@ msgstr ""
 msgid "Host group"
 msgstr "Gruppo di host"
 
+msgid "Host group location %s must also be associated to the discovery rule"
+msgid_plural "Host group locations %s must also be associated to the discovery rule"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "Host group organization %s must also be associated to the discovery rule"
+msgid_plural "Host group organizations %s must also be associated to the discovery rule"
+msgstr[0] ""
+msgstr[1] ""
+
 msgid "Host of type %s can not be rebooted"
 msgstr ""
 
@@ -197,17 +205,11 @@ msgstr ""
 msgid "IP Address"
 msgstr "IP Address"
 
-msgid "Imported discovered host"
+msgid "Incompatible version of puppet fact parser"
 msgstr ""
 
 msgid "Invalid facts, must be a Hash"
 msgstr "Eventi non validi, deve essere un Hash"
-
-msgid "Invalid facts: hash does not contain IP address"
-msgstr ""
-
-msgid "Invalid facts: hash does not contain the required fact '%s'"
-msgstr "Eventi non validi: hash deve avere l'evento '%s' necessario"
 
 msgid "Last facts upload"
 msgstr "Ultimo caricamento eventi"
@@ -220,6 +222,9 @@ msgstr ""
 
 msgid "Location"
 msgstr "Posizione"
+
+msgid "Locations"
+msgstr ""
 
 msgid "Maximum hosts provisioned with this rule (0 = unlimited)"
 msgstr ""
@@ -242,10 +247,16 @@ msgstr ""
 msgid "New Rule"
 msgstr ""
 
+msgid "New in the last 24 hours"
+msgstr ""
+
 msgid "No discovered hosts available"
 msgstr ""
 
 msgid "No discovered hosts to provision"
+msgstr ""
+
+msgid "No discovered hosts to reboot"
 msgstr ""
 
 msgid "No hosts selected"
@@ -257,11 +268,20 @@ msgstr "Nessun host trovato con l'id o nome indicato"
 msgid "No rule found for host %s"
 msgstr ""
 
+msgid "Not reported in more than 7 days"
+msgstr ""
+
 msgid "Organization"
 msgstr "Organizzazione"
 
+msgid "Organizations"
+msgstr ""
+
 msgid "Please Confirm"
 msgstr "Conferma"
+
+msgid "Primary"
+msgstr ""
 
 msgid "Provision"
 msgstr "Provisioning"
@@ -272,10 +292,16 @@ msgstr ""
 msgid "Reboot"
 msgstr ""
 
+msgid "Reboot All"
+msgstr ""
+
 msgid "Rebooting %s"
 msgstr "Riavvio di %s"
 
 msgid "Rebooting a discovered host"
+msgstr ""
+
+msgid "Rebooting all discovered hosts"
 msgstr ""
 
 msgid "Rebooting host %s"
@@ -285,6 +311,9 @@ msgid "Refresh facts"
 msgstr "Aggiorna eventi"
 
 msgid "Refreshing the facts of a discovered host"
+msgstr ""
+
+msgid "Reported in the last 7 days"
 msgstr ""
 
 msgid "Rule disabled"
@@ -314,15 +343,10 @@ msgstr ""
 msgid "Show a discovery rule"
 msgstr ""
 
-msgid "Show fact as an extra column in the discovered hosts list"
-msgstr ""
-
 msgid "Something went wrong while selecting hosts - %s"
 msgstr "Si è verificato un errore durante la selezione degli host - %s"
 
-msgid ""
-"Specify target hostname template pattern in the same syntax as in "
-"Provisioning Templates (ERB)."
+msgid "Specify target hostname template pattern in the same syntax as in Provisioning Templates (ERB)."
 msgstr ""
 
 msgid "Submit"
@@ -337,9 +361,6 @@ msgstr ""
 msgid "Template"
 msgstr "Modello"
 
-msgid "The default fact name to use for the MAC of the system"
-msgstr "Il nome dell'evento predefinito da usare per il MAC del sistema"
-
 msgid "The default location to place discovered hosts in"
 msgstr "La posizione predefinita nella quale posizionare gli host trovati"
 
@@ -352,18 +373,22 @@ msgstr ""
 msgid "The following hosts were not deleted: %s"
 msgstr "I seguenti host non sono stati rilevati: %s"
 
-msgid ""
-"This might take a while, as all hosts, facts and reports will be destroyed "
-"as well"
+msgid "This might take a while, as all hosts, facts and reports will be destroyed as well"
 msgstr "Questa operazione potrebbe richiedere qualche istante poichè saranno annullati anche gli host, eventi e riporti"
 
-msgid "Total pool size"
-msgid_plural "Total pool size"
-msgstr[0] ""
-msgstr[1] ""
+msgid "UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks"
+msgstr ""
 
-msgid ""
-"UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks"
+msgid "Unable to assign subnet, primary interface is missing IP address"
+msgstr ""
+
+msgid "Unable to detect primary interface using MAC '%{mac}' specified by discovery_fact '%{fact}'"
+msgstr ""
+
+msgid "Unable to find a discovery rule, no host provided (check permissions)"
+msgstr ""
+
+msgid "Unable to reboot %{name}: %{msg}"
 msgstr ""
 
 msgid "Update a rule"
@@ -378,19 +403,25 @@ msgstr "Valore"
 msgid "Warning"
 msgstr "Avvertenza"
 
-msgid ""
-"When creating hostname patterns, make sure the resulting host names are "
-"unique. Hostnames must not start with numbers. A good approach is to use "
-"unique information provided by facter (MAC address, BIOS or serial ID)."
+msgid "When creating hostname patterns, make sure the resulting host names are unique. Hostnames must not start with numbers. A good approach is to use unique information provided by facter (MAC address, BIOS or serial ID)."
 msgstr ""
 
 msgid "can't contain white spaces."
 msgstr ""
 
+msgid "defines a pattern to assign human-readable hostnames to the matching hosts"
+msgstr ""
+
+msgid "enables to limit maximum amount of provisioned hosts per rule"
+msgstr ""
+
 msgid "filter results"
 msgstr ""
 
-msgid "hash containing facts for the host"
+msgid "flag is used for temporary shutdown of rules"
+msgstr ""
+
+msgid "hash containing facts for the host with minimum set of facts: discovery_bootif, macaddress_eth0, ipaddress, ipaddress_eth0, interfaces: eth0 (example in case primary interface is named eth0)"
 msgstr ""
 
 msgid "items selected. Uncheck to Clear"
@@ -411,10 +442,26 @@ msgstr ""
 msgid "paginate results"
 msgstr ""
 
-msgid ""
-"required if value is not inherited from host group or default password in "
-"settings"
+msgid "puts the rules in order, low numbers go first. Must be greater then zero"
+msgstr ""
+
+msgid "query to match discovered hosts for the particular rule"
+msgstr ""
+
+msgid "represents rule name shown to the users"
+msgstr ""
+
+msgid "required if value is not inherited from host group or default password in settings"
 msgstr ""
 
 msgid "sort results"
 msgstr ""
+
+msgid "the hostgroup that is used to auto provision a host"
+msgstr ""
+
+#~ msgid "Invalid facts: hash does not contain the required fact '%s'"
+#~ msgstr "Eventi non validi: hash deve avere l'evento '%s' necessario"
+
+#~ msgid "The default fact name to use for the MAC of the system"
+#~ msgstr "Il nome dell'evento predefinito da usare per il MAC del sistema"

--- a/locale/ja/foreman_discovery.po
+++ b/locale/ja/foreman_discovery.po
@@ -1,21 +1,21 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the foreman package.
-# 
+#
 # Translators:
 # Shuji Yamada <uzy.exe@gmail.com>, 2015
 msgid ""
 msgstr ""
 "Project-Id-Version: foreman_discovery 3.0.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-01-28 17:53+0100\n"
+"Report-Msgid-Bugs-To: foreman-dev@googlegroups.com\n"
+"POT-Creation-Date: 2015-08-13 16:23+0200\n"
 "PO-Revision-Date: 2015-04-05 12:23+0000\n"
 "Last-Translator: Shuji Yamada <uzy.exe@gmail.com>\n"
 "Language-Team: Japanese (http://www.transifex.com/foreman/foreman/language/ja/)\n"
+"Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ja\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 msgid "%s - The following hosts are about to be changed"
@@ -39,10 +39,11 @@ msgstr "自動プロビジョン"
 msgid "Auto Provision All"
 msgstr "全自動プロビジョン"
 
-msgid ""
-"Automatically provision newly discovered hosts, according to the "
-"provisioning rules"
+msgid "Automatically provision newly discovered hosts, according to the provisioning rules"
 msgstr "プロビジョニングルールに従って、新しく発見されたホストを自動プロビジョニングする"
+
+msgid "Automatically reboot discovered host during provisioning"
+msgstr ""
 
 msgid "CPUs"
 msgstr "CPU"
@@ -53,8 +54,8 @@ msgstr "取り消し"
 msgid "Could not get facts from proxy %{url}: %{error}"
 msgstr "プロキシーからファクトを取得できませんでした: %{url}: %{error}"
 
-msgid "Create a discovered host"
-msgstr "検出されたホストを作成します"
+msgid "Create a discovered host for testing (use /facts to create new hosts)"
+msgstr ""
 
 msgid "Create a discovery rule"
 msgstr "検出ルールを作成します"
@@ -83,9 +84,6 @@ msgstr "無効"
 msgid "Disable rule?"
 msgstr "ルールを無効にしますか？"
 
-msgid "Discovered Host Pool"
-msgstr "検出されたホストのプール"
-
 msgid "Discovered host: %s"
 msgstr "検出されたホスト: %s"
 
@@ -95,14 +93,11 @@ msgstr "検出されたホスト"
 msgid "Discovered hosts are provisioning now"
 msgstr "現在、検出されたホストはプロビジョニング中です"
 
+msgid "Discovered hosts are rebooting now"
+msgstr ""
+
 msgid "Discovery Rules"
 msgstr "検出ルール"
-
-msgid "Discovery rules"
-msgstr "検出ルール"
-
-msgid "Discovery widget"
-msgstr "検出ウィジット"
 
 msgid "DiscoveryRule|Enabled"
 msgstr "有効"
@@ -122,10 +117,7 @@ msgstr "ディスク数"
 msgid "Disks size"
 msgstr "ディスク容量"
 
-msgid ""
-"Domain will be appended automatically. A hostname based on MAC address will "
-"be used when left blank. In addition to @host attribute function rand for "
-"random integers is available. Examples:"
+msgid "Domain will be appended automatically. A hostname based on MAC address will be used when left blank. In addition to @host attribute function rand for random integers is available. Examples:"
 msgstr ""
 
 msgid "Edit Discovery Rule"
@@ -140,14 +132,26 @@ msgstr "ルールを有効化しますか?"
 msgid "Errors during auto provisioning: %s"
 msgstr "自動プロビジョニング中のエラー: %s"
 
+msgid "Errors during reboot: %s"
+msgstr ""
+
 msgid "Execute rules against a discovered host"
 msgstr "検出されたホストに対してルールを実行"
 
 msgid "Execute rules against all currently discovered hosts"
 msgstr "すべての検出されているホストに対してルールを実行"
 
+msgid "Expected discovery_fact '%s' is missing, unable to detect primary interface and set hostname"
+msgstr ""
+
+msgid "Extra facter columns to show in host lists (separate by comma)"
+msgstr ""
+
 msgid "Fact"
 msgstr "ファクト"
+
+msgid "Fact name to use for primary interface detection and hostname"
+msgstr ""
 
 msgid "Facts discovered on this host"
 msgstr "このホストで検出されたファクト"
@@ -157,12 +161,6 @@ msgstr "%s について更新されたファクト"
 
 msgid "Failed to auto provision host %s: %s"
 msgstr "ホスト %s の自動プロビジョニングに失敗しました: %s"
-
-msgid "Failed to import facts for discovered host"
-msgstr "検出されたホストのファクトをインポートできませんでした"
-
-msgid "Failed to import facts for discovered host: %s"
-msgstr ""
 
 msgid "Failed to reboot host %s"
 msgstr "ホスト %s の再起動に失敗しました"
@@ -182,6 +180,14 @@ msgstr ""
 msgid "Host group"
 msgstr "ホストグループ"
 
+msgid "Host group location %s must also be associated to the discovery rule"
+msgid_plural "Host group locations %s must also be associated to the discovery rule"
+msgstr[0] ""
+
+msgid "Host group organization %s must also be associated to the discovery rule"
+msgid_plural "Host group organizations %s must also be associated to the discovery rule"
+msgstr[0] ""
+
 msgid "Host of type %s can not be rebooted"
 msgstr "タイプ %s のホストを再起動することができません"
 
@@ -197,17 +203,11 @@ msgstr "ホスト/制限"
 msgid "IP Address"
 msgstr "IP アドレス"
 
-msgid "Imported discovered host"
-msgstr "検出されたホストのインポート"
+msgid "Incompatible version of puppet fact parser"
+msgstr ""
 
 msgid "Invalid facts, must be a Hash"
 msgstr "無効なファクトです。ハッシュにする必要があります"
-
-msgid "Invalid facts: hash does not contain IP address"
-msgstr "無効なファクト : ハッシュは IP アドレスが含まれていません"
-
-msgid "Invalid facts: hash does not contain the required fact '%s'"
-msgstr "無効なファクト: ハッシュには必要なファクト '%s' が含まれていません"
 
 msgid "Last facts upload"
 msgstr "最終ファクトのアップロード"
@@ -220,6 +220,9 @@ msgstr "すべての検出ルールを一覧表示"
 
 msgid "Location"
 msgstr "ロケーション"
+
+msgid "Locations"
+msgstr ""
 
 msgid "Maximum hosts provisioned with this rule (0 = unlimited)"
 msgstr ""
@@ -242,10 +245,16 @@ msgstr "新規検出ルール"
 msgid "New Rule"
 msgstr "新規ルール"
 
+msgid "New in the last 24 hours"
+msgstr ""
+
 msgid "No discovered hosts available"
 msgstr ""
 
 msgid "No discovered hosts to provision"
+msgstr ""
+
+msgid "No discovered hosts to reboot"
 msgstr ""
 
 msgid "No hosts selected"
@@ -257,11 +266,20 @@ msgstr "該当する ID または名前のホストが見つかりませんで�
 msgid "No rule found for host %s"
 msgstr "ホスト %s のルールが見つかりません"
 
+msgid "Not reported in more than 7 days"
+msgstr ""
+
 msgid "Organization"
 msgstr "組織"
 
+msgid "Organizations"
+msgstr ""
+
 msgid "Please Confirm"
 msgstr "確認してください"
+
+msgid "Primary"
+msgstr ""
 
 msgid "Provision"
 msgstr "プロビジョニング"
@@ -272,11 +290,17 @@ msgstr "検出されたホストのプロビジョン"
 msgid "Reboot"
 msgstr "再起動"
 
+msgid "Reboot All"
+msgstr ""
+
 msgid "Rebooting %s"
 msgstr "%s の再起動中"
 
 msgid "Rebooting a discovered host"
 msgstr "検出されたホストの再起動"
+
+msgid "Rebooting all discovered hosts"
+msgstr ""
 
 msgid "Rebooting host %s"
 msgstr "ホスト %s の再起動中"
@@ -286,6 +310,9 @@ msgstr "ファクトの更新"
 
 msgid "Refreshing the facts of a discovered host"
 msgstr "検出されたホストのファクト更新"
+
+msgid "Reported in the last 7 days"
+msgstr ""
 
 msgid "Rule disabled"
 msgstr "ルールの無効化"
@@ -314,15 +341,10 @@ msgstr "検出されたホストを表示"
 msgid "Show a discovery rule"
 msgstr "検出ルールを表示"
 
-msgid "Show fact as an extra column in the discovered hosts list"
-msgstr ""
-
 msgid "Something went wrong while selecting hosts - %s"
 msgstr "ホストの選択中に問題が発生しました - %s"
 
-msgid ""
-"Specify target hostname template pattern in the same syntax as in "
-"Provisioning Templates (ERB)."
+msgid "Specify target hostname template pattern in the same syntax as in Provisioning Templates (ERB)."
 msgstr ""
 
 msgid "Submit"
@@ -337,9 +359,6 @@ msgstr ""
 msgid "Template"
 msgstr "テンプレート"
 
-msgid "The default fact name to use for the MAC of the system"
-msgstr "システムの MAC に使用するデフォルトのファクト名"
-
 msgid "The default location to place discovered hosts in"
 msgstr "検出されたホストを配置するデフォルトのロケーション"
 
@@ -352,17 +371,22 @@ msgstr "ホスト名に使用するデフォルトの接頭辞は、文字で始
 msgid "The following hosts were not deleted: %s"
 msgstr "以下のホストが削除されました: %s"
 
-msgid ""
-"This might take a while, as all hosts, facts and reports will be destroyed "
-"as well"
+msgid "This might take a while, as all hosts, facts and reports will be destroyed as well"
 msgstr "ホスト、ファクトおよびレポートがすべて破棄されるため、時間がかかる場合があります。"
 
-msgid "Total pool size"
-msgid_plural "Total pool size"
-msgstr[0] "合計プールサイズ"
+msgid "UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks"
+msgstr ""
 
-msgid ""
-"UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks"
+msgid "Unable to assign subnet, primary interface is missing IP address"
+msgstr ""
+
+msgid "Unable to detect primary interface using MAC '%{mac}' specified by discovery_fact '%{fact}'"
+msgstr ""
+
+msgid "Unable to find a discovery rule, no host provided (check permissions)"
+msgstr ""
+
+msgid "Unable to reboot %{name}: %{msg}"
 msgstr ""
 
 msgid "Update a rule"
@@ -377,19 +401,25 @@ msgstr "値"
 msgid "Warning"
 msgstr "警告"
 
-msgid ""
-"When creating hostname patterns, make sure the resulting host names are "
-"unique. Hostnames must not start with numbers. A good approach is to use "
-"unique information provided by facter (MAC address, BIOS or serial ID)."
+msgid "When creating hostname patterns, make sure the resulting host names are unique. Hostnames must not start with numbers. A good approach is to use unique information provided by facter (MAC address, BIOS or serial ID)."
 msgstr ""
 
 msgid "can't contain white spaces."
 msgstr "空白を含めることはできません."
 
+msgid "defines a pattern to assign human-readable hostnames to the matching hosts"
+msgstr ""
+
+msgid "enables to limit maximum amount of provisioned hosts per rule"
+msgstr ""
+
 msgid "filter results"
 msgstr "結果をフィルタ"
 
-msgid "hash containing facts for the host"
+msgid "flag is used for temporary shutdown of rules"
+msgstr ""
+
+msgid "hash containing facts for the host with minimum set of facts: discovery_bootif, macaddress_eth0, ipaddress, ipaddress_eth0, interfaces: eth0 (example in case primary interface is named eth0)"
 msgstr ""
 
 msgid "items selected. Uncheck to Clear"
@@ -410,10 +440,51 @@ msgstr "リクエストあたりのエントリ数"
 msgid "paginate results"
 msgstr "結果をページ分割"
 
-msgid ""
-"required if value is not inherited from host group or default password in "
-"settings"
+msgid "puts the rules in order, low numbers go first. Must be greater then zero"
+msgstr ""
+
+msgid "query to match discovered hosts for the particular rule"
+msgstr ""
+
+msgid "represents rule name shown to the users"
+msgstr ""
+
+msgid "required if value is not inherited from host group or default password in settings"
 msgstr ""
 
 msgid "sort results"
 msgstr "結果をソート"
+
+msgid "the hostgroup that is used to auto provision a host"
+msgstr ""
+
+#~ msgid "Create a discovered host"
+#~ msgstr "検出されたホストを作成します"
+
+#~ msgid "Discovered Host Pool"
+#~ msgstr "検出されたホストのプール"
+
+#~ msgid "Discovery rules"
+#~ msgstr "検出ルール"
+
+#~ msgid "Discovery widget"
+#~ msgstr "検出ウィジット"
+
+#~ msgid "Failed to import facts for discovered host"
+#~ msgstr "検出されたホストのファクトをインポートできませんでした"
+
+#~ msgid "Imported discovered host"
+#~ msgstr "検出されたホストのインポート"
+
+#~ msgid "Invalid facts: hash does not contain IP address"
+#~ msgstr "無効なファクト : ハッシュは IP アドレスが含まれていません"
+
+#~ msgid "Invalid facts: hash does not contain the required fact '%s'"
+#~ msgstr "無効なファクト: ハッシュには必要なファクト '%s' が含まれていません"
+
+#~ msgid "The default fact name to use for the MAC of the system"
+#~ msgstr "システムの MAC に使用するデフォルトのファクト名"
+
+#~ msgid "Total pool size"
+#~ msgid_plural "Total pool size"
+#~ msgstr[0] "合計プールサイズ"

--- a/locale/ko/foreman_discovery.po
+++ b/locale/ko/foreman_discovery.po
@@ -1,20 +1,20 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the foreman package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: foreman_discovery 3.0.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-01-28 17:53+0100\n"
+"Report-Msgid-Bugs-To: foreman-dev@googlegroups.com\n"
+"POT-Creation-Date: 2015-08-13 16:23+0200\n"
 "PO-Revision-Date: 2015-03-21 22:53+0000\n"
 "Last-Translator: Lukáš Zapletal\n"
 "Language-Team: Korean (http://www.transifex.com/foreman/foreman/language/ko/)\n"
+"Language: ko\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ko\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 msgid "%s - The following hosts are about to be changed"
@@ -38,9 +38,10 @@ msgstr ""
 msgid "Auto Provision All"
 msgstr ""
 
-msgid ""
-"Automatically provision newly discovered hosts, according to the "
-"provisioning rules"
+msgid "Automatically provision newly discovered hosts, according to the provisioning rules"
+msgstr ""
+
+msgid "Automatically reboot discovered host during provisioning"
 msgstr ""
 
 msgid "CPUs"
@@ -52,7 +53,7 @@ msgstr "취소 "
 msgid "Could not get facts from proxy %{url}: %{error}"
 msgstr ""
 
-msgid "Create a discovered host"
+msgid "Create a discovered host for testing (use /facts to create new hosts)"
 msgstr ""
 
 msgid "Create a discovery rule"
@@ -82,9 +83,6 @@ msgstr ""
 msgid "Disable rule?"
 msgstr ""
 
-msgid "Discovered Host Pool"
-msgstr ""
-
 msgid "Discovered host: %s"
 msgstr "검색된 호스트: %s"
 
@@ -94,13 +92,10 @@ msgstr "검색된 호스트 "
 msgid "Discovered hosts are provisioning now"
 msgstr ""
 
+msgid "Discovered hosts are rebooting now"
+msgstr ""
+
 msgid "Discovery Rules"
-msgstr ""
-
-msgid "Discovery rules"
-msgstr ""
-
-msgid "Discovery widget"
 msgstr ""
 
 msgid "DiscoveryRule|Enabled"
@@ -121,10 +116,7 @@ msgstr ""
 msgid "Disks size"
 msgstr ""
 
-msgid ""
-"Domain will be appended automatically. A hostname based on MAC address will "
-"be used when left blank. In addition to @host attribute function rand for "
-"random integers is available. Examples:"
+msgid "Domain will be appended automatically. A hostname based on MAC address will be used when left blank. In addition to @host attribute function rand for random integers is available. Examples:"
 msgstr ""
 
 msgid "Edit Discovery Rule"
@@ -139,14 +131,26 @@ msgstr ""
 msgid "Errors during auto provisioning: %s"
 msgstr ""
 
+msgid "Errors during reboot: %s"
+msgstr ""
+
 msgid "Execute rules against a discovered host"
 msgstr ""
 
 msgid "Execute rules against all currently discovered hosts"
 msgstr ""
 
+msgid "Expected discovery_fact '%s' is missing, unable to detect primary interface and set hostname"
+msgstr ""
+
+msgid "Extra facter columns to show in host lists (separate by comma)"
+msgstr ""
+
 msgid "Fact"
 msgstr "정보 "
+
+msgid "Fact name to use for primary interface detection and hostname"
+msgstr ""
 
 msgid "Facts discovered on this host"
 msgstr "이 호스트에서 검색된 정보 "
@@ -155,12 +159,6 @@ msgid "Facts refreshed for %s"
 msgstr "%s에 대해 업데이트된 정보 "
 
 msgid "Failed to auto provision host %s: %s"
-msgstr ""
-
-msgid "Failed to import facts for discovered host"
-msgstr ""
-
-msgid "Failed to import facts for discovered host: %s"
 msgstr ""
 
 msgid "Failed to reboot host %s"
@@ -181,6 +179,14 @@ msgstr ""
 msgid "Host group"
 msgstr "호스트 그룹 "
 
+msgid "Host group location %s must also be associated to the discovery rule"
+msgid_plural "Host group locations %s must also be associated to the discovery rule"
+msgstr[0] ""
+
+msgid "Host group organization %s must also be associated to the discovery rule"
+msgid_plural "Host group organizations %s must also be associated to the discovery rule"
+msgstr[0] ""
+
 msgid "Host of type %s can not be rebooted"
 msgstr ""
 
@@ -196,17 +202,11 @@ msgstr ""
 msgid "IP Address"
 msgstr "IP 주소"
 
-msgid "Imported discovered host"
+msgid "Incompatible version of puppet fact parser"
 msgstr ""
 
 msgid "Invalid facts, must be a Hash"
 msgstr "잘못된 정보, 해시여야 합니다 "
-
-msgid "Invalid facts: hash does not contain IP address"
-msgstr ""
-
-msgid "Invalid facts: hash does not contain the required fact '%s'"
-msgstr "잘못된 정보:  해시에 필요한 정보 '%s'가 포함되어 있지 않습니다 "
 
 msgid "Last facts upload"
 msgstr "마지막 정보 업로드 "
@@ -219,6 +219,9 @@ msgstr ""
 
 msgid "Location"
 msgstr "위치 "
+
+msgid "Locations"
+msgstr ""
 
 msgid "Maximum hosts provisioned with this rule (0 = unlimited)"
 msgstr ""
@@ -241,10 +244,16 @@ msgstr ""
 msgid "New Rule"
 msgstr ""
 
+msgid "New in the last 24 hours"
+msgstr ""
+
 msgid "No discovered hosts available"
 msgstr ""
 
 msgid "No discovered hosts to provision"
+msgstr ""
+
+msgid "No discovered hosts to reboot"
 msgstr ""
 
 msgid "No hosts selected"
@@ -256,11 +265,20 @@ msgstr "해당 ID 또는 이름의 호스트를 찾을 수 없습니다 "
 msgid "No rule found for host %s"
 msgstr ""
 
+msgid "Not reported in more than 7 days"
+msgstr ""
+
 msgid "Organization"
 msgstr "조직 "
 
+msgid "Organizations"
+msgstr ""
+
 msgid "Please Confirm"
 msgstr "확인해 주십시오 "
+
+msgid "Primary"
+msgstr ""
 
 msgid "Provision"
 msgstr "프로비저닝 "
@@ -271,10 +289,16 @@ msgstr ""
 msgid "Reboot"
 msgstr ""
 
+msgid "Reboot All"
+msgstr ""
+
 msgid "Rebooting %s"
 msgstr "%s 재부팅 중 "
 
 msgid "Rebooting a discovered host"
+msgstr ""
+
+msgid "Rebooting all discovered hosts"
 msgstr ""
 
 msgid "Rebooting host %s"
@@ -284,6 +308,9 @@ msgid "Refresh facts"
 msgstr "정보 새로 고침 "
 
 msgid "Refreshing the facts of a discovered host"
+msgstr ""
+
+msgid "Reported in the last 7 days"
 msgstr ""
 
 msgid "Rule disabled"
@@ -313,15 +340,10 @@ msgstr ""
 msgid "Show a discovery rule"
 msgstr ""
 
-msgid "Show fact as an extra column in the discovered hosts list"
-msgstr ""
-
 msgid "Something went wrong while selecting hosts - %s"
 msgstr "호스트를 선택하는 도중 문제가 발생했습니다 - %s"
 
-msgid ""
-"Specify target hostname template pattern in the same syntax as in "
-"Provisioning Templates (ERB)."
+msgid "Specify target hostname template pattern in the same syntax as in Provisioning Templates (ERB)."
 msgstr ""
 
 msgid "Submit"
@@ -336,9 +358,6 @@ msgstr ""
 msgid "Template"
 msgstr "템플릿"
 
-msgid "The default fact name to use for the MAC of the system"
-msgstr "시스템의 MAC에 사용할 기본 정보 이름 "
-
 msgid "The default location to place discovered hosts in"
 msgstr "검색된 호스트를 배치하기 위한 기본 위치 "
 
@@ -351,17 +370,22 @@ msgstr ""
 msgid "The following hosts were not deleted: %s"
 msgstr "다음 호스트가 삭제되지 않았습니다: %s"
 
-msgid ""
-"This might take a while, as all hosts, facts and reports will be destroyed "
-"as well"
+msgid "This might take a while, as all hosts, facts and reports will be destroyed as well"
 msgstr "모든 호스트, 정보, 보고서가 모두 삭제되기 때문에 시간이 걸릴 수 있습니다 "
 
-msgid "Total pool size"
-msgid_plural "Total pool size"
-msgstr[0] ""
+msgid "UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks"
+msgstr ""
 
-msgid ""
-"UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks"
+msgid "Unable to assign subnet, primary interface is missing IP address"
+msgstr ""
+
+msgid "Unable to detect primary interface using MAC '%{mac}' specified by discovery_fact '%{fact}'"
+msgstr ""
+
+msgid "Unable to find a discovery rule, no host provided (check permissions)"
+msgstr ""
+
+msgid "Unable to reboot %{name}: %{msg}"
 msgstr ""
 
 msgid "Update a rule"
@@ -376,19 +400,25 @@ msgstr "값 "
 msgid "Warning"
 msgstr "경고 "
 
-msgid ""
-"When creating hostname patterns, make sure the resulting host names are "
-"unique. Hostnames must not start with numbers. A good approach is to use "
-"unique information provided by facter (MAC address, BIOS or serial ID)."
+msgid "When creating hostname patterns, make sure the resulting host names are unique. Hostnames must not start with numbers. A good approach is to use unique information provided by facter (MAC address, BIOS or serial ID)."
 msgstr ""
 
 msgid "can't contain white spaces."
 msgstr ""
 
+msgid "defines a pattern to assign human-readable hostnames to the matching hosts"
+msgstr ""
+
+msgid "enables to limit maximum amount of provisioned hosts per rule"
+msgstr ""
+
 msgid "filter results"
 msgstr ""
 
-msgid "hash containing facts for the host"
+msgid "flag is used for temporary shutdown of rules"
+msgstr ""
+
+msgid "hash containing facts for the host with minimum set of facts: discovery_bootif, macaddress_eth0, ipaddress, ipaddress_eth0, interfaces: eth0 (example in case primary interface is named eth0)"
 msgstr ""
 
 msgid "items selected. Uncheck to Clear"
@@ -409,10 +439,26 @@ msgstr ""
 msgid "paginate results"
 msgstr ""
 
-msgid ""
-"required if value is not inherited from host group or default password in "
-"settings"
+msgid "puts the rules in order, low numbers go first. Must be greater then zero"
+msgstr ""
+
+msgid "query to match discovered hosts for the particular rule"
+msgstr ""
+
+msgid "represents rule name shown to the users"
+msgstr ""
+
+msgid "required if value is not inherited from host group or default password in settings"
 msgstr ""
 
 msgid "sort results"
 msgstr ""
+
+msgid "the hostgroup that is used to auto provision a host"
+msgstr ""
+
+#~ msgid "Invalid facts: hash does not contain the required fact '%s'"
+#~ msgstr "잘못된 정보:  해시에 필요한 정보 '%s'가 포함되어 있지 않습니다 "
+
+#~ msgid "The default fact name to use for the MAC of the system"
+#~ msgstr "시스템의 MAC에 사용할 기본 정보 이름 "

--- a/locale/pt_BR/foreman_discovery.po
+++ b/locale/pt_BR/foreman_discovery.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the foreman package.
-# 
+#
 # Translators:
 # Dominic Cleal <dcleal@redhat.com>, 2014
 # Especialista em Automatizaçao <alvin@intechne.com.br>, 2014
@@ -9,15 +9,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: foreman_discovery 3.0.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-01-28 17:53+0100\n"
+"Report-Msgid-Bugs-To: foreman-dev@googlegroups.com\n"
+"POT-Creation-Date: 2015-08-13 16:23+0200\n"
 "PO-Revision-Date: 2015-03-28 23:01+0000\n"
 "Last-Translator: Lukáš Zapletal\n"
 "Language-Team: Portuguese (Brazil) (http://www.transifex.com/foreman/foreman/language/pt_BR/)\n"
+"Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: pt_BR\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 msgid "%s - The following hosts are about to be changed"
@@ -41,9 +41,10 @@ msgstr ""
 msgid "Auto Provision All"
 msgstr ""
 
-msgid ""
-"Automatically provision newly discovered hosts, according to the "
-"provisioning rules"
+msgid "Automatically provision newly discovered hosts, according to the provisioning rules"
+msgstr ""
+
+msgid "Automatically reboot discovered host during provisioning"
 msgstr ""
 
 msgid "CPUs"
@@ -55,7 +56,7 @@ msgstr "Cancelar"
 msgid "Could not get facts from proxy %{url}: %{error}"
 msgstr ""
 
-msgid "Create a discovered host"
+msgid "Create a discovered host for testing (use /facts to create new hosts)"
 msgstr ""
 
 msgid "Create a discovery rule"
@@ -85,9 +86,6 @@ msgstr ""
 msgid "Disable rule?"
 msgstr ""
 
-msgid "Discovered Host Pool"
-msgstr ""
-
 msgid "Discovered host: %s"
 msgstr "Host descoberto: %s"
 
@@ -97,13 +95,10 @@ msgstr "Hosts descobertos"
 msgid "Discovered hosts are provisioning now"
 msgstr ""
 
+msgid "Discovered hosts are rebooting now"
+msgstr ""
+
 msgid "Discovery Rules"
-msgstr ""
-
-msgid "Discovery rules"
-msgstr ""
-
-msgid "Discovery widget"
 msgstr ""
 
 msgid "DiscoveryRule|Enabled"
@@ -124,10 +119,7 @@ msgstr ""
 msgid "Disks size"
 msgstr ""
 
-msgid ""
-"Domain will be appended automatically. A hostname based on MAC address will "
-"be used when left blank. In addition to @host attribute function rand for "
-"random integers is available. Examples:"
+msgid "Domain will be appended automatically. A hostname based on MAC address will be used when left blank. In addition to @host attribute function rand for random integers is available. Examples:"
 msgstr ""
 
 msgid "Edit Discovery Rule"
@@ -142,14 +134,26 @@ msgstr ""
 msgid "Errors during auto provisioning: %s"
 msgstr ""
 
+msgid "Errors during reboot: %s"
+msgstr ""
+
 msgid "Execute rules against a discovered host"
 msgstr ""
 
 msgid "Execute rules against all currently discovered hosts"
 msgstr ""
 
+msgid "Expected discovery_fact '%s' is missing, unable to detect primary interface and set hostname"
+msgstr ""
+
+msgid "Extra facter columns to show in host lists (separate by comma)"
+msgstr ""
+
 msgid "Fact"
 msgstr "Fato"
+
+msgid "Fact name to use for primary interface detection and hostname"
+msgstr ""
 
 msgid "Facts discovered on this host"
 msgstr "Fatos descobertos neste host"
@@ -158,12 +162,6 @@ msgid "Facts refreshed for %s"
 msgstr "Fatos atualizados de %s"
 
 msgid "Failed to auto provision host %s: %s"
-msgstr ""
-
-msgid "Failed to import facts for discovered host"
-msgstr ""
-
-msgid "Failed to import facts for discovered host: %s"
 msgstr ""
 
 msgid "Failed to reboot host %s"
@@ -184,6 +182,16 @@ msgstr ""
 msgid "Host group"
 msgstr "Grupo de Host"
 
+msgid "Host group location %s must also be associated to the discovery rule"
+msgid_plural "Host group locations %s must also be associated to the discovery rule"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "Host group organization %s must also be associated to the discovery rule"
+msgid_plural "Host group organizations %s must also be associated to the discovery rule"
+msgstr[0] ""
+msgstr[1] ""
+
 msgid "Host of type %s can not be rebooted"
 msgstr ""
 
@@ -199,17 +207,11 @@ msgstr ""
 msgid "IP Address"
 msgstr "Endereço IP"
 
-msgid "Imported discovered host"
+msgid "Incompatible version of puppet fact parser"
 msgstr ""
 
 msgid "Invalid facts, must be a Hash"
 msgstr "Fatos inválidos, devem ser um Hash"
-
-msgid "Invalid facts: hash does not contain IP address"
-msgstr ""
-
-msgid "Invalid facts: hash does not contain the required fact '%s'"
-msgstr "Fatos inválidos: hash não contém o fato requerido '%s'"
 
 msgid "Last facts upload"
 msgstr "Ultimos fatos enviados"
@@ -222,6 +224,9 @@ msgstr ""
 
 msgid "Location"
 msgstr "Localização"
+
+msgid "Locations"
+msgstr ""
 
 msgid "Maximum hosts provisioned with this rule (0 = unlimited)"
 msgstr ""
@@ -244,10 +249,16 @@ msgstr ""
 msgid "New Rule"
 msgstr ""
 
+msgid "New in the last 24 hours"
+msgstr ""
+
 msgid "No discovered hosts available"
 msgstr ""
 
 msgid "No discovered hosts to provision"
+msgstr ""
+
+msgid "No discovered hosts to reboot"
 msgstr ""
 
 msgid "No hosts selected"
@@ -259,11 +270,20 @@ msgstr "Nenhum host foi encontrado com este id ou nome"
 msgid "No rule found for host %s"
 msgstr ""
 
+msgid "Not reported in more than 7 days"
+msgstr ""
+
 msgid "Organization"
 msgstr "Organização"
 
+msgid "Organizations"
+msgstr ""
+
 msgid "Please Confirm"
 msgstr "Por favor Confirme"
+
+msgid "Primary"
+msgstr ""
 
 msgid "Provision"
 msgstr "Provisão"
@@ -274,10 +294,16 @@ msgstr ""
 msgid "Reboot"
 msgstr ""
 
+msgid "Reboot All"
+msgstr ""
+
 msgid "Rebooting %s"
 msgstr "Reiniciando %s"
 
 msgid "Rebooting a discovered host"
+msgstr ""
+
+msgid "Rebooting all discovered hosts"
 msgstr ""
 
 msgid "Rebooting host %s"
@@ -287,6 +313,9 @@ msgid "Refresh facts"
 msgstr "Atualizar fatos"
 
 msgid "Refreshing the facts of a discovered host"
+msgstr ""
+
+msgid "Reported in the last 7 days"
 msgstr ""
 
 msgid "Rule disabled"
@@ -316,15 +345,10 @@ msgstr ""
 msgid "Show a discovery rule"
 msgstr ""
 
-msgid "Show fact as an extra column in the discovered hosts list"
-msgstr ""
-
 msgid "Something went wrong while selecting hosts - %s"
 msgstr "Aldo deu errado ao selecionar hosts - %s"
 
-msgid ""
-"Specify target hostname template pattern in the same syntax as in "
-"Provisioning Templates (ERB)."
+msgid "Specify target hostname template pattern in the same syntax as in Provisioning Templates (ERB)."
 msgstr ""
 
 msgid "Submit"
@@ -339,9 +363,6 @@ msgstr ""
 msgid "Template"
 msgstr "Template"
 
-msgid "The default fact name to use for the MAC of the system"
-msgstr "O nome do fato padrão utilizado para o MAC do sistema"
-
 msgid "The default location to place discovered hosts in"
 msgstr "A localização padrão para colocar os hosts descobertos"
 
@@ -354,18 +375,22 @@ msgstr ""
 msgid "The following hosts were not deleted: %s"
 msgstr "Os seguintes hosts não foram excluídos: %s"
 
-msgid ""
-"This might take a while, as all hosts, facts and reports will be destroyed "
-"as well"
+msgid "This might take a while, as all hosts, facts and reports will be destroyed as well"
 msgstr "Isso pode levar um tempo, todos os hosts, fatos e relatórios serão destruídos"
 
-msgid "Total pool size"
-msgid_plural "Total pool size"
-msgstr[0] ""
-msgstr[1] ""
+msgid "UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks"
+msgstr ""
 
-msgid ""
-"UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks"
+msgid "Unable to assign subnet, primary interface is missing IP address"
+msgstr ""
+
+msgid "Unable to detect primary interface using MAC '%{mac}' specified by discovery_fact '%{fact}'"
+msgstr ""
+
+msgid "Unable to find a discovery rule, no host provided (check permissions)"
+msgstr ""
+
+msgid "Unable to reboot %{name}: %{msg}"
 msgstr ""
 
 msgid "Update a rule"
@@ -380,19 +405,25 @@ msgstr "Valor"
 msgid "Warning"
 msgstr "Aviso"
 
-msgid ""
-"When creating hostname patterns, make sure the resulting host names are "
-"unique. Hostnames must not start with numbers. A good approach is to use "
-"unique information provided by facter (MAC address, BIOS or serial ID)."
+msgid "When creating hostname patterns, make sure the resulting host names are unique. Hostnames must not start with numbers. A good approach is to use unique information provided by facter (MAC address, BIOS or serial ID)."
 msgstr ""
 
 msgid "can't contain white spaces."
 msgstr ""
 
+msgid "defines a pattern to assign human-readable hostnames to the matching hosts"
+msgstr ""
+
+msgid "enables to limit maximum amount of provisioned hosts per rule"
+msgstr ""
+
 msgid "filter results"
 msgstr "filtrar resultados"
 
-msgid "hash containing facts for the host"
+msgid "flag is used for temporary shutdown of rules"
+msgstr ""
+
+msgid "hash containing facts for the host with minimum set of facts: discovery_bootif, macaddress_eth0, ipaddress, ipaddress_eth0, interfaces: eth0 (example in case primary interface is named eth0)"
 msgstr ""
 
 msgid "items selected. Uncheck to Clear"
@@ -413,10 +444,26 @@ msgstr "número de entradas por requisições"
 msgid "paginate results"
 msgstr "paginar resultados"
 
-msgid ""
-"required if value is not inherited from host group or default password in "
-"settings"
+msgid "puts the rules in order, low numbers go first. Must be greater then zero"
+msgstr ""
+
+msgid "query to match discovered hosts for the particular rule"
+msgstr ""
+
+msgid "represents rule name shown to the users"
+msgstr ""
+
+msgid "required if value is not inherited from host group or default password in settings"
 msgstr ""
 
 msgid "sort results"
 msgstr "ordenar resultados"
+
+msgid "the hostgroup that is used to auto provision a host"
+msgstr ""
+
+#~ msgid "Invalid facts: hash does not contain the required fact '%s'"
+#~ msgstr "Fatos inválidos: hash não contém o fato requerido '%s'"
+
+#~ msgid "The default fact name to use for the MAC of the system"
+#~ msgstr "O nome do fato padrão utilizado para o MAC do sistema"

--- a/locale/ru/foreman_discovery.po
+++ b/locale/ru/foreman_discovery.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the foreman package.
-# 
+#
 # Translators:
 # Evgrafov Denis <stereodenis@gmail.com>, 2014
 # Dominic Cleal <dcleal@redhat.com>, 2014
@@ -9,15 +9,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: foreman_discovery 3.0.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-01-28 17:53+0100\n"
+"Report-Msgid-Bugs-To: foreman-dev@googlegroups.com\n"
+"POT-Creation-Date: 2015-08-13 16:23+0200\n"
 "PO-Revision-Date: 2015-07-03 11:07+0000\n"
 "Last-Translator: Vladimir Pavlov <v.pavlov@i-teco.ru>\n"
 "Language-Team: Russian (http://www.transifex.com/foreman/foreman/language/ru/)\n"
+"Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ru\n"
 "Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
 
 msgid "%s - The following hosts are about to be changed"
@@ -41,10 +41,11 @@ msgstr "Автоматическая подготовка"
 msgid "Auto Provision All"
 msgstr "Автоматическая подготовка всего"
 
-msgid ""
-"Automatically provision newly discovered hosts, according to the "
-"provisioning rules"
+msgid "Automatically provision newly discovered hosts, according to the provisioning rules"
 msgstr "Автоматическая подготовка новых найденных узлов, основываясь на правилах подготовки"
+
+msgid "Automatically reboot discovered host during provisioning"
+msgstr ""
 
 msgid "CPUs"
 msgstr "CPU"
@@ -55,8 +56,8 @@ msgstr "Отмена"
 msgid "Could not get facts from proxy %{url}: %{error}"
 msgstr "Не удалось получить факты через прокси %{url}: %{error}"
 
-msgid "Create a discovered host"
-msgstr "Создать обнаруженный узел"
+msgid "Create a discovered host for testing (use /facts to create new hosts)"
+msgstr ""
 
 msgid "Create a discovery rule"
 msgstr "Создать правило обнаружения"
@@ -85,9 +86,6 @@ msgstr "Отключен"
 msgid "Disable rule?"
 msgstr "Отключить правило?"
 
-msgid "Discovered Host Pool"
-msgstr "Пул обнаруженных узлов"
-
 msgid "Discovered host: %s"
 msgstr "Обнаружен узел: %s"
 
@@ -97,14 +95,11 @@ msgstr "Обнаруженные узлы"
 msgid "Discovered hosts are provisioning now"
 msgstr "Сейчас подготавливаются обнаруженные узлы"
 
+msgid "Discovered hosts are rebooting now"
+msgstr ""
+
 msgid "Discovery Rules"
 msgstr "Правила обнаружения"
-
-msgid "Discovery rules"
-msgstr "Правила обнаружения"
-
-msgid "Discovery widget"
-msgstr "Виджет обнаружения"
 
 msgid "DiscoveryRule|Enabled"
 msgstr "Включено"
@@ -124,10 +119,7 @@ msgstr "Количество дисков"
 msgid "Disks size"
 msgstr "Размер диска"
 
-msgid ""
-"Domain will be appended automatically. A hostname based on MAC address will "
-"be used when left blank. In addition to @host attribute function rand for "
-"random integers is available. Examples:"
+msgid "Domain will be appended automatically. A hostname based on MAC address will be used when left blank. In addition to @host attribute function rand for random integers is available. Examples:"
 msgstr "Домен будет добавлен автоматически. Имя узла основанное на MAC адресе будут использовано при не указанном. В дополнение к атрибуту @host доступны случайные значения от функции генерации случайных чисел. Например:"
 
 msgid "Edit Discovery Rule"
@@ -142,14 +134,26 @@ msgstr "Включить правило?"
 msgid "Errors during auto provisioning: %s"
 msgstr "Ошибка во время автоматической подготовки: %s"
 
+msgid "Errors during reboot: %s"
+msgstr ""
+
 msgid "Execute rules against a discovered host"
 msgstr "Вызвать правила против обнаруженного узла"
 
 msgid "Execute rules against all currently discovered hosts"
 msgstr "Вызвать правила против все текущих обнаруженных узлов"
 
+msgid "Expected discovery_fact '%s' is missing, unable to detect primary interface and set hostname"
+msgstr ""
+
+msgid "Extra facter columns to show in host lists (separate by comma)"
+msgstr ""
+
 msgid "Fact"
 msgstr "Аргумент"
+
+msgid "Fact name to use for primary interface detection and hostname"
+msgstr ""
 
 msgid "Facts discovered on this host"
 msgstr "Обнаружена статистика узла"
@@ -159,12 +163,6 @@ msgstr "Статистика %s обновлена"
 
 msgid "Failed to auto provision host %s: %s"
 msgstr "Сбой автоматической подготовки узла %s: %s"
-
-msgid "Failed to import facts for discovered host"
-msgstr "Сбой импорта фактов для обнаруженного узла"
-
-msgid "Failed to import facts for discovered host: %s"
-msgstr "Сбой импорта фактов для обнаруженного узла:  %s"
 
 msgid "Failed to reboot host %s"
 msgstr "Сбой перезагрузки узла %s"
@@ -184,6 +182,20 @@ msgstr "Узел %{host} был подготовлен с правилом %{rul
 msgid "Host group"
 msgstr "Группа узлов"
 
+msgid "Host group location %s must also be associated to the discovery rule"
+msgid_plural "Host group locations %s must also be associated to the discovery rule"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+msgid "Host group organization %s must also be associated to the discovery rule"
+msgid_plural "Host group organizations %s must also be associated to the discovery rule"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
 msgid "Host of type %s can not be rebooted"
 msgstr "Узел типа %s не может быть перезагружен"
 
@@ -199,17 +211,11 @@ msgstr "Ограничения/узлов"
 msgid "IP Address"
 msgstr "IP-адрес"
 
-msgid "Imported discovered host"
-msgstr "Импортировать обнаруженный узел"
+msgid "Incompatible version of puppet fact parser"
+msgstr ""
 
 msgid "Invalid facts, must be a Hash"
 msgstr "Недопустимый формат статистики. Ожидается: хэш-таблица"
-
-msgid "Invalid facts: hash does not contain IP address"
-msgstr "Неверные факты: хэш не может содержать IP адрес"
-
-msgid "Invalid facts: hash does not contain the required fact '%s'"
-msgstr "Недопустимый формат статистики. Хэш-таблица должна содержать аргумент «%s»"
 
 msgid "Last facts upload"
 msgstr "Отправка последней статистики"
@@ -222,6 +228,9 @@ msgstr "Список всех правил обнаружения"
 
 msgid "Location"
 msgstr "Расположение"
+
+msgid "Locations"
+msgstr ""
 
 msgid "Maximum hosts provisioned with this rule (0 = unlimited)"
 msgstr "Максимальное число узлов подготовленных с этим правилом (0 = не ограничено)"
@@ -244,11 +253,17 @@ msgstr "Новое правило обнаружения"
 msgid "New Rule"
 msgstr "Новое правило"
 
+msgid "New in the last 24 hours"
+msgstr ""
+
 msgid "No discovered hosts available"
 msgstr "Нет доступных обнаруженных узлов"
 
 msgid "No discovered hosts to provision"
 msgstr "Нет доступных узлов для подготовки"
+
+msgid "No discovered hosts to reboot"
+msgstr ""
 
 msgid "No hosts selected"
 msgstr "Узел не выбран"
@@ -259,11 +274,20 @@ msgstr "Нет узла с таким идентификатором или им
 msgid "No rule found for host %s"
 msgstr "Не найдено правил для узла %s"
 
+msgid "Not reported in more than 7 days"
+msgstr ""
+
 msgid "Organization"
 msgstr "Организация"
 
+msgid "Organizations"
+msgstr ""
+
 msgid "Please Confirm"
 msgstr "Подтвердите"
+
+msgid "Primary"
+msgstr ""
 
 msgid "Provision"
 msgstr "Подготовка"
@@ -274,11 +298,17 @@ msgstr "Подготовить обнаруженный узел"
 msgid "Reboot"
 msgstr "Перезагрука"
 
+msgid "Reboot All"
+msgstr ""
+
 msgid "Rebooting %s"
 msgstr "Перезагрузка %s"
 
 msgid "Rebooting a discovered host"
 msgstr "Перезагрузить обнаруженный узел"
+
+msgid "Rebooting all discovered hosts"
+msgstr ""
 
 msgid "Rebooting host %s"
 msgstr "Перезагрузка узла %s"
@@ -288,6 +318,9 @@ msgstr "Обновить статистику"
 
 msgid "Refreshing the facts of a discovered host"
 msgstr "Освежить факты обнаруженного узла"
+
+msgid "Reported in the last 7 days"
+msgstr ""
 
 msgid "Rule disabled"
 msgstr "Правило выключено"
@@ -316,15 +349,10 @@ msgstr "Показать обнаруженный узел"
 msgid "Show a discovery rule"
 msgstr "Показать правило обнаружения"
 
-msgid "Show fact as an extra column in the discovered hosts list"
-msgstr "Показать факты как дополнительный столбец в списке обнаруженных узлов"
-
 msgid "Something went wrong while selecting hosts - %s"
 msgstr "Непредвиденное поведение при выборе узлов: %s"
 
-msgid ""
-"Specify target hostname template pattern in the same syntax as in "
-"Provisioning Templates (ERB)."
+msgid "Specify target hostname template pattern in the same syntax as in Provisioning Templates (ERB)."
 msgstr "Укажите целевой шаблон имени узла в таком же синтаксисе что и шаблон подготовки (ERB)."
 
 msgid "Submit"
@@ -339,9 +367,6 @@ msgstr "Целевая группа узлов для этого правила 
 msgid "Template"
 msgstr "Шаблон"
 
-msgid "The default fact name to use for the MAC of the system"
-msgstr "Стандартный аргумент статистики для MAC"
-
 msgid "The default location to place discovered hosts in"
 msgstr "Место размещения обнаруженных узлов"
 
@@ -354,21 +379,23 @@ msgstr "Приставка по умолчанию для использован
 msgid "The following hosts were not deleted: %s"
 msgstr "Узлы не были удалены: %s"
 
-msgid ""
-"This might take a while, as all hosts, facts and reports will be destroyed "
-"as well"
+msgid "This might take a while, as all hosts, facts and reports will be destroyed as well"
 msgstr "Это может занять некоторое время, так как в ходе выполнения будут удалены узлы, статистика и все отчеты"
 
-msgid "Total pool size"
-msgid_plural "Total pool size"
-msgstr[0] "Итоговый размер пула"
-msgstr[1] "Итоговый размер пула"
-msgstr[2] "Итоговый размер пула"
-msgstr[3] "Итоговый размер пула"
-
-msgid ""
-"UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks"
+msgid "UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks"
 msgstr "UUID для инструментального отслеживания состояния задания, GET /api/orchestration/:UUID/tasks"
+
+msgid "Unable to assign subnet, primary interface is missing IP address"
+msgstr ""
+
+msgid "Unable to detect primary interface using MAC '%{mac}' specified by discovery_fact '%{fact}'"
+msgstr ""
+
+msgid "Unable to find a discovery rule, no host provided (check permissions)"
+msgstr ""
+
+msgid "Unable to reboot %{name}: %{msg}"
+msgstr ""
 
 msgid "Update a rule"
 msgstr "Обновить правило"
@@ -382,20 +409,26 @@ msgstr "Значение"
 msgid "Warning"
 msgstr "Предупреждение"
 
-msgid ""
-"When creating hostname patterns, make sure the resulting host names are "
-"unique. Hostnames must not start with numbers. A good approach is to use "
-"unique information provided by facter (MAC address, BIOS or serial ID)."
+msgid "When creating hostname patterns, make sure the resulting host names are unique. Hostnames must not start with numbers. A good approach is to use unique information provided by facter (MAC address, BIOS or serial ID)."
 msgstr "Когда создается шаблон имени узла, убедитесь что в результате все имена уникальны. Имена узлов не должны начинаться с цифр. Хорошим тоном будет использование уникальной информации поставляемой производителем (MAC адрес или серийный номер)."
 
 msgid "can't contain white spaces."
 msgstr "не может содержать пробелы."
 
+msgid "defines a pattern to assign human-readable hostnames to the matching hosts"
+msgstr ""
+
+msgid "enables to limit maximum amount of provisioned hosts per rule"
+msgstr ""
+
 msgid "filter results"
 msgstr "отфильтровать результаты"
 
-msgid "hash containing facts for the host"
-msgstr "хэш содержит факты узла"
+msgid "flag is used for temporary shutdown of rules"
+msgstr ""
+
+msgid "hash containing facts for the host with minimum set of facts: discovery_bootif, macaddress_eth0, ipaddress, ipaddress_eth0, interfaces: eth0 (example in case primary interface is named eth0)"
+msgstr ""
 
 msgid "items selected. Uncheck to Clear"
 msgstr "выбрано. Чтобы очистить, снимите флажок"
@@ -415,10 +448,63 @@ msgstr "количество записей на запрос"
 msgid "paginate results"
 msgstr "разместить результат на нескольких страницах"
 
-msgid ""
-"required if value is not inherited from host group or default password in "
-"settings"
+msgid "puts the rules in order, low numbers go first. Must be greater then zero"
+msgstr ""
+
+msgid "query to match discovered hosts for the particular rule"
+msgstr ""
+
+msgid "represents rule name shown to the users"
+msgstr ""
+
+msgid "required if value is not inherited from host group or default password in settings"
 msgstr "требуется или значение не унаследовано из группы узлов или пароля по умолчанию из настроек"
 
 msgid "sort results"
 msgstr "отсортировать результаты"
+
+msgid "the hostgroup that is used to auto provision a host"
+msgstr ""
+
+#~ msgid "Create a discovered host"
+#~ msgstr "Создать обнаруженный узел"
+
+#~ msgid "Discovered Host Pool"
+#~ msgstr "Пул обнаруженных узлов"
+
+#~ msgid "Discovery rules"
+#~ msgstr "Правила обнаружения"
+
+#~ msgid "Discovery widget"
+#~ msgstr "Виджет обнаружения"
+
+#~ msgid "Failed to import facts for discovered host"
+#~ msgstr "Сбой импорта фактов для обнаруженного узла"
+
+#~ msgid "Failed to import facts for discovered host: %s"
+#~ msgstr "Сбой импорта фактов для обнаруженного узла:  %s"
+
+#~ msgid "Imported discovered host"
+#~ msgstr "Импортировать обнаруженный узел"
+
+#~ msgid "Invalid facts: hash does not contain IP address"
+#~ msgstr "Неверные факты: хэш не может содержать IP адрес"
+
+#~ msgid "Invalid facts: hash does not contain the required fact '%s'"
+#~ msgstr "Недопустимый формат статистики. Хэш-таблица должна содержать аргумент «%s»"
+
+#~ msgid "Show fact as an extra column in the discovered hosts list"
+#~ msgstr "Показать факты как дополнительный столбец в списке обнаруженных узлов"
+
+#~ msgid "The default fact name to use for the MAC of the system"
+#~ msgstr "Стандартный аргумент статистики для MAC"
+
+#~ msgid "Total pool size"
+#~ msgid_plural "Total pool size"
+#~ msgstr[0] "Итоговый размер пула"
+#~ msgstr[1] "Итоговый размер пула"
+#~ msgstr[2] "Итоговый размер пула"
+#~ msgstr[3] "Итоговый размер пула"
+
+#~ msgid "hash containing facts for the host"
+#~ msgstr "хэш содержит факты узла"

--- a/locale/sv_SE/foreman_discovery.po
+++ b/locale/sv_SE/foreman_discovery.po
@@ -1,22 +1,22 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the foreman package.
-# 
+#
 # Translators:
 # Dominic Cleal <dcleal@redhat.com>, 2014
 # johnny.westerlund <johnny.westerlund@gmail.com>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: foreman_discovery 3.0.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-01-28 17:53+0100\n"
+"Report-Msgid-Bugs-To: foreman-dev@googlegroups.com\n"
+"POT-Creation-Date: 2015-08-13 16:23+0200\n"
 "PO-Revision-Date: 2015-03-21 22:54+0000\n"
 "Last-Translator: Lukáš Zapletal\n"
 "Language-Team: Swedish (Sweden) (http://www.transifex.com/foreman/foreman/language/sv_SE/)\n"
+"Language: sv_SE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sv_SE\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "%s - The following hosts are about to be changed"
@@ -40,9 +40,10 @@ msgstr ""
 msgid "Auto Provision All"
 msgstr ""
 
-msgid ""
-"Automatically provision newly discovered hosts, according to the "
-"provisioning rules"
+msgid "Automatically provision newly discovered hosts, according to the provisioning rules"
+msgstr ""
+
+msgid "Automatically reboot discovered host during provisioning"
 msgstr ""
 
 msgid "CPUs"
@@ -54,7 +55,7 @@ msgstr "Avbryt"
 msgid "Could not get facts from proxy %{url}: %{error}"
 msgstr ""
 
-msgid "Create a discovered host"
+msgid "Create a discovered host for testing (use /facts to create new hosts)"
 msgstr ""
 
 msgid "Create a discovery rule"
@@ -84,9 +85,6 @@ msgstr ""
 msgid "Disable rule?"
 msgstr ""
 
-msgid "Discovered Host Pool"
-msgstr ""
-
 msgid "Discovered host: %s"
 msgstr "Hittade värdar: %s"
 
@@ -96,13 +94,10 @@ msgstr "Hittade värdar"
 msgid "Discovered hosts are provisioning now"
 msgstr ""
 
+msgid "Discovered hosts are rebooting now"
+msgstr ""
+
 msgid "Discovery Rules"
-msgstr ""
-
-msgid "Discovery rules"
-msgstr ""
-
-msgid "Discovery widget"
 msgstr ""
 
 msgid "DiscoveryRule|Enabled"
@@ -123,10 +118,7 @@ msgstr ""
 msgid "Disks size"
 msgstr ""
 
-msgid ""
-"Domain will be appended automatically. A hostname based on MAC address will "
-"be used when left blank. In addition to @host attribute function rand for "
-"random integers is available. Examples:"
+msgid "Domain will be appended automatically. A hostname based on MAC address will be used when left blank. In addition to @host attribute function rand for random integers is available. Examples:"
 msgstr ""
 
 msgid "Edit Discovery Rule"
@@ -141,14 +133,26 @@ msgstr ""
 msgid "Errors during auto provisioning: %s"
 msgstr ""
 
+msgid "Errors during reboot: %s"
+msgstr ""
+
 msgid "Execute rules against a discovered host"
 msgstr ""
 
 msgid "Execute rules against all currently discovered hosts"
 msgstr ""
 
+msgid "Expected discovery_fact '%s' is missing, unable to detect primary interface and set hostname"
+msgstr ""
+
+msgid "Extra facter columns to show in host lists (separate by comma)"
+msgstr ""
+
 msgid "Fact"
 msgstr "Fakta"
+
+msgid "Fact name to use for primary interface detection and hostname"
+msgstr ""
 
 msgid "Facts discovered on this host"
 msgstr "Fakta hittade för denna värd"
@@ -157,12 +161,6 @@ msgid "Facts refreshed for %s"
 msgstr "Fakta uppdaterade för %s"
 
 msgid "Failed to auto provision host %s: %s"
-msgstr ""
-
-msgid "Failed to import facts for discovered host"
-msgstr ""
-
-msgid "Failed to import facts for discovered host: %s"
 msgstr ""
 
 msgid "Failed to reboot host %s"
@@ -183,6 +181,16 @@ msgstr ""
 msgid "Host group"
 msgstr "Värdgrupp"
 
+msgid "Host group location %s must also be associated to the discovery rule"
+msgid_plural "Host group locations %s must also be associated to the discovery rule"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "Host group organization %s must also be associated to the discovery rule"
+msgid_plural "Host group organizations %s must also be associated to the discovery rule"
+msgstr[0] ""
+msgstr[1] ""
+
 msgid "Host of type %s can not be rebooted"
 msgstr ""
 
@@ -198,16 +206,10 @@ msgstr ""
 msgid "IP Address"
 msgstr "IPadress"
 
-msgid "Imported discovered host"
+msgid "Incompatible version of puppet fact parser"
 msgstr ""
 
 msgid "Invalid facts, must be a Hash"
-msgstr ""
-
-msgid "Invalid facts: hash does not contain IP address"
-msgstr ""
-
-msgid "Invalid facts: hash does not contain the required fact '%s'"
 msgstr ""
 
 msgid "Last facts upload"
@@ -221,6 +223,9 @@ msgstr ""
 
 msgid "Location"
 msgstr "Lokation"
+
+msgid "Locations"
+msgstr ""
 
 msgid "Maximum hosts provisioned with this rule (0 = unlimited)"
 msgstr ""
@@ -243,10 +248,16 @@ msgstr ""
 msgid "New Rule"
 msgstr ""
 
+msgid "New in the last 24 hours"
+msgstr ""
+
 msgid "No discovered hosts available"
 msgstr ""
 
 msgid "No discovered hosts to provision"
+msgstr ""
+
+msgid "No discovered hosts to reboot"
 msgstr ""
 
 msgid "No hosts selected"
@@ -258,11 +269,20 @@ msgstr "Inga värdar med det idt eller namnet hittades"
 msgid "No rule found for host %s"
 msgstr ""
 
+msgid "Not reported in more than 7 days"
+msgstr ""
+
 msgid "Organization"
 msgstr "Organisation"
 
+msgid "Organizations"
+msgstr ""
+
 msgid "Please Confirm"
 msgstr "Var god, bekräfta"
+
+msgid "Primary"
+msgstr ""
 
 msgid "Provision"
 msgstr "Provisionera"
@@ -273,10 +293,16 @@ msgstr ""
 msgid "Reboot"
 msgstr ""
 
+msgid "Reboot All"
+msgstr ""
+
 msgid "Rebooting %s"
 msgstr "Startar om %s"
 
 msgid "Rebooting a discovered host"
+msgstr ""
+
+msgid "Rebooting all discovered hosts"
 msgstr ""
 
 msgid "Rebooting host %s"
@@ -286,6 +312,9 @@ msgid "Refresh facts"
 msgstr "Uppdatera fakta"
 
 msgid "Refreshing the facts of a discovered host"
+msgstr ""
+
+msgid "Reported in the last 7 days"
 msgstr ""
 
 msgid "Rule disabled"
@@ -315,15 +344,10 @@ msgstr ""
 msgid "Show a discovery rule"
 msgstr ""
 
-msgid "Show fact as an extra column in the discovered hosts list"
-msgstr ""
-
 msgid "Something went wrong while selecting hosts - %s"
 msgstr "Något blev fel vid markering av värdar - %s"
 
-msgid ""
-"Specify target hostname template pattern in the same syntax as in "
-"Provisioning Templates (ERB)."
+msgid "Specify target hostname template pattern in the same syntax as in Provisioning Templates (ERB)."
 msgstr ""
 
 msgid "Submit"
@@ -338,9 +362,6 @@ msgstr ""
 msgid "Template"
 msgstr "Mall"
 
-msgid "The default fact name to use for the MAC of the system"
-msgstr "Fördefinierat faktanamn att använda för MAC för systemet"
-
 msgid "The default location to place discovered hosts in"
 msgstr "Standardplatsen att placera värdar i"
 
@@ -353,18 +374,22 @@ msgstr ""
 msgid "The following hosts were not deleted: %s"
 msgstr "Följande värdar raderades inte: %s"
 
-msgid ""
-"This might take a while, as all hosts, facts and reports will be destroyed "
-"as well"
+msgid "This might take a while, as all hosts, facts and reports will be destroyed as well"
 msgstr "Detta kan dröja då alla värdar, fakta och rapporter också kommer bli förstörda"
 
-msgid "Total pool size"
-msgid_plural "Total pool size"
-msgstr[0] ""
-msgstr[1] ""
+msgid "UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks"
+msgstr ""
 
-msgid ""
-"UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks"
+msgid "Unable to assign subnet, primary interface is missing IP address"
+msgstr ""
+
+msgid "Unable to detect primary interface using MAC '%{mac}' specified by discovery_fact '%{fact}'"
+msgstr ""
+
+msgid "Unable to find a discovery rule, no host provided (check permissions)"
+msgstr ""
+
+msgid "Unable to reboot %{name}: %{msg}"
 msgstr ""
 
 msgid "Update a rule"
@@ -379,19 +404,25 @@ msgstr "Värde"
 msgid "Warning"
 msgstr "Varning"
 
-msgid ""
-"When creating hostname patterns, make sure the resulting host names are "
-"unique. Hostnames must not start with numbers. A good approach is to use "
-"unique information provided by facter (MAC address, BIOS or serial ID)."
+msgid "When creating hostname patterns, make sure the resulting host names are unique. Hostnames must not start with numbers. A good approach is to use unique information provided by facter (MAC address, BIOS or serial ID)."
 msgstr ""
 
 msgid "can't contain white spaces."
 msgstr ""
 
+msgid "defines a pattern to assign human-readable hostnames to the matching hosts"
+msgstr ""
+
+msgid "enables to limit maximum amount of provisioned hosts per rule"
+msgstr ""
+
 msgid "filter results"
 msgstr ""
 
-msgid "hash containing facts for the host"
+msgid "flag is used for temporary shutdown of rules"
+msgstr ""
+
+msgid "hash containing facts for the host with minimum set of facts: discovery_bootif, macaddress_eth0, ipaddress, ipaddress_eth0, interfaces: eth0 (example in case primary interface is named eth0)"
 msgstr ""
 
 msgid "items selected. Uncheck to Clear"
@@ -412,10 +443,23 @@ msgstr ""
 msgid "paginate results"
 msgstr ""
 
-msgid ""
-"required if value is not inherited from host group or default password in "
-"settings"
+msgid "puts the rules in order, low numbers go first. Must be greater then zero"
+msgstr ""
+
+msgid "query to match discovered hosts for the particular rule"
+msgstr ""
+
+msgid "represents rule name shown to the users"
+msgstr ""
+
+msgid "required if value is not inherited from host group or default password in settings"
 msgstr ""
 
 msgid "sort results"
 msgstr ""
+
+msgid "the hostgroup that is used to auto provision a host"
+msgstr ""
+
+#~ msgid "The default fact name to use for the MAC of the system"
+#~ msgstr "Fördefinierat faktanamn att använda för MAC för systemet"

--- a/locale/zh_CN/foreman_discovery.po
+++ b/locale/zh_CN/foreman_discovery.po
@@ -1,20 +1,20 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the foreman package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: foreman_discovery 3.0.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-01-28 17:53+0100\n"
+"Report-Msgid-Bugs-To: foreman-dev@googlegroups.com\n"
+"POT-Creation-Date: 2015-08-13 16:23+0200\n"
 "PO-Revision-Date: 2015-03-21 22:54+0000\n"
 "Last-Translator: Lukáš Zapletal\n"
 "Language-Team: Chinese (China) (http://www.transifex.com/foreman/foreman/language/zh_CN/)\n"
+"Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: zh_CN\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 msgid "%s - The following hosts are about to be changed"
@@ -38,9 +38,10 @@ msgstr ""
 msgid "Auto Provision All"
 msgstr ""
 
-msgid ""
-"Automatically provision newly discovered hosts, according to the "
-"provisioning rules"
+msgid "Automatically provision newly discovered hosts, according to the provisioning rules"
+msgstr ""
+
+msgid "Automatically reboot discovered host during provisioning"
 msgstr ""
 
 msgid "CPUs"
@@ -52,7 +53,7 @@ msgstr "取消"
 msgid "Could not get facts from proxy %{url}: %{error}"
 msgstr ""
 
-msgid "Create a discovered host"
+msgid "Create a discovered host for testing (use /facts to create new hosts)"
 msgstr ""
 
 msgid "Create a discovery rule"
@@ -82,9 +83,6 @@ msgstr ""
 msgid "Disable rule?"
 msgstr ""
 
-msgid "Discovered Host Pool"
-msgstr ""
-
 msgid "Discovered host: %s"
 msgstr "找到的主机：%s"
 
@@ -94,13 +92,10 @@ msgstr "找到的主机"
 msgid "Discovered hosts are provisioning now"
 msgstr ""
 
+msgid "Discovered hosts are rebooting now"
+msgstr ""
+
 msgid "Discovery Rules"
-msgstr ""
-
-msgid "Discovery rules"
-msgstr ""
-
-msgid "Discovery widget"
 msgstr ""
 
 msgid "DiscoveryRule|Enabled"
@@ -121,10 +116,7 @@ msgstr ""
 msgid "Disks size"
 msgstr ""
 
-msgid ""
-"Domain will be appended automatically. A hostname based on MAC address will "
-"be used when left blank. In addition to @host attribute function rand for "
-"random integers is available. Examples:"
+msgid "Domain will be appended automatically. A hostname based on MAC address will be used when left blank. In addition to @host attribute function rand for random integers is available. Examples:"
 msgstr ""
 
 msgid "Edit Discovery Rule"
@@ -139,14 +131,26 @@ msgstr ""
 msgid "Errors during auto provisioning: %s"
 msgstr ""
 
+msgid "Errors during reboot: %s"
+msgstr ""
+
 msgid "Execute rules against a discovered host"
 msgstr ""
 
 msgid "Execute rules against all currently discovered hosts"
 msgstr ""
 
+msgid "Expected discovery_fact '%s' is missing, unable to detect primary interface and set hostname"
+msgstr ""
+
+msgid "Extra facter columns to show in host lists (separate by comma)"
+msgstr ""
+
 msgid "Fact"
 msgstr "详情"
+
+msgid "Fact name to use for primary interface detection and hostname"
+msgstr ""
 
 msgid "Facts discovered on this host"
 msgstr "在这台主机中找到的详情"
@@ -155,12 +159,6 @@ msgid "Facts refreshed for %s"
 msgstr "为 %s 刷新详情"
 
 msgid "Failed to auto provision host %s: %s"
-msgstr ""
-
-msgid "Failed to import facts for discovered host"
-msgstr ""
-
-msgid "Failed to import facts for discovered host: %s"
 msgstr ""
 
 msgid "Failed to reboot host %s"
@@ -181,6 +179,14 @@ msgstr ""
 msgid "Host group"
 msgstr "主机组"
 
+msgid "Host group location %s must also be associated to the discovery rule"
+msgid_plural "Host group locations %s must also be associated to the discovery rule"
+msgstr[0] ""
+
+msgid "Host group organization %s must also be associated to the discovery rule"
+msgid_plural "Host group organizations %s must also be associated to the discovery rule"
+msgstr[0] ""
+
 msgid "Host of type %s can not be rebooted"
 msgstr ""
 
@@ -196,17 +202,11 @@ msgstr ""
 msgid "IP Address"
 msgstr "IP地址"
 
-msgid "Imported discovered host"
+msgid "Incompatible version of puppet fact parser"
 msgstr ""
 
 msgid "Invalid facts, must be a Hash"
 msgstr "无效详情，必须是 hash"
-
-msgid "Invalid facts: hash does not contain IP address"
-msgstr ""
-
-msgid "Invalid facts: hash does not contain the required fact '%s'"
-msgstr "无效详情：未含有所需详情 '%s'"
 
 msgid "Last facts upload"
 msgstr "最后一个上传的详情"
@@ -219,6 +219,9 @@ msgstr ""
 
 msgid "Location"
 msgstr "位置"
+
+msgid "Locations"
+msgstr ""
 
 msgid "Maximum hosts provisioned with this rule (0 = unlimited)"
 msgstr ""
@@ -241,10 +244,16 @@ msgstr ""
 msgid "New Rule"
 msgstr ""
 
+msgid "New in the last 24 hours"
+msgstr ""
+
 msgid "No discovered hosts available"
 msgstr ""
 
 msgid "No discovered hosts to provision"
+msgstr ""
+
+msgid "No discovered hosts to reboot"
 msgstr ""
 
 msgid "No hosts selected"
@@ -256,11 +265,20 @@ msgstr "未找到符合此 id 或者名称的主机"
 msgid "No rule found for host %s"
 msgstr ""
 
+msgid "Not reported in more than 7 days"
+msgstr ""
+
 msgid "Organization"
 msgstr "机构"
 
+msgid "Organizations"
+msgstr ""
+
 msgid "Please Confirm"
 msgstr "请确认"
+
+msgid "Primary"
+msgstr ""
 
 msgid "Provision"
 msgstr "供应"
@@ -271,10 +289,16 @@ msgstr ""
 msgid "Reboot"
 msgstr ""
 
+msgid "Reboot All"
+msgstr ""
+
 msgid "Rebooting %s"
 msgstr "正在重启 %s"
 
 msgid "Rebooting a discovered host"
+msgstr ""
+
+msgid "Rebooting all discovered hosts"
 msgstr ""
 
 msgid "Rebooting host %s"
@@ -284,6 +308,9 @@ msgid "Refresh facts"
 msgstr "刷新详情"
 
 msgid "Refreshing the facts of a discovered host"
+msgstr ""
+
+msgid "Reported in the last 7 days"
 msgstr ""
 
 msgid "Rule disabled"
@@ -313,15 +340,10 @@ msgstr ""
 msgid "Show a discovery rule"
 msgstr ""
 
-msgid "Show fact as an extra column in the discovered hosts list"
-msgstr ""
-
 msgid "Something went wrong while selecting hosts - %s"
 msgstr "选择主机时出错 - %s"
 
-msgid ""
-"Specify target hostname template pattern in the same syntax as in "
-"Provisioning Templates (ERB)."
+msgid "Specify target hostname template pattern in the same syntax as in Provisioning Templates (ERB)."
 msgstr ""
 
 msgid "Submit"
@@ -336,9 +358,6 @@ msgstr ""
 msgid "Template"
 msgstr "模板"
 
-msgid "The default fact name to use for the MAC of the system"
-msgstr "该系统 MAC 的默认详情名称"
-
 msgid "The default location to place discovered hosts in"
 msgstr "找到主机的默认位置"
 
@@ -351,17 +370,22 @@ msgstr ""
 msgid "The following hosts were not deleted: %s"
 msgstr "未删除以下主机：%s"
 
-msgid ""
-"This might take a while, as all hosts, facts and reports will be destroyed "
-"as well"
+msgid "This might take a while, as all hosts, facts and reports will be destroyed as well"
 msgstr "这需要一些时间，因为同时还要删除所有主机、详情及报告。"
 
-msgid "Total pool size"
-msgid_plural "Total pool size"
-msgstr[0] ""
+msgid "UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks"
+msgstr ""
 
-msgid ""
-"UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks"
+msgid "Unable to assign subnet, primary interface is missing IP address"
+msgstr ""
+
+msgid "Unable to detect primary interface using MAC '%{mac}' specified by discovery_fact '%{fact}'"
+msgstr ""
+
+msgid "Unable to find a discovery rule, no host provided (check permissions)"
+msgstr ""
+
+msgid "Unable to reboot %{name}: %{msg}"
 msgstr ""
 
 msgid "Update a rule"
@@ -376,19 +400,25 @@ msgstr "值"
 msgid "Warning"
 msgstr "警告"
 
-msgid ""
-"When creating hostname patterns, make sure the resulting host names are "
-"unique. Hostnames must not start with numbers. A good approach is to use "
-"unique information provided by facter (MAC address, BIOS or serial ID)."
+msgid "When creating hostname patterns, make sure the resulting host names are unique. Hostnames must not start with numbers. A good approach is to use unique information provided by facter (MAC address, BIOS or serial ID)."
 msgstr ""
 
 msgid "can't contain white spaces."
 msgstr ""
 
+msgid "defines a pattern to assign human-readable hostnames to the matching hosts"
+msgstr ""
+
+msgid "enables to limit maximum amount of provisioned hosts per rule"
+msgstr ""
+
 msgid "filter results"
 msgstr ""
 
-msgid "hash containing facts for the host"
+msgid "flag is used for temporary shutdown of rules"
+msgstr ""
+
+msgid "hash containing facts for the host with minimum set of facts: discovery_bootif, macaddress_eth0, ipaddress, ipaddress_eth0, interfaces: eth0 (example in case primary interface is named eth0)"
 msgstr ""
 
 msgid "items selected. Uncheck to Clear"
@@ -409,10 +439,26 @@ msgstr ""
 msgid "paginate results"
 msgstr ""
 
-msgid ""
-"required if value is not inherited from host group or default password in "
-"settings"
+msgid "puts the rules in order, low numbers go first. Must be greater then zero"
+msgstr ""
+
+msgid "query to match discovered hosts for the particular rule"
+msgstr ""
+
+msgid "represents rule name shown to the users"
+msgstr ""
+
+msgid "required if value is not inherited from host group or default password in settings"
 msgstr ""
 
 msgid "sort results"
 msgstr ""
+
+msgid "the hostgroup that is used to auto provision a host"
+msgstr ""
+
+#~ msgid "Invalid facts: hash does not contain the required fact '%s'"
+#~ msgstr "无效详情：未含有所需详情 '%s'"
+
+#~ msgid "The default fact name to use for the MAC of the system"
+#~ msgstr "该系统 MAC 的默认详情名称"

--- a/locale/zh_TW/foreman_discovery.po
+++ b/locale/zh_TW/foreman_discovery.po
@@ -1,20 +1,20 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the foreman package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: foreman_discovery 3.0.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-01-28 17:53+0100\n"
+"Report-Msgid-Bugs-To: foreman-dev@googlegroups.com\n"
+"POT-Creation-Date: 2015-08-13 16:23+0200\n"
 "PO-Revision-Date: 2015-03-21 22:54+0000\n"
 "Last-Translator: Lukáš Zapletal\n"
 "Language-Team: Chinese (Taiwan) (http://www.transifex.com/foreman/foreman/language/zh_TW/)\n"
+"Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: zh_TW\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 msgid "%s - The following hosts are about to be changed"
@@ -38,9 +38,10 @@ msgstr ""
 msgid "Auto Provision All"
 msgstr ""
 
-msgid ""
-"Automatically provision newly discovered hosts, according to the "
-"provisioning rules"
+msgid "Automatically provision newly discovered hosts, according to the provisioning rules"
+msgstr ""
+
+msgid "Automatically reboot discovered host during provisioning"
 msgstr ""
 
 msgid "CPUs"
@@ -52,7 +53,7 @@ msgstr "取消"
 msgid "Could not get facts from proxy %{url}: %{error}"
 msgstr ""
 
-msgid "Create a discovered host"
+msgid "Create a discovered host for testing (use /facts to create new hosts)"
 msgstr ""
 
 msgid "Create a discovery rule"
@@ -82,9 +83,6 @@ msgstr ""
 msgid "Disable rule?"
 msgstr ""
 
-msgid "Discovered Host Pool"
-msgstr ""
-
 msgid "Discovered host: %s"
 msgstr "發現的主機：%s"
 
@@ -94,13 +92,10 @@ msgstr "發現的主機"
 msgid "Discovered hosts are provisioning now"
 msgstr ""
 
+msgid "Discovered hosts are rebooting now"
+msgstr ""
+
 msgid "Discovery Rules"
-msgstr ""
-
-msgid "Discovery rules"
-msgstr ""
-
-msgid "Discovery widget"
 msgstr ""
 
 msgid "DiscoveryRule|Enabled"
@@ -121,10 +116,7 @@ msgstr ""
 msgid "Disks size"
 msgstr ""
 
-msgid ""
-"Domain will be appended automatically. A hostname based on MAC address will "
-"be used when left blank. In addition to @host attribute function rand for "
-"random integers is available. Examples:"
+msgid "Domain will be appended automatically. A hostname based on MAC address will be used when left blank. In addition to @host attribute function rand for random integers is available. Examples:"
 msgstr ""
 
 msgid "Edit Discovery Rule"
@@ -139,14 +131,26 @@ msgstr ""
 msgid "Errors during auto provisioning: %s"
 msgstr ""
 
+msgid "Errors during reboot: %s"
+msgstr ""
+
 msgid "Execute rules against a discovered host"
 msgstr ""
 
 msgid "Execute rules against all currently discovered hosts"
 msgstr ""
 
+msgid "Expected discovery_fact '%s' is missing, unable to detect primary interface and set hostname"
+msgstr ""
+
+msgid "Extra facter columns to show in host lists (separate by comma)"
+msgstr ""
+
 msgid "Fact"
 msgstr "詳情"
+
+msgid "Fact name to use for primary interface detection and hostname"
+msgstr ""
 
 msgid "Facts discovered on this host"
 msgstr "在這部主機上發現的詳情"
@@ -155,12 +159,6 @@ msgid "Facts refreshed for %s"
 msgstr "%s 的詳情已刷新"
 
 msgid "Failed to auto provision host %s: %s"
-msgstr ""
-
-msgid "Failed to import facts for discovered host"
-msgstr ""
-
-msgid "Failed to import facts for discovered host: %s"
 msgstr ""
 
 msgid "Failed to reboot host %s"
@@ -181,6 +179,14 @@ msgstr ""
 msgid "Host group"
 msgstr "主機群組"
 
+msgid "Host group location %s must also be associated to the discovery rule"
+msgid_plural "Host group locations %s must also be associated to the discovery rule"
+msgstr[0] ""
+
+msgid "Host group organization %s must also be associated to the discovery rule"
+msgid_plural "Host group organizations %s must also be associated to the discovery rule"
+msgstr[0] ""
+
 msgid "Host of type %s can not be rebooted"
 msgstr ""
 
@@ -196,17 +202,11 @@ msgstr ""
 msgid "IP Address"
 msgstr "IP 位址"
 
-msgid "Imported discovered host"
+msgid "Incompatible version of puppet fact parser"
 msgstr ""
 
 msgid "Invalid facts, must be a Hash"
 msgstr "詳情無效，必須是雜湊"
-
-msgid "Invalid facts: hash does not contain IP address"
-msgstr ""
-
-msgid "Invalid facts: hash does not contain the required fact '%s'"
-msgstr "詳情無效：雜湊未包含必要的詳情「%s」"
 
 msgid "Last facts upload"
 msgstr "最後上傳的詳情"
@@ -219,6 +219,9 @@ msgstr ""
 
 msgid "Location"
 msgstr "位置"
+
+msgid "Locations"
+msgstr ""
 
 msgid "Maximum hosts provisioned with this rule (0 = unlimited)"
 msgstr ""
@@ -241,10 +244,16 @@ msgstr ""
 msgid "New Rule"
 msgstr ""
 
+msgid "New in the last 24 hours"
+msgstr ""
+
 msgid "No discovered hosts available"
 msgstr ""
 
 msgid "No discovered hosts to provision"
+msgstr ""
+
+msgid "No discovered hosts to reboot"
 msgstr ""
 
 msgid "No hosts selected"
@@ -256,11 +265,20 @@ msgstr "沒有找到擁有此 ID 或名稱的主機"
 msgid "No rule found for host %s"
 msgstr ""
 
+msgid "Not reported in more than 7 days"
+msgstr ""
+
 msgid "Organization"
 msgstr "組織"
 
+msgid "Organizations"
+msgstr ""
+
 msgid "Please Confirm"
 msgstr "請確認"
+
+msgid "Primary"
+msgstr ""
 
 msgid "Provision"
 msgstr "佈建"
@@ -271,10 +289,16 @@ msgstr ""
 msgid "Reboot"
 msgstr ""
 
+msgid "Reboot All"
+msgstr ""
+
 msgid "Rebooting %s"
 msgstr "重新啟動 %s"
 
 msgid "Rebooting a discovered host"
+msgstr ""
+
+msgid "Rebooting all discovered hosts"
 msgstr ""
 
 msgid "Rebooting host %s"
@@ -284,6 +308,9 @@ msgid "Refresh facts"
 msgstr "刷新詳情"
 
 msgid "Refreshing the facts of a discovered host"
+msgstr ""
+
+msgid "Reported in the last 7 days"
 msgstr ""
 
 msgid "Rule disabled"
@@ -313,15 +340,10 @@ msgstr ""
 msgid "Show a discovery rule"
 msgstr ""
 
-msgid "Show fact as an extra column in the discovered hosts list"
-msgstr ""
-
 msgid "Something went wrong while selecting hosts - %s"
 msgstr "選擇主機時發生了錯誤 - %s"
 
-msgid ""
-"Specify target hostname template pattern in the same syntax as in "
-"Provisioning Templates (ERB)."
+msgid "Specify target hostname template pattern in the same syntax as in Provisioning Templates (ERB)."
 msgstr ""
 
 msgid "Submit"
@@ -336,9 +358,6 @@ msgstr ""
 msgid "Template"
 msgstr "範本"
 
-msgid "The default fact name to use for the MAC of the system"
-msgstr "系統之 MAC 所使用的預設詳情名稱"
-
 msgid "The default location to place discovered hosts in"
 msgstr "放置已發現之主機的預設位置"
 
@@ -351,17 +370,22 @@ msgstr ""
 msgid "The following hosts were not deleted: %s"
 msgstr "下列主機尚未刪除：%s"
 
-msgid ""
-"This might take a while, as all hosts, facts and reports will be destroyed "
-"as well"
+msgid "This might take a while, as all hosts, facts and reports will be destroyed as well"
 msgstr "這可能會花上一段時間，因為所有主機、詳情與報告皆會被刪除"
 
-msgid "Total pool size"
-msgid_plural "Total pool size"
-msgstr[0] ""
+msgid "UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks"
+msgstr ""
 
-msgid ""
-"UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks"
+msgid "Unable to assign subnet, primary interface is missing IP address"
+msgstr ""
+
+msgid "Unable to detect primary interface using MAC '%{mac}' specified by discovery_fact '%{fact}'"
+msgstr ""
+
+msgid "Unable to find a discovery rule, no host provided (check permissions)"
+msgstr ""
+
+msgid "Unable to reboot %{name}: %{msg}"
 msgstr ""
 
 msgid "Update a rule"
@@ -376,19 +400,25 @@ msgstr "值"
 msgid "Warning"
 msgstr "警告"
 
-msgid ""
-"When creating hostname patterns, make sure the resulting host names are "
-"unique. Hostnames must not start with numbers. A good approach is to use "
-"unique information provided by facter (MAC address, BIOS or serial ID)."
+msgid "When creating hostname patterns, make sure the resulting host names are unique. Hostnames must not start with numbers. A good approach is to use unique information provided by facter (MAC address, BIOS or serial ID)."
 msgstr ""
 
 msgid "can't contain white spaces."
 msgstr ""
 
+msgid "defines a pattern to assign human-readable hostnames to the matching hosts"
+msgstr ""
+
+msgid "enables to limit maximum amount of provisioned hosts per rule"
+msgstr ""
+
 msgid "filter results"
 msgstr ""
 
-msgid "hash containing facts for the host"
+msgid "flag is used for temporary shutdown of rules"
+msgstr ""
+
+msgid "hash containing facts for the host with minimum set of facts: discovery_bootif, macaddress_eth0, ipaddress, ipaddress_eth0, interfaces: eth0 (example in case primary interface is named eth0)"
 msgstr ""
 
 msgid "items selected. Uncheck to Clear"
@@ -409,10 +439,26 @@ msgstr ""
 msgid "paginate results"
 msgstr ""
 
-msgid ""
-"required if value is not inherited from host group or default password in "
-"settings"
+msgid "puts the rules in order, low numbers go first. Must be greater then zero"
+msgstr ""
+
+msgid "query to match discovered hosts for the particular rule"
+msgstr ""
+
+msgid "represents rule name shown to the users"
+msgstr ""
+
+msgid "required if value is not inherited from host group or default password in settings"
 msgstr ""
 
 msgid "sort results"
 msgstr ""
+
+msgid "the hostgroup that is used to auto provision a host"
+msgstr ""
+
+#~ msgid "Invalid facts: hash does not contain the required fact '%s'"
+#~ msgstr "詳情無效：雜湊未包含必要的詳情「%s」"
+
+#~ msgid "The default fact name to use for the MAC of the system"
+#~ msgstr "系統之 MAC 所使用的預設詳情名稱"


### PR DESCRIPTION
Forgot to do this for 4.0 release but we can rollout 4.0.1 gem only, it only
affects gem installations.
