### PR TITLE
Fixes #11708 - removed auto_provisioning RABL, improved unit tests

### DIFF
--- a/app/views/api/v2/discovered_hosts/auto_provision.json.rabl
+++ b/app/views/api/v2/discovered_hosts/auto_provision.json.rabl
@@ -1,3 +1,0 @@
-object @discovered_host
-
-extends "api/v2/hosts/main"

--- a/app/views/api/v2/discovered_hosts/auto_provision_all.json.rabl
+++ b/app/views/api/v2/discovered_hosts/auto_provision_all.json.rabl
@@ -1,3 +1,0 @@
-object @discovered_host
-
-extends "api/v2/hosts/main"

--- a/test/functional/api/v2/discovered_hosts_controller_test.rb
+++ b/test/functional/api/v2/discovered_hosts_controller_test.rb
@@ -77,11 +77,11 @@ class Api::V2::DiscoveredHostsControllerTest < ActionController::TestCase
     disable_orchestration
     facts = @facts.merge({"somefact" => "abc"})
     host = Host::Discovered.import_host_and_facts(facts).first
-    FactoryGirl.create(:discovery_rule, :priority => 1, :search => "facts.somefact = abc",
+    rule = FactoryGirl.create(:discovery_rule, :priority => 1, :search => "facts.somefact = abc",
                        :hostgroup => FactoryGirl.create(:hostgroup, :with_os, :with_rootpass),
                        :organizations => [host.organization], :locations => [host.location])
     post :auto_provision, { :id => host.id }
-    assert_match host.name, @response.body
+    assert_match /Host #{host.name} was provisioned with rule #{rule.name}/, @response.body
     assert_response :success
   end
 
@@ -144,7 +144,7 @@ class Api::V2::DiscoveredHostsControllerTest < ActionController::TestCase
                        :hostgroup => FactoryGirl.create(:hostgroup, :with_os, :with_rootpass), :organizations => [host.organization],
                        :locations => [host.location])
     post :auto_provision_all, {}
-    assert_equal '{}', @response.body
+    assert_match /1 discovered hosts were provisioned/, @response.body
     assert_response :success
   end
 
@@ -153,7 +153,7 @@ class Api::V2::DiscoveredHostsControllerTest < ActionController::TestCase
     facts = @facts.merge({"somefact" => "abc"})
     Host::Discovered.import_host_and_facts(facts).first
     post :auto_provision_all, {}
-    assert_equal '{}', @response.body
+    assert_match /0 discovered hosts were provisioned/, @response.body
     assert_response :success
   end
 

--- a/test/unit/discovered_extensions_test.rb
+++ b/test/unit/discovered_extensions_test.rb
@@ -135,7 +135,7 @@ class FindDiscoveryRulesTest < ActiveSupport::TestCase
                               :hostname => '<%= "" %>',
                               :organizations => [host.organization],
                               :locations => [host.location])
-      perform_auto_provision host, r1
+      refute perform_auto_provision host, r1
       assert_equal "macaabbccddeeff", host.name
     end
 
@@ -146,7 +146,7 @@ class FindDiscoveryRulesTest < ActiveSupport::TestCase
                               :hostname => 'x<%= 1+1 %>',
                               :organizations => [host.organization],
                               :locations => [host.location])
-      perform_auto_provision host, r1
+      refute perform_auto_provision host, r1
       assert_equal "x2", host.name
     end
 
@@ -157,7 +157,7 @@ class FindDiscoveryRulesTest < ActiveSupport::TestCase
                               :hostname => 'x<%= rand(4) %>',
                               :organizations => [host.organization],
                               :locations => [host.location])
-      perform_auto_provision host, r1
+      refute perform_auto_provision host, r1
       assert_match(/x[0123]/, host.name)
     end
 
@@ -168,7 +168,7 @@ class FindDiscoveryRulesTest < ActiveSupport::TestCase
                               :hostname => 'x<%= @host.name %>',
                               :organizations => [host.organization],
                               :locations => [host.location])
-      perform_auto_provision host, r1
+      refute perform_auto_provision host, r1
       assert_equal "xmacaabbccddeeff", host.name
     end
 
@@ -179,19 +179,19 @@ class FindDiscoveryRulesTest < ActiveSupport::TestCase
                               :hostname => 'x<%= @host.ip.gsub(".","-") %>',
                               :organizations => [host.organization],
                               :locations => [host.location])
-      perform_auto_provision host, r1
+      refute perform_auto_provision host, r1
       assert_equal "x192-168-100-42", host.name
     end
 
     test "hostname attribute facts_hash is renderer properly using #{renderer_name}" do
-      skip "until http://projects.theforeman.org/issues/2948 is fixed"
-      host = Host::Discovered.import_host_and_facts(@facts).first
+      facts = @facts.merge({"somefact" => "abc"})
+      host = Host::Discovered.import_host_and_facts(facts).first
       r1 = FactoryGirl.create(:discovery_rule,
                               :search => "facts.somefact = abc",
                               :hostname => 'x<%= @host.facts["somefact"] %>',
                               :organizations => [host.organization],
                               :locations => [host.location])
-      perform_auto_provision host, r1
+      refute perform_auto_provision host, r1
       assert_equal "xabc", host.name
     end
 


### PR DESCRIPTION
It looks like the RABL files are useless for auto_provison actions as we only
check HTTP code in the CLI and there is no need to render any info. More info
in the issue.

I also improved our unit tests, removed skipped test and added `refute` keyword
to tests where we expect failures actually (we test ERB in these).

@orabin ?
