### PR TITLE
Refs #12237 - migration for Red Hat Kexec template change

### DIFF
--- a/db/migrate/20151023144501_regenerate_red_hat_kexec.rb
+++ b/db/migrate/20151023144501_regenerate_red_hat_kexec.rb
@@ -1,0 +1,10 @@
+class RegenerateRedHatKexec < ActiveRecord::Migration
+  def up
+    t = ProvisioningTemplate.find_by_name("Discovery Red Hat kexec")
+    t.update_attributes(:template => t.template.sub(/rescue ''$/, 'if mac')) if t
+  end
+
+  def down
+    # rollback is not supported
+  end
+end


### PR DESCRIPTION
One more thing, since the 4.1.1 plugin was released for testing, it's better to
have a migration for those who already started using Discovery 4.1.

Complements https://github.com/theforeman/foreman_discovery/pull/224

Thanks @stbenjam!
