### PR TITLE
Fixes #4426 - Add modal wizard to host creation

### DIFF
--- a/app/helpers/discovered_hosts_helper.rb
+++ b/app/helpers/discovered_hosts_helper.rb
@@ -75,4 +75,28 @@ module DiscoveredHostsHelper
     "<span class='glyphicon #{status_glyph}' style='color: #{status_color}'
       title='#{status_message}'/>".html_safe
   end
+
+  def host_taxonomy_select(f, taxonomy)
+    # Add hidden field with taxonomy value to be updated by the form on submit
+    tax_html = super
+    tax_id = "#{taxonomy.to_s.downcase}_id"
+    selected_taxonomy = params[:host][tax_id]
+    if @override_taxonomy && selected_taxonomy
+      hidden_tax = f.hidden_field tax_id.to_sym, :value => selected_taxonomy
+      tax_html += hidden_tax
+    end
+    tax_html
+  end
+
+  def provision_button(host, authorization_options)
+    return '' unless authorized_for(authorization_options)
+
+    button_tag(
+      _('Provision'),
+      :type => :button,
+      :class => 'btn btn-sm btn-default',
+      :data => {
+        :toggle => 'modal',
+        :target => "#fixedPropertiesSelector-#{host.id}"})
+  end
 end

--- a/app/views/discovered_hosts/_discovered_hosts_list.html.erb
+++ b/app/views/discovered_hosts/_discovered_hosts_list.html.erb
@@ -38,8 +38,39 @@
       <td class="hidden-tablet hidden-xs"><%= host.primary_interface.try(:subnet) %></td>
       <td class="hidden-tablet hidden-xs"><%= disc_report_column(host) %></td>
       <td>
+        <!-- Modal -->
+      <div class="modal" id="<%= "fixedPropertiesSelector-#{host.id}" %>" tabindex="-1" role="dialog" aria-labelledby="fixedPropertiesSelectorLabel">
+        <div class="modal-dialog" role="document">
+          <div class="modal-content">
+            <%= form_for host, :url => edit_discovered_host_path(host), :method => :get do |f| %>
+              <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="fixedPropertiesSelectorLabel"><%= _('Select initial host properties') %></h4>
+              </div>
+              <div class="modal-body">
+                  <%= select_f f, :hostgroup_id, accessible_hostgroups, :id, :to_label,
+                    { :include_blank => true },
+                    { :help_inline => :indicator, :size => 'col-md-10' } %>
+
+                  <% if show_organization_tab?  %>
+                    <%= select_f f, :organization_id, Organization.my_organizations, :id, :to_label, {}, {:size => 'col-md-10'} %>
+                  <% end %>
+
+                  <% if show_location_tab? %>
+                    <%= select_f f, :location_id, Location.my_locations, :id, :to_label, {}, {:size => 'col-md-10'} %>
+                  <% end %>
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                <input type="submit" class="btn btn-default" value="Quick create" name="quick_submit"></input>
+                <input type="submit" class="btn btn-primary" value="Create host"></input>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
         <%= action_buttons(
-          display_link_if_authorized(_("Provision"), hash_for_edit_discovered_host_path(:id => host)),
+          provision_button(host, hash_for_edit_discovered_host_path(:id => host)),
           display_link_if_authorized(_("Auto Provision"), hash_for_auto_provision_discovered_host_path(:id => host), :method => :post),
           display_link_if_authorized(_("Refresh facts"), hash_for_refresh_facts_discovered_host_path(:id => host)),
           display_link_if_authorized(_("Reboot"), hash_for_reboot_discovered_host_path(:id => host), :method => :put),


### PR DESCRIPTION
Each discovered host in thelist gets a modal wizard that will ask for organization, location and hostgroup before redirecting to host edit screen.
