### PR TITLE
Fixes #13593 - Preload assets before sprockets

### DIFF
--- a/lib/foreman_discovery/engine.rb
+++ b/lib/foreman_discovery/engine.rb
@@ -44,7 +44,7 @@ module ForemanDiscovery
       end
     end
 
-    initializer 'foreman_discovery.register_plugin', :after=> :finisher_hook do |app|
+    initializer 'foreman_discovery.register_plugin', :before => :finisher_hook do |app|
       Foreman::Plugin.register :foreman_discovery do
         requires_foreman '>= 1.11.0'
 

--- a/test/functional/discovered_hosts_controller_test.rb
+++ b/test/functional/discovered_hosts_controller_test.rb
@@ -80,7 +80,9 @@ class DiscoveredHostsControllerTest < ActionController::TestCase
     Host::Discovered::any_instance.stubs(:proxied?).returns(false)
     Host::Discovered::any_instance.stubs(:proxy_url).returns("http://1.2.3.4:8443")
     ::ForemanDiscovery::NodeAPI::PowerLegacyDirectService.any_instance.expects(:reboot).returns(true)
-    post "reboot", { :id => host.id }, set_session_user
+    ActiveSupport::Deprecation.silence do
+      post "reboot", { :id => host.id }, set_session_user
+    end
     assert_redirected_to discovered_hosts_url
     assert_nil flash[:error]
     assert_equal "Rebooting host #{host.name}", flash[:notice]


### PR DESCRIPTION
Currently Foreman core has an initializer (assets_paths) that takes care
of finding the Discovery assets in the engine and load them before
sprockets is loaded. This is happening because sprockets tries to load
the assets before they are defined (:after => finisher_hook is too
    late).

Just changing it to :before finisher_hook is enough to make it load
assets before then and the deprecation error will go away.
