### PR TITLE
Fixes #13715 - fixed multiple deletion of hosts

### DIFF
--- a/app/controllers/discovered_hosts_controller.rb
+++ b/app/controllers/discovered_hosts_controller.rb
@@ -115,7 +115,7 @@ class DiscoveredHostsController < ::ApplicationController
 
   def submit_multiple_destroy
     # keep all the ones that were not deleted for notification.
-    @hosts.delete_if {|host| host.destroy}
+    @hosts.to_a.delete_if {|host| host.destroy}
 
     missed_hosts = @hosts.map(&:name).join('<br/>')
     if @hosts.empty?


### PR DESCRIPTION
What an association return is not an Array in Rails 4+. If we want do array
operation on it we should call to_a.
