### PR TITLE
Fixes #12414 - fixed katello medium and better errors

### DIFF
--- a/app/models/host/managed_extensions.rb
+++ b/app/models/host/managed_extensions.rb
@@ -35,11 +35,16 @@ module Host::ManagedExtensions
   end
 
   def boot_url pxe_file
-    operatingsystem.medium_vars_to_uri("#{medium.path}/#{operatingsystem.url_for_boot(pxe_file)}", architecture.name, operatingsystem).to_s
+    raise ::Foreman::Exception.new(N_("Operating system not set for host/hostgroup")) unless operatingsystem
+    base = operatingsystem.medium_uri(self)
+    raise ::Foreman::Exception.new(N_("Medium not set for host/hostgroup")) unless base
+    path = operatingsystem.url_for_boot(pxe_file)
+    operatingsystem.medium_vars_to_uri("#{base}/#{path}", architecture.name, operatingsystem).to_s
   end
 
   def setKexec
     template = provisioning_template(:kind => 'kexec')
+    raise ::Foreman::Exception.new(N_("Kexec template not associated with operating system")) unless template
     @host = self
     @kernel = boot_url(:kernel)
     @initrd = boot_url(:initrd)


### PR DESCRIPTION
This is a fatal bug downstream @stbenjam :-(

I was testing this without katello plugin and it looks like medium is not used
at all for hosts. Medium is bound to ContentView/Source via Hostgroup,
therefore the only way of determining the root path for kexec is via HG. Added
a fallback when medium is not set, so this works both with and without Katello
plugin.

Also improved error reporting when some elements are not present.
