### PR TITLE
Fixes #13322 - Impossible to select OS and media on discovered hosts

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,9 +2,9 @@
 Rails.application.routes.draw do
 
   # Needed to make the hosts/edit form render
-  get 'architecture_selected_discovered_hosts' => 'hosts#architecture_selected'
-  get 'os_selected_discovered_hosts'           => 'hosts#os_selected'
-  get 'medium_selected_discovered_hosts'       => 'hosts#medium_selected'
+  post 'architecture_selected_discovered_hosts' => 'hosts#architecture_selected'
+  post 'os_selected_discovered_hosts'           => 'hosts#os_selected'
+  post 'medium_selected_discovered_hosts'       => 'hosts#medium_selected'
 
   constraints(:id => /[^\/]+/) do
     resources :discovered_hosts, :except => [:new, :create] do


### PR DESCRIPTION
config/routes.rb matches hosts#architecture_selected and other routes as
GET. These routes are POST in Foreman core, so when javascript contacts
'GET architecture_selected_discovered_hosts', Foreman 404s.
The solution is simple, just actually match the requests as POST. I am
guessing this worked before Rails 4 because it used the method of the
matched route.

I'd say this one is important as currently provisioning a discovered
system isn't possible unless you select a hostgroup with the
OS/media/etc.
