### PR TITLE
Fixed unit tests for random execution

### DIFF
--- a/app/views/discovered_mailer/discovered_summary.text.erb
+++ b/app/views/discovered_mailer/discovered_summary.text.erb
@@ -21,4 +21,4 @@
   <%= _('No new discovered hosts for this period') %>
 <% end %>
 
-<%= discovered_hosts_path(:host => @url.host, :port => @url.port, :only_path => false, :protocol => @url.scheme, :search => @query) %>
+<%= discovered_hosts_url(:host => @url.host, :port => @url.port, :only_path => false, :protocol => @url.scheme, :search => @query) %>

--- a/test/functional/api/v2/fact_value_extensions_test.rb
+++ b/test/functional/api/v2/fact_value_extensions_test.rb
@@ -26,7 +26,7 @@ module Api
       test 'list discovered host facts' do
         disable_orchestration
         facts = @facts.merge({ "somefact" => "abc" })
-        host  = Host::Discovered.import_host_and_facts(facts).first
+        host = Host::Discovered.import_host(facts)
         get :index, { :discovered_host_id => host.id }
         assert_response :success
         show_response = ActiveSupport::JSON.decode(@response.body)

--- a/test/functional/discovered_hosts_controller_test.rb
+++ b/test/functional/discovered_hosts_controller_test.rb
@@ -48,7 +48,7 @@ class DiscoveredHostsControllerTest < ActionController::TestCase
   end
 
   def test_show_page_categories
-    host = Host::Discovered.import_host_and_facts(@facts).first
+    host = Host::Discovered.import_host(@facts)
     get :show, {:id => host.id}, set_session_user_default_reader
     assert_select "#category-highlights" do
       assert_select "#fact-ipaddress" do
@@ -77,8 +77,7 @@ class DiscoveredHostsControllerTest < ActionController::TestCase
 
   def test_add_entry_to_nav_menu
     get :index, {}, set_session_user
-    assert_tag :tag        => 'a',
-               :attributes => { :href => '/discovered_hosts' }
+    assert_select "a[href=?]", "/discovered_hosts"
   end
 
   def test_reboot_success

--- a/test/functional/discovery_rules_controller_test.rb
+++ b/test/functional/discovery_rules_controller_test.rb
@@ -6,7 +6,7 @@ class DiscoveryRulesControllerTest < ActionController::TestCase
 
   test "should add a link to navigation" do
     get :index, {}, set_session_user
-    assert_tag :tag => 'a', :attributes => {:href => '/discovery_rules'}
+    assert_select "a[href=?]", "/discovery_rules"
   end
 
   test "reader role should get index" do

--- a/test/test_helper_discovery.rb
+++ b/test/test_helper_discovery.rb
@@ -12,7 +12,7 @@ def set_session_user_with_perms perms
   user = FactoryGirl.create :user, :with_mail, :admin => false
   user.roles << role
   user.save!
-  SETTINGS[:login] ? {:user => user, :expires_at => 5.minutes.from_now} : {}
+  SETTINGS[:login] ? {:user => user.id, :expires_at => 5.minutes.from_now} : {}
 end
 
 def set_session_user_default_reader

--- a/test/unit/discovered_extensions_test.rb
+++ b/test/unit/discovered_extensions_test.rb
@@ -77,7 +77,7 @@ class FindDiscoveryRulesTest < ActiveSupport::TestCase
 
   test "first rule out of two with different priorities is found for a discovered host" do
     facts = @facts.merge({"somefact" => "abc"})
