### PR TITLE
Fixes #9490 - Added setting to specify fact to use for hostname

### DIFF
--- a/app/models/setting/discovered.rb
+++ b/app/models/setting/discovered.rb
@@ -8,6 +8,7 @@ class Setting::Discovered < ::Setting
   BLANK_ATTRS << 'discovery_facts_hardware'
   BLANK_ATTRS << 'discovery_facts_network'
   BLANK_ATTRS << 'discovery_facts_ipmi'
+  BLANK_ATTRS << 'discovery_prefix'
 
   def self.load_defaults
     # Check the table exists
@@ -15,7 +16,8 @@ class Setting::Discovered < ::Setting
 
     Setting.transaction do
       [
-        self.set('discovery_fact', N_("Fact name to use for primary interface detection and hostname"), "discovery_bootif"),
+        self.set('discovery_fact', N_("Fact name to use for primary interface detection"), "discovery_bootif"),
+        self.set('discovery_hostname', N_("List of facts to use for the hostname (separated by comma, first wins)"), "discovery_bootif"),
         self.set('discovery_auto', N_("Automatically provision newly discovered hosts, according to the provisioning rules"), false),
         self.set('discovery_reboot', N_("Automatically reboot discovered host during provisioning"), true),
       ].compact.each { |s| self.create s.update(:category => "Setting::Discovered")}
@@ -64,8 +66,17 @@ class Setting::Discovered < ::Setting
 
   def self.discovery_fact_column_array
     return [] if !Setting['discovery_fact_column'].present?
+    discovery_comma_to_array Setting['discovery_fact_column']
+  end
+
+  def self.discovery_hostname_fact_array
+    return [] if !Setting['discovery_hostname'].present?
+    discovery_comma_to_array Setting['discovery_hostname']
+  end
+
+  def self.discovery_comma_to_array string
     list = []
-    Setting['discovery_fact_column'].to_s.split(",").each do |value|
+    string.to_s.split(",").each do |value|
       list << value.strip
     end
   rescue => error

--- a/test/functional/api/v2/discovered_hosts_controller_test.rb
+++ b/test/functional/api/v2/discovered_hosts_controller_test.rb
@@ -29,6 +29,14 @@ class Api::V2::DiscoveredHostsControllerTest < ActionController::TestCase
                        :name => 'discovery_reboot',
                        :value => true,
                        :category => 'Setting::Discovered')
+    FactoryGirl.create(:setting,
+                       :name => 'discovery_hostname',
+                       :value => 'discovery_bootif',
+                       :category => 'Setting::Discovered')
+    FactoryGirl.create(:setting,
+                       :name => 'discovery_prefix',
+                       :value => 'mac',
+                       :category => 'Setting::Discovered')
     ::ForemanDiscovery::NodeAPI::PowerService.any_instance.stubs(:reboot).returns(true)
   end
 

--- a/test/functional/api/v2/discovery_rules_controller_test.rb
+++ b/test/functional/api/v2/discovery_rules_controller_test.rb
@@ -4,6 +4,15 @@ class Api::V2::DiscoveryRulesControllerTest < ActionController::TestCase
 
   setup do
     User.current = User.find_by_login "admin"
+
+    FactoryGirl.create(:setting,
+                       :name => 'discovery_hostname',
+                       :value => 'discovery_bootif',
+                       :category => 'Setting::Discovered')
+    FactoryGirl.create(:setting,
+                       :name => 'discovery_prefix',
+                       :value => 'mac',
+                       :category => 'Setting::Discovered')
   end
 
   test "should get index" do

--- a/test/functional/discovered_hosts_controller_test.rb
+++ b/test/functional/discovered_hosts_controller_test.rb
@@ -18,6 +18,14 @@ class DiscoveredHostsControllerTest < ActionController::TestCase
                        :name => 'discovery_reboot',
                        :value => true,
                        :category => 'Setting::Discovered')
+    FactoryGirl.create(:setting,
+                       :name => 'discovery_hostname',
+                       :value => 'discovery_bootif',
+                       :category => 'Setting::Discovered')
+    FactoryGirl.create(:setting,
+                       :name => 'discovery_prefix',
+                       :value => 'mac',
+                       :category => 'Setting::Discovered')
     ::ForemanDiscovery::NodeAPI::PowerService.any_instance.stubs(:reboot).returns(true)
   end
 

--- a/test/unit/discovered_extensions_test.rb
+++ b/test/unit/discovered_extensions_test.rb
@@ -11,6 +11,15 @@ class FindDiscoveryRulesTest < ActiveSupport::TestCase
       "macaddress_eth0"  => "AA:BB:CC:DD:EE:FF",
       "discovery_bootif" => "AA:BB:CC:DD:EE:FF",
     }
+
+    FactoryGirl.create(:setting,
+                       :name => 'discovery_hostname',
+                       :value => 'discovery_bootif',
+                       :category => 'Setting::Discovered')
+    FactoryGirl.create(:setting,
+                       :name => 'discovery_prefix',
+                       :value => 'mac',
+                       :category => 'Setting::Discovered')
   end
 
   test "no rule is found for empty rule set" do

--- a/test/unit/discovery_attribute_set_test.rb
+++ b/test/unit/discovery_attribute_set_test.rb
@@ -1,6 +1,18 @@
 require 'test_helper'
 
 class DiscoveryAttributeSetTest < ActiveSupport::TestCase
+
+  setup do
+    FactoryGirl.create(:setting,
+                       :name => 'discovery_hostname',
+                       :value => 'discovery_bootif',
+                       :category => 'Setting::Discovered')
+    FactoryGirl.create(:setting,
+                       :name => 'discovery_prefix',
+                       :value => 'mac',
+                       :category => 'Setting::Discovered')
+  end
+
   test "can search discovered hosts by cpu" do
     raw = parse_json_fixture('/facts.json')
     host = Host::Discovered.import_host_and_facts(raw['facts']).first


### PR DESCRIPTION
Supersedes  #213 

Based on the original patch from @orrabin 
