### PR TITLE
Fixes #12765 - rule ordering in UI by priority and creation time

### DIFF
--- a/app/controllers/discovery_rules_controller.rb
+++ b/app/controllers/discovery_rules_controller.rb
@@ -5,7 +5,7 @@ class DiscoveryRulesController < ApplicationController
   before_filter :find_resource, :only => [:edit, :update, :destroy, :enable, :disable, :auto_provision]
 
   def index
-    base = resource_base.search_for(params[:search], :order => (params[:order] || 'priority ASC'))
+    base = resource_base.search_for(params[:search], :order => (params[:order]))
     @discovery_rules = base.paginate(:page => params[:page]).includes(:hostgroup)
   end
 

--- a/app/models/discovery_rule.rb
+++ b/app/models/discovery_rule.rb
@@ -28,13 +28,11 @@ class DiscoveryRule < ActiveRecord::Base
   scoped_search :on => :enabled
   scoped_search :in => :hostgroup, :on => :name, :complete_value => true, :rename => :hostgroup
 
-  # with proc support, default_scope can no longer be chained
-  # include all default scoping here
   default_scope lambda {
-                  with_taxonomy_scope do
-                    order("discovery_rules.name")
-                  end
-                }
+    with_taxonomy_scope do
+      order('discovery_rules.priority, discovery_rules.created_at')
+    end
+  }
 
   def default_int_attributes
    self.max_count ||= 0


### PR DESCRIPTION
This is how it's done in core.