-    host = Host::Discovered.import_host_and_facts(facts).first
+    host = Host::Discovered.import_host(facts)
     r1 = FactoryGirl.create(:discovery_rule, :name => "A", :priority => 1, :search => "facts.somefact = abc",
                             :organizations => [host.organization], :locations => [host.location])
     r2 = FactoryGirl.create(:discovery_rule, :name => "B", :priority => 2, :search => "facts.somefact = abc",
@@ -87,7 +87,7 @@ class FindDiscoveryRulesTest < ActiveSupport::TestCase
 
   test "second rule out of two with different priorities is found for a discovered host" do
     facts = @facts.merge({"somefact" => "abc"})
-    host = Host::Discovered.import_host_and_facts(facts).first
+    host = Host::Discovered.import_host(facts)
     r1 = FactoryGirl.create(:discovery_rule, :name => "A", :priority => 2, :search => "facts.somefact = abc",
                        :organizations => [host.organization], :locations => [host.location])
     r2 = FactoryGirl.create(:discovery_rule, :name => "B", :priority => 1, :search => "facts.somefact = abc",
@@ -97,7 +97,7 @@ class FindDiscoveryRulesTest < ActiveSupport::TestCase
 
   test "older rule out of two is found for a discovered host" do
     facts = @facts.merge({"somefact" => "abc"})
-    host = Host::Discovered.import_host_and_facts(facts).first
+    host = Host::Discovered.import_host(facts)
     r1 = FactoryGirl.create(:discovery_rule, :priority => 1, :search => "facts.somefact = abc",
                        :organizations => [host.organization], :locations => [host.location])
     r2 = FactoryGirl.create(:discovery_rule, :priority => 1, :search => "facts.somefact = abc",

--- a/test/unit/discovery_taxonomy_extensions_test.rb
+++ b/test/unit/discovery_taxonomy_extensions_test.rb
@@ -16,7 +16,7 @@ class DiscoveryTaxonomyExtensionsTest < ActiveSupport::TestCase
     location = FactoryGirl.create(:location)
 
     raw = parse_json_fixture('/facts.json')
-    assert (host = Host::Discovered.import_host_and_facts(raw['facts']).first)
+    assert (host = Host::Discovered.import_host(raw['facts']))
     host.location = location
     assert host.save
 

--- a/test/unit/host_discovered_test.rb
+++ b/test/unit/host_discovered_test.rb
@@ -29,7 +29,7 @@ class HostDiscoveredTest < ActiveSupport::TestCase
 
   test "should setup subnet" do
     raw = parse_json_fixture('/facts.json')
-    subnet = FactoryGirl.create(:subnet, :organizations => [Organization.first], :locations => [Location.first])
+    subnet = FactoryGirl.create(:subnet_ipv4, :name => 'Subnet99', :network => '192.168.99.0', :ipam => Subnet::IPAM_MODES[:db], :organizations => [Organization.first], :locations => [Location.first])
     Subnet.expects(:subnet_for).with('10.35.27.3').returns(subnet)
     host = Host::Discovered.import_host(raw['facts'])
     assert_equal subnet, host.primary_interface.subnet
@@ -47,7 +47,7 @@ class HostDiscoveredTest < ActiveSupport::TestCase
                        :value => loc.name,
                        :category => 'Setting::Discovered')
     raw = parse_json_fixture('/facts.json')
-    subnet = FactoryGirl.create(:subnet, :organizations => [org], :locations => [loc])
+    subnet = FactoryGirl.create(:subnet_ipv4, :name => 'Subnet99', :network => '192.168.99.0', :ipam => Subnet::IPAM_MODES[:db], :organizations => [org], :locations => [loc])
     Subnet.expects(:subnet_for).with('10.35.27.3').returns(subnet)
     host = Host::Discovered.import_host(raw['facts'])
     assert_equal subnet, host.primary_interface.subnet
@@ -174,7 +174,7 @@ class HostDiscoveredTest < ActiveSupport::TestCase
       'delete_me' => "content",
       'discovery_dont_delete_me' => "content",
       })
-    host = Host::Discovered.import_host_and_facts(raw).first
+    host = Host::Discovered.import_host(raw)
     host.save
     managed = ::ForemanDiscovery::HostConverter.to_managed(host)
     managed.clear_facts


### PR DESCRIPTION
This patch fixes unit tests for various problems:

Unit tests are now executed in random order, one test was disabling taxonomy
which led to random failures.

Subnet FactoryGirl was renamed in core due to IPv6 changed which led to
immediate failures.

User object instead of id was stored in session which led to deprecated
warning.

Deprecated `assert_tag` was removed.

Deprecated `*_path` with `only_path` was also renamed.
