### PR TITLE
Fixes #9784 - fixed inherited parameters

### DIFF
--- a/app/controllers/api/v2/discovered_hosts_controller.rb
+++ b/app/controllers/api/v2/discovered_hosts_controller.rb
@@ -78,7 +78,7 @@ module Api
       def update
         @host = ::ForemanDiscovery::HostConverter.to_managed(@discovered_host)
         forward_request_url
-        update_response = @host.update_attributes(params[:discovered_host])
+        update_response = @host.update_attributes(@host.apply_inherited_attributes(params[:discovered_host]))
         process_response update_response
       end
 

--- a/app/controllers/concerns/foreman/controller/discovered_extensions.rb
+++ b/app/controllers/concerns/foreman/controller/discovered_extensions.rb
@@ -54,6 +54,8 @@ module Foreman::Controller::DiscoveredExtensions
     host.name = host.render_template(rule.hostname) unless rule.hostname.empty?
     # fallback to the original if template did not expand
     host.name = original_name if host.name.empty?
+    # explicitly set all inheritable attributes from hostgroup
+    host.attributes = host.apply_inherited_attributes(hostgroup_id: rule.hostgroup_id)
     # save! does not work here
     host.save
   end

--- a/app/controllers/discovered_hosts_controller.rb
+++ b/app/controllers/discovered_hosts_controller.rb
@@ -50,6 +50,7 @@ class DiscoveredHostsController < ::ApplicationController
 
   def edit
     @host = ::ForemanDiscovery::HostConverter.to_managed(@host, true, false) unless @host.nil?
+    @force_inherited_params = true
     render :template => 'hosts/edit'
   end
 
@@ -57,7 +58,7 @@ class DiscoveredHostsController < ::ApplicationController
     @host = ::ForemanDiscovery::HostConverter.to_managed(@host)
     forward_url_options
     Taxonomy.no_taxonomy_scope do
-      if @host.update_attributes(params[:host])
+      if @host.update_attributes(@host.apply_inherited_attributes(params[:host]))
         process_success :success_redirect => host_path(@host), :redirect_xhr => request.xhr?
       else
         taxonomy_scope

--- a/app/services/foreman_discovery/host_converter.rb
+++ b/app/services/foreman_discovery/host_converter.rb
@@ -9,6 +9,10 @@ class ForemanDiscovery::HostConverter
     if set_managed
       host.managed = set_managed
       host.primary_interface.managed = set_managed
+      # render all inherit buttons as selected on Edit Host form
+      #host.define_singleton_method(:force_inherited) do |_|
+        #true
+      #end
     end
     # set build only and only on final save (facts are deleted)
     if set_build


### PR DESCRIPTION
Discovery process had issues with inheritable attributes (Puppet Master/CA,
Realm and few others). It was simply ignored and there was no way of setting
them.

For interactive provisioning, we need to make sure that the new
`apply_inherited_attributes` is called. Also, since discovery uses Edit Host
form and hostgroup is not yet set, all the Inherit buttons are not rendered as
pressed, which is bad UX. As part of this patch, a parameter "inherit_all" is
passed into views to override the inherit button state.

In case of auto-provisioning, inherited attributes were completely ignored.
During the process, all the inheritable attributes are now explicitly set from
the matched hostgroup.
