### PR TITLE
Fixes #13752 - Display dropdown for discovery_taxonomy settings

### DIFF
--- a/app/helpers/concerns/foreman_discovery/settings_helper_extensions.rb
+++ b/app/helpers/concerns/foreman_discovery/settings_helper_extensions.rb
@@ -1,0 +1,34 @@
+module ForemanDiscovery
+  module SettingsHelperExtensions
+    extend ActiveSupport::Concern
+
+    included do
+      alias_method_chain :value, :discovery
+    end
+
+    def value_with_discovery(setting)
+      return value_without_discovery(setting) unless [
+        'discovery_location',
+        'discovery_organization'].include?(setting.name)
+
+      case setting.name
+      when "discovery_location"
+        edit_select(
+          setting,
+          :value,
+          :select_values => discovery_taxonomy_values(Location))
+      when "discovery_organization"
+        edit_select(
+          setting,
+          :value,
+          :select_values => discovery_taxonomy_values(Organization))
+      end
+    end
+
+    private
+
+    def discovery_taxonomy_values(taxonomy_class)
+      Hash[taxonomy_class.all.map{ |org| [org[:title], org[:title]] }].to_json
+    end
+  end
+end

--- a/lib/foreman_discovery/engine.rb
+++ b/lib/foreman_discovery/engine.rb
@@ -170,6 +170,8 @@ module ForemanDiscovery
 
       # Include helper for dashboard
       ::DashboardHelper.send(:include, DiscoveredHostsHelper)
+
+      ::SettingsHelper.send :include, ForemanDiscovery::SettingsHelperExtensions
     end
 
     rake_tasks do


### PR DESCRIPTION
Similar to #13721 , discovery_location and discovery_taxonomy should
show all taxonomies available instead of being a text field.
