### PR TITLE
Fixes #13314 - improved taxonomy logging

### DIFF
--- a/app/controllers/discovered_hosts_controller.rb
+++ b/app/controllers/discovered_hosts_controller.rb
@@ -3,7 +3,6 @@ class DiscoveredHostsController < ::ApplicationController
   include Foreman::Controller::TaxonomyMultiple
   include Foreman::Controller::DiscoveredExtensions
   include ActionView::Helpers::NumberHelper
-  unloadable
 
   before_filter :find_by_name, :only => %w[edit update destroy refresh_facts convert reboot auto_provision]
   before_filter :find_by_name_incl_subnet, :only => [:show]


### PR DESCRIPTION
This can bite.

```
2016-01-21T14:49:41 [app] [D] Merging facts for 'mac525400b4afad': deleted 0 facts
2016-01-21T14:49:41 [app] [D] Merging facts for 'mac525400b4afad': added 28 facts
2016-01-21T14:49:41 [app] [D] No facts update required for mac525400b4afad
2016-01-21T14:49:41 [app] [I] Import facts for 'mac525400b4afad' completed. Added: 28, Updated: 0, Deleted 0 facts
2016-01-21T14:49:41 [app] [D] We have following interfaces 'fake1, fake2, fake3' based on facts
2016-01-21T14:49:41 [app] [D] Interface fake1 facts: {"macaddress"=>"52:54:00:55:3b:ac", "ipaddress"=>"192.168.122.37"}
2016-01-21T14:49:41 [app] [D] Interface fake2 facts: {"macaddress"=>"52:54:00:b4:af:ad", "ipaddress"=>"192.168.122.64"}
2016-01-21T14:49:41 [app] [D] Interface fake3 facts: {"macaddress"=>"52:54:00:ed:05:93", "ipaddress"=>"10.210.131.189"}
2016-01-21T14:49:41 [app] [D] Detected primary interface: ["fake2", {"macaddress"=>"52:54:00:b4:af:ad", "ipaddress"=>"192.168.122.64", "virtual"=>false}]
2016-01-21T14:49:42 [app] [I] Detected subnet: local.lan (192.168.122.0/24) with taxonomy ["Red Hat", "TestOrg1", "SubOrg1", "TestOrg2"]/["Brno", "Olomouc", "TestLoc1", "TestSubLoc1", "TestLoc2"]
2016-01-21T14:49:42 [app] [I] Assigned location: Brno
2016-01-21T14:49:42 [app] [I] Assigned organization: Red Hat
```
