### PR TITLE
Refs #12951 - Allowing mass assignment of discovery_rule_id

### DIFF
--- a/app/models/host/discovered.rb
+++ b/app/models/host/discovered.rb
@@ -1,6 +1,8 @@
 class Host::Discovered < ::Host::Base
   include ScopedSearchExtensions
 
+  attr_accessible :discovery_rule_id
+
   belongs_to :hostgroup
   has_one    :discovery_attribute_set, :foreign_key => :host_id, :dependent => :destroy
 


### PR DESCRIPTION
core tests were failing because of discovery_rule_id
