### PR TITLE
Fixes #13785 - removed N+1 queries

### DIFF
--- a/app/controllers/discovered_hosts_controller.rb
+++ b/app/controllers/discovered_hosts_controller.rb
@@ -4,8 +4,8 @@ class DiscoveredHostsController < ::ApplicationController
   include Foreman::Controller::DiscoveredExtensions
   include ActionView::Helpers::NumberHelper
 
-  before_filter :find_by_name, :only => %w[edit update destroy refresh_facts convert reboot auto_provision]
-  before_filter :find_by_name_incl_subnet, :only => [:show]
+  before_filter :find_by_name, :only => %w[edit update destroy convert reboot auto_provision]
+  before_filter :find_by_name_incl_subnet, :only => [:show, :refresh_facts]
   before_filter :find_multiple, :only => [:multiple_destroy, :submit_multiple_destroy]
   before_filter :taxonomy_scope, :only => [:edit]
 

--- a/app/models/host/discovered.rb
+++ b/app/models/host/discovered.rb
@@ -91,6 +91,8 @@ class Host::Discovered < ::Host::Base
     unless primary_ip.nil?
       subnet = Subnet.subnet_for(primary_ip)
       if subnet
+        # reload subnet to fetch all references
+        subnet.reload
         Rails.logger.info "Detected subnet: #{subnet} with taxonomy #{subnet.organizations.collect(&:name)}/#{subnet.locations.collect(&:name)}"
       else
         Rails.logger.warn "Subnet could not be detected for #{primary_ip}"


### PR DESCRIPTION
There are N+1 problems. The one with refresh_facts is clear, the other one when
new host is discovered is a bit weird.

```
2016-02-18T12:08:49 [app] [W] user: lzap
 | http://localhost:3000/api/v2/discovered_hosts/facts
 | N+1 Query detected
 |   Subnet => [:organizations]
 |   Add to your finder: :includes => [:organizations]
 | N+1 Query method call stack
 |   /home/lzap/work/foreman_discovery/app/models/host/discovered.rb:86:in `populate_fields_from_facts'
 |   /home/lzap/work/foreman/app/models/host/base.rb:151:in `import_facts'
 |   /home/lzap/work/foreman_discovery/app/models/host/discovered.rb:62:in `import_facts'
 |   /home/lzap/work/foreman_discovery/app/models/host/discovered.rb:54:in `import_host_and_facts'
 |   /home/lzap/work/foreman_discovery/app/controllers/api/v2/discovered_hosts_controller.rb:100:in `block in facts'
 |   /home/lzap/work/foreman/app/models/host.rb:15:in `method_missing'
 |   /home/lzap/work/foreman_discovery/app/controllers/api/v2/discovered_hosts_controller.rb:99:in `facts'
 |   /home/lzap/work/foreman/app/controllers/api/v2/base_controller.rb:152:in `disable_json_root'
 |   /home/lzap/work/foreman/app/controllers/concerns/application_shared.rb:13:in `set_timezone'
 |   /home/lzap/work/foreman/app/models/concerns/foreman/thread_session.rb:32:in `clear_thread'
 |   /home/lzap/work/foreman/lib/middleware/catch_json_parse_errors.rb:9:in `call'
 | 
 | /home/lzap/work/foreman_discovery/app/models/host/discovered.rb:86:in `populate_fields_from_facts'
 | /home/lzap/work/foreman/app/models/host/base.rb:151:in `import_facts'
 | /home/lzap/work/foreman_discovery/app/models/host/discovered.rb:62:in `import_facts'
 | /home/lzap/work/foreman_discovery/app/models/host/discovered.rb:54:in `import_host_and_facts'
 | /home/lzap/work/foreman_discovery/app/controllers/api/v2/discovered_hosts_controller.rb:100:in `block in facts'
 | /home/lzap/work/foreman/app/models/host.rb:15:in `method_missing'
 | /home/lzap/work/foreman_discovery/app/controllers/api/v2/discovered_hosts_controller.rb:99:in `facts'
 | /home/lzap/work/foreman/app/controllers/api/v2/base_controller.rb:152:in `disable_json_root'
 | /home/lzap/work/foreman/app/controllers/concerns/application_shared.rb:13:in `set_timezone'
 | /home/lzap/work/foreman/app/models/concerns/foreman/thread_session.rb:32:in `clear_thread'
 | /home/lzap/work/foreman/lib/middleware/catch_json_parse_errors.rb:9:in `call'
2016-02-18T12:08:49 [app] [W] user: lzap
 | http://localhost:3000/api/v2/discovered_hosts/facts
 | N+1 Query detected
 |   Subnet => [:locations]
 |   Add to your finder: :includes => [:locations]
 | N+1 Query method call stack
 |   /home/lzap/work/foreman_discovery/app/models/host/discovered.rb:86:in `populate_fields_from_facts'
 |   /home/lzap/work/foreman/app/models/host/base.rb:151:in `import_facts'
 |   /home/lzap/work/foreman_discovery/app/models/host/discovered.rb:62:in `import_facts'
 |   /home/lzap/work/foreman_discovery/app/models/host/discovered.rb:54:in `import_host_and_facts'
 |   /home/lzap/work/foreman_discovery/app/controllers/api/v2/discovered_hosts_controller.rb:100:in `block in facts'
 |   /home/lzap/work/foreman/app/models/host.rb:15:in `method_missing'
 |   /home/lzap/work/foreman_discovery/app/controllers/api/v2/discovered_hosts_controller.rb:99:in `facts'
 |   /home/lzap/work/foreman/app/controllers/api/v2/base_controller.rb:152:in `disable_json_root'
 |   /home/lzap/work/foreman/app/controllers/concerns/application_shared.rb:13:in `set_timezone'
 |   /home/lzap/work/foreman/app/models/concerns/foreman/thread_session.rb:32:in `clear_thread'
 |   /home/lzap/work/foreman/lib/middleware/catch_json_parse_errors.rb:9:in `call'
 | 
 | /home/lzap/work/foreman_discovery/app/models/host/discovered.rb:86:in `populate_fields_from_facts'
 | /home/lzap/work/foreman/app/models/host/base.rb:151:in `import_facts'
 | /home/lzap/work/foreman_discovery/app/models/host/discovered.rb:62:in `import_facts'
 | /home/lzap/work/foreman_discovery/app/models/host/discovered.rb:54:in `import_host_and_facts'
 | /home/lzap/work/foreman_discovery/app/controllers/api/v2/discovered_hosts_controller.rb:100:in `block in facts'
 | /home/lzap/work/foreman/app/models/host.rb:15:in `method_missing'
 | /home/lzap/work/foreman_discovery/app/controllers/api/v2/discovered_hosts_controller.rb:99:in `facts'
 | /home/lzap/work/foreman/app/controllers/api/v2/base_controller.rb:152:in `disable_json_root'
 | /home/lzap/work/foreman/app/controllers/concerns/application_shared.rb:13:in `set_timezone'
 | /home/lzap/work/foreman/app/models/concerns/foreman/thread_session.rb:32:in `clear_thread'
 | /home/lzap/work/foreman/lib/middleware/catch_json_parse_errors.rb:9:in `call'

```

Let me explain the patch.

I tried to add `joins` or `includes` but because of the code in puppet import
class, the interfaces/subnet gets refreshed. Therefore it does not work. The
only way I can think of is to reload the modified instances again. Since reload
also reloads references, it works fine.
