### PR TITLE
Fixes #15731 - introduced discovery_delete_facts setting

### DIFF
--- a/app/models/setting/discovered.rb
+++ b/app/models/setting/discovered.rb
@@ -17,6 +17,7 @@ class Setting::Discovered < ::Setting
     Setting.transaction do
       [
         self.set('discovery_fact', N_("Fact name to use for primary interface detection"), "discovery_bootif", N_("Interface fact")),
+        self.set('discovery_clean_facts', N_("Clean all reported facts during provisioning"), false, N_("Clean all facts")),
         self.set('discovery_hostname', N_("List of facts to use for the hostname (separated by comma, first wins)"), "discovery_bootif", N_("Hostname facts")),
         self.set('discovery_auto', N_("Automatically provision newly discovered hosts, according to the provisioning rules"), false, N_("Auto provisioning")),
         self.set('discovery_reboot', N_("Automatically reboot or kexec discovered host during provisioning"), true, N_("Reboot")),


### PR DESCRIPTION
It does not make sense not to delete them, initial facts upload will overwrite
everything. This is blocking users from using some facts in templates.
