### PR TITLE
Fixes #13829 - view hosts permission added to reader

### DIFF
--- a/lib/foreman_discovery/engine.rb
+++ b/lib/foreman_discovery/engine.rb
@@ -103,12 +103,17 @@ module ForemanDiscovery
         end
 
         READER = [
-          :view_discovered_hosts,
-          :view_discovery_rules,
+          # core permissions
           :view_organizations,
           :view_locations,
+          :view_hosts,
+          # discovered_hosts
+          :view_discovered_hosts,
+          # discovered_rules
+          :view_discovery_rules,
         ]
         MANAGER = READER + [
+          # core permissions
           :assign_organizations,
           :assign_locations,
           # discovered_hosts


### PR DESCRIPTION
SSIA, see the linked BZ for details. I am _not_ adding a seed script to add
this permission to existing roles for security reasons - users must explicitly
add this permission if they need it.
