### PR TITLE
Fixes #9784 - autoprovisioning populates from hostgroup

### DIFF
--- a/app/controllers/concerns/foreman/controller/discovered_extensions.rb
+++ b/app/controllers/concerns/foreman/controller/discovered_extensions.rb
@@ -54,8 +54,11 @@ module Foreman::Controller::DiscoveredExtensions
     host.name = host.render_template(rule.hostname) unless rule.hostname.empty?
     # fallback to the original if template did not expand
     host.name = original_name if host.name.empty?
+    # explicitly set all inheritable attributes from hostgroup
+    host.attributes = host.apply_inherited_attributes(hostgroup_id: rule.hostgroup_id)
+    host.set_hostgroup_defaults
     # save! does not work here
-    host.save
+    host.save ? host : false
   end
 
   def perform_reboot_all hosts = Host::Discovered.all


### PR DESCRIPTION
Sets ignored flags like Environment, Puppet or CA. This patch is only for
auto-provisioning. For edit host form, you can now use the new modal dialog
which was merged last week.

When testing this, you may hit: http://projects.theforeman.org/issues/15469

That's a different story.
