### PR TITLE
Fixes #12951 - rails 4 changes

### DIFF
--- a/app/views/dashboard/_discovery_widget.html.erb
+++ b/app/views/dashboard/_discovery_widget.html.erb
@@ -1,4 +1,4 @@
-<% all_hosts = Host::Discovered.includes(:model).includes(:discovery_attribute_set).scoped %>
+<% all_hosts = Host::Discovered.includes(:model).includes(:discovery_attribute_set).all %>
 <% hosts = all_hosts.limit(6) %>
 
 <h4 class="header">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,9 +2,9 @@
 Rails.application.routes.draw do
 
   # Needed to make the hosts/edit form render
-  match 'architecture_selected_discovered_hosts' => 'hosts#architecture_selected'
-  match 'os_selected_discovered_hosts'           => 'hosts#os_selected'
-  match 'medium_selected_discovered_hosts'       => 'hosts#medium_selected'
+  get 'architecture_selected_discovered_hosts' => 'hosts#architecture_selected'
+  get 'os_selected_discovered_hosts'           => 'hosts#os_selected'
+  get 'medium_selected_discovered_hosts'       => 'hosts#medium_selected'
 
   constraints(:id => /[^\/]+/) do
     resources :discovered_hosts, :except => [:new, :create] do

--- a/db/migrate/20141223142759_fill_discovery_attribute_sets_for_existing_hosts.rb
+++ b/db/migrate/20141223142759_fill_discovery_attribute_sets_for_existing_hosts.rb
@@ -1,6 +1,6 @@
 class FillDiscoveryAttributeSetsForExistingHosts < ActiveRecord::Migration
   def up
-    Host::Discovered.scoped.each { |host| host.populate_fields_from_facts}
+    Host::Discovered.all.each { |host| host.populate_fields_from_facts}
   end
 
   def down

--- a/db/seeds.d/50_discovery_templates.rb
+++ b/db/seeds.d/50_discovery_templates.rb
@@ -1,9 +1,8 @@
-kind = TemplateKind.find_or_create_by_name('kexec')
+kind = TemplateKind.where(:name => 'kexec').first_or_create
 
 ProvisioningTemplate.without_auditing do
   content = File.read(File.join(ForemanDiscovery::Engine.root, 'app', 'views', 'foreman_discovery', 'redhat_kexec.erb'))
-  tmpl = ProvisioningTemplate.find_or_create_by_name(
-    :name => 'Discovery Red Hat kexec',
+  tmpl = ProvisioningTemplate.where(:name => 'Discovery Red Hat kexec').first_or_create(
     :template_kind_id => kind.id,
     :snippet => false,
     :template => content

--- a/db/seeds.d/60_discovery_proxy_feature.rb
+++ b/db/seeds.d/60_discovery_proxy_feature.rb
@@ -1,2 +1,2 @@
-f = Feature.find_or_create_by_name('Discovery')
+f = Feature.where(:name => 'Discovery').first_or_create
 raise "Unable to create proxy feature: #{format_errors f}" if f.nil? || f.errors.any?

--- a/lib/foreman_discovery/engine.rb
+++ b/lib/foreman_discovery/engine.rb
@@ -39,12 +39,14 @@ module ForemanDiscovery
 
     # Add any db migrations
     initializer "foreman_discovery.load_app_instance_data" do |app|
-      app.config.paths['db/migrate'] += ForemanDiscovery::Engine.paths['db/migrate'].existent
+      ForemanDiscovery::Engine.paths['db/migrate'].existent.each do |path|
+        app.config.paths['db/migrate'] << path
+      end
     end
 
     initializer 'foreman_discovery.register_plugin', :after=> :finisher_hook do |app|
       Foreman::Plugin.register :foreman_discovery do
-        requires_foreman '>= 1.9.0'
+        requires_foreman '>= 1.11.0'
 
         # discovered hosts permissions
         security_block :discovery do
@@ -145,10 +147,6 @@ module ForemanDiscovery
         # Only available in 1.8, otherwise it has to be in the initializer below
         apipie_documented_controllers ["#{ForemanDiscovery::Engine.root}/app/controllers/api/v2/*.rb"]
       end
-    end
-
-    initializer "foreman_discovery.load_app_instance_data" do |app|
-      app.config.paths['db/migrate'] += ForemanDiscovery::Engine.paths['db/migrate'].existent
     end
 
     initializer "foreman_discovery.apipie" do


### PR DESCRIPTION
This replaces: https://github.com/theforeman/foreman_discovery/pull/228
The changed I added:
- removed `organization_ids` from `app/models/discovery_rule.rb`
- changed `app/views/dashboard/_discovery_widget.html.erb` to use `all` instead of `scoped`
- fixed both seeds files that used `find_or_create_by_name` to use `find_or_create_by(:name => )`
- bumped foreman version to  1.11
