### PR TITLE
Fixes #14010 - network facts are properly displayed

### DIFF
--- a/app/views/discovered_hosts/show.html.erb
+++ b/app/views/discovered_hosts/show.html.erb
@@ -4,12 +4,12 @@
 
 <div class="row">
   <div class="col-md-6">
-    <div class="panel panel-default">
+    <div id="category-highlights" class="panel panel-default">
       <div class="panel-heading" ><strong> <%= _(@categories_names[0]) %></strong> </div>
         <table class="table table-bordered table-condensed table-fixed">
-        <% @categories[0].sort.each do |keys, val| %>
-            <tr class="">
-              <th class="ellipsis" width="40%"> <strong> <%= keys %> </strong></th>
+        <% @categories[0].sort.each do |key, val| %>
+            <tr id="fact-<%= key.try(:downcase) %>" class="">
+              <th class="ellipsis" width="40%"> <strong> <%= key %> </strong></th>
               <td><%= val %></td>
             </tr>
         <% end -%>
@@ -51,7 +51,7 @@
     <div class="col-md-6">
       <% @categories.each_with_index do |val, index| %>
         <% next if index == 0 || val.empty? %>
-        <div class="panel panel-default">
+        <div id="category-<%= @categories_names[index].downcase %>" class="panel panel-default">
           <div class="panel-heading" role="tab">
             <h4 class="panel-title">
               <a role="button" class="expendable-link" data-toggle="collapse" data-parent="#accordion" href="#<%= @categories_names[index].to_s + "panel" %>" aria-expanded="true" onclick="$(this).find(':first-child').toggleClass('glyphicon glyphicon-minus-sign glyphicon glyphicon-plus-sign')">

--- a/test/functional/discovered_hosts_controller_test.rb
+++ b/test/functional/discovered_hosts_controller_test.rb
@@ -47,6 +47,17 @@ class DiscoveredHostsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  def test_show_page_categories
+    host = Host::Discovered.import_host_and_facts(@facts).first
+    get :show, {:id => host.id}, set_session_user_default_reader
+    assert_select "#category-highlights" do
+      assert_select "#fact-ipaddress" do
+        assert_select "td", /192.168.100.42/
+      end
+    end
+    assert_response :success
+  end
+
   def test_edit_form_elements
     host = Host::Discovered.import_host_and_facts(@facts).first
     get :edit, {:id => host.id}, set_session_user_default_manager


### PR DESCRIPTION
Some network facts (those ending with _eth0 or similar) are ignored and not
shown on the discovered host page, for example auto_negotiation_XXX. The
current code skips all facts because it present them in the Highlight section,
while we should still show them.

Also there is a pending PR for the image to add LLDAP facts like
lldp_neighbor_portid_XXX which are also completely ignored.
