### PR TITLE
Fixes #4426 - org/loc enabled for discovered hosts

### DIFF
--- a/app/controllers/discovered_hosts_controller.rb
+++ b/app/controllers/discovered_hosts_controller.rb
@@ -46,7 +46,10 @@ class DiscoveredHostsController < ::ApplicationController
 
   def edit
     Host.transaction do
-      @host = ::ForemanDiscovery::HostConverter.to_managed(@host, true, false) unless @host.nil?
+      unless @host.nil?
+        @host = ::ForemanDiscovery::HostConverter.to_managed(@host, true, false)
+        @host.taxonomy_edit_enabled = true
+      end
       render :template => 'hosts/edit'
     end
   end

--- a/app/models/host/discovered.rb
+++ b/app/models/host/discovered.rb
@@ -90,14 +90,18 @@ class Host::Discovered < ::Host::Base
       # set location and organization
       if SETTINGS[:locations_enabled]
         self.location = Location.find_by_name(Setting[:discovery_location]) ||
+          Location.find_by_name(facts[Setting[:location_fact]]) ||
           subnet.try(:locations).try(:first) ||
-          Location.first
+          Location.find_by_name(Setting[:default_location]) ||
+          Location.first rescue Location.first
         Rails.logger.info "Assigned location: #{self.location}"
       end
       if SETTINGS[:organizations_enabled]
         self.organization = Organization.find_by_name(Setting[:discovery_organization]) ||
+          Organization.find_by_name(facts[Setting[:organization_fact]]) ||
           subnet.try(:organizations).try(:first) ||
-          Organization.first
+          Organization.find_by_name(Setting[:default_organization]) ||
+          Organization.first rescue Organization.first
         Rails.logger.info "Assigned organization: #{self.organization}"
       end
     else


### PR DESCRIPTION
Enables taxonomy fields on DiscoveredHost#edit form. Also modifies how
taxonomy is set for discovered hosts.

Do not merge. This is my first attempt to get taxonomy working on the form. It
does not currently work. I am able to re-enable taxonomy and also disable
triggering of form reload (form reload totally ruins everything discovery is
trying to do - network setup and also form target URL). With this patch, you
can modify taxonomy. But the moment you select a hostgroup taxonomy is disabled
again (?) and after you submit, changed value has not effect.

Any ideas @orabin ?
