### PR TITLE
Fixes #11978 - fixed kexec auto provisioning

### DIFF
--- a/app/models/host/managed_extensions.rb
+++ b/app/models/host/managed_extensions.rb
@@ -40,6 +40,7 @@ module Host::ManagedExtensions
 
   def setKexec
     template = provisioning_template(:kind => 'kexec')
+    @host = self
     @kernel = boot_url(:kernel)
     @initrd = boot_url(:initrd)
     json = unattended_render(template)


### PR DESCRIPTION
Variable `@host` was not available in all contexts.
