### PR TITLE
Fixes #12548 - Allow discovery_rule to be mass assigned

### DIFF
--- a/app/models/concerns/discovery_subnet.rb
+++ b/app/models/concerns/discovery_subnet.rb
@@ -2,6 +2,8 @@ module DiscoverySubnet
   extend ActiveSupport::Concern
   included do
     belongs_to :discovery, :class_name => "SmartProxy"
+
+    attr_accessible :discovery_id
   end
 end
 

--- a/app/models/discovery_rule.rb
+++ b/app/models/discovery_rule.rb
@@ -5,6 +5,8 @@ class DiscoveryRule < ActiveRecord::Base
   include Parameterizable::ByIdName
   include Taxonomix
 
+  attr_accessible :name, :priority, :search, :enabled, :hostgroup, :hostgroup_id, :max_count, :hostname
+
   validates :name, :presence => true, :uniqueness => true,
     :format => { :with => /\A(\S+)\Z/, :message => N_("can't contain white spaces.") }
   validates :search, :presence => true

--- a/app/models/host/managed_extensions.rb
+++ b/app/models/host/managed_extensions.rb
@@ -10,6 +10,7 @@ module Host::ManagedExtensions
 
     # extra flag for post_queue callbacks which has no access to facts
     attr_accessor :legacy_api
+    attr_accessible :discovery_rule_id
   end
 
   def queue_reboot

--- a/app/models/hostgroup_extensions.rb
+++ b/app/models/hostgroup_extensions.rb
@@ -3,5 +3,6 @@ module HostgroupExtensions
 
   included do
     has_many :discovery_rules
+    attr_accessible :discovery_rules, :discovery_rule_ids, :discovery_rule_names, :type
   end
 end


### PR DESCRIPTION
As part of projects.theforeman.org/projects/foreman/issues/7568 , the
Host and Hostgroup models will become mass-assignment protected.
In that case, we have to whitelist the attributes that come from
discovery that are mass assigned. A few tests use it and will fail
otherwise.
