### PR TITLE
Fixes #15469 - fixed host_taxonomy_select nil exception

### DIFF
--- a/app/helpers/discovered_hosts_helper.rb
+++ b/app/helpers/discovered_hosts_helper.rb
@@ -80,7 +80,7 @@ module DiscoveredHostsHelper
     # Add hidden field with taxonomy value to be updated by the form on submit
     tax_html = super
     tax_id = "#{taxonomy.to_s.downcase}_id"
-    selected_taxonomy = params[:host][tax_id]
+    selected_taxonomy = params[:host][tax_id] if params[:host]
     if @override_taxonomy && selected_taxonomy
       hidden_tax = f.hidden_field tax_id.to_sym, :value => selected_taxonomy
       tax_html += hidden_tax


### PR DESCRIPTION
When editing host, the `params[:host]` is still `nil`
