### PR TITLE
Fixes #14100 - prevents clearing discovery_* facts

### DIFF
--- a/app/services/foreman_discovery/host_converter.rb
+++ b/app/services/foreman_discovery/host_converter.rb
@@ -15,7 +15,7 @@ class ForemanDiscovery::HostConverter
       # set legacy_api flag for post_queue actions
       host.legacy_api = self.legacy_host(host)
       # do not delete all facts (keep discovery ones)
-      host.define_singleton_method(:clearFacts) do
+      host.define_singleton_method(:clear_facts) do
         keep_ids = FactValue.where("host_id = #{host.id}").joins(:fact_name).where("fact_names.name like 'discovery_%'").pluck("fact_values.id")
         FactValue.where("host_id = #{host.id} and id not in (?)", keep_ids).delete_all
       end


### PR DESCRIPTION
The method name in core was renamed, that was the reason. I've added a test to
prevent this in the future. Quick merge please @stbenjam for 6.2? Thanks!
