### PR TITLE
Fixes #15368 - refresh existing discovered host

### DIFF
--- a/app/controllers/discovered_hosts_controller.rb
+++ b/app/controllers/discovered_hosts_controller.rb
@@ -253,10 +253,12 @@ class DiscoveredHostsController < ::ApplicationController
   end
 
   def find_by_name(*includes)
-    params[:id].downcase! if params[:id].present?
-    @host = includes.empty? ? resource_base.find_by_id(params[:id]) : resource_base.includes(includes).find_by_id(params[:id])
-    @host ||= includes.empty? ? resource_base.find_by_name(params[:id]) : resource_base.includes(includes).find_by_name(params[:id])
-    return false unless @host
+    not_found and return false if (id = params[:id]).blank?
+    id.downcase!
+    @host = includes.empty? ? resource_base.find_by_id(id) : resource_base.includes(includes).find_by_id(id)
+    @host ||= includes.empty? ? resource_base.find_by_name(id) : resource_base.includes(includes).find_by_name(id)
+    not_found and return(false) unless @host
+    @host
   end
 
   def find_by_name_incl_subnet

--- a/test/unit/host_discovered_test.rb
+++ b/test/unit/host_discovered_test.rb
@@ -144,6 +144,15 @@ class HostDiscoveredTest < ActiveSupport::TestCase
     assert_equal 'e41f13cc3658',host.name
   end
 
+  test "should refresh existing discovered" do
+    raw = parse_json_fixture('/facts.json')
+    interface = mock()
+    interface.stubs(:host).returns(Host.create(:name => "xyz", :type => "Host::Discovered"))
+    ::Nic::Managed.stubs(:where).with(:mac => raw['facts']['discovery_bootif'].downcase, :primary => true).returns([interface])
+    host = Host::Discovered.import_host(raw['facts'])
+    assert_equal 'xyz', host.name
+  end
+
   test "should raise when hostname fact cannot be found" do
     raw = parse_json_fixture('/facts.json')
     Setting[:discovery_hostname] = 'macaddress_foo'


### PR DESCRIPTION
Existing host (when renamed) was ignored.

Also fixed 404 for show page.

Replaces https://github.com/theforeman/foreman_discovery/pull/275
