### PR TITLE
Fixes #15145 - added nomodeset to the kexec template

### DIFF
--- a/app/views/foreman_discovery/redhat_kexec.erb
+++ b/app/views/foreman_discovery/redhat_kexec.erb
@@ -37,8 +37,8 @@ information about semantics.
   "initram": "<%= @initrd %>",
 <% if (@host.operatingsystem.name == 'Fedora' and @host.operatingsystem.major.to_i > 16) or
     (@host.operatingsystem.name != 'Fedora' and @host.operatingsystem.major.to_i >= 7) -%>
-  "append": "ks=<%= foreman_url('provision') + "&static=yes" %> inst.ks.sendmac <%= "ip=#{ip}::#{gw}:#{mask}:::none nameserver=#{dns} ksdevice=bootif BOOTIF=#{bootif} #{append}" %>"
+  "append": "ks=<%= foreman_url('provision') + "&static=yes" %> inst.ks.sendmac <%= "ip=#{ip}::#{gw}:#{mask}:::none nameserver=#{dns} ksdevice=bootif BOOTIF=#{bootif} nomodeset #{append}" %>"
 <% else -%>
-  "append": "ks=<%= foreman_url('provision') + "&static=yes" %> kssendmac nicdelay=5 <%= "ip=#{ip} netmask=#{mask} gateway=#{gw} dns=#{dns} ksdevice=#{mac} BOOTIF=#{bootif} #{append}" %>"
+  "append": "ks=<%= foreman_url('provision') + "&static=yes" %> kssendmac nicdelay=5 <%= "ip=#{ip} netmask=#{mask} gateway=#{gw} dns=#{dns} ksdevice=#{mac} BOOTIF=#{bootif} nomodeset #{append}" %>"
 <% end -%>
 }


### PR DESCRIPTION
To test this, when kexecing RHEL7 Anaconda screen should stay in 80x25 mode.

Ideally test with https://github.com/theforeman/foreman-discovery-image/pull/74
