### PR TITLE
Fixes #9306 - added missing view_* permissions

### DIFF
--- a/app/controllers/api/v2/discovered_hosts_controller.rb
+++ b/app/controllers/api/v2/discovered_hosts_controller.rb
@@ -95,10 +95,9 @@ module Api
       def facts
         state = true
         @discovered_host = Host::Discovered.import_host(params[:facts])
+        Rails.logger.warn "Discovered facts import unsuccessful, skipping auto provisioning" unless @discovered_host
         if Setting['discovery_auto'] && @discovered_host && rule = find_discovery_rule(@discovered_host)
           state = perform_auto_provision(@discovered_host, rule)
-        else
-          Rails.logger.warn "Discovered facts import unsuccessful, skipping auto provisioning"
         end
         process_response state
       rescue Exception => e

--- a/db/migrate/20160719124942_add_missing_view_permissions.rb
+++ b/db/migrate/20160719124942_add_missing_view_permissions.rb
@@ -1,0 +1,16 @@
+class AddMissingViewPermissions < ActiveRecord::Migration
+  def up
+    permissions = [
+      "view_architectures", "view_domains", "view_environments", "view_hosts",
+      "view_hostgroups", "view_media", "view_models", "view_operatingsystems",
+      "view_provisioning_templates", "view_ptables", "view_puppetclasses",
+      "view_realms", "view_smart_proxies", "view_subnets"
+    ]
+    Role.find_by_name("Discovery Reader").add_permissions!(permissions)
+    Role.find_by_name("Discovery Manager").add_permissions!(permissions + ["create_hosts"])
+  end
+
+  def down
+    # not implemented
+  end
+end

--- a/lib/foreman_discovery/engine.rb
+++ b/lib/foreman_discovery/engine.rb
@@ -103,7 +103,6 @@ module ForemanDiscovery
           :view_organizations,
           :view_locations,
           :view_hosts,
-          :view_operatingsystems,
           # discovered_hosts
           :view_discovered_hosts,
           # discovered_rules
@@ -111,8 +110,23 @@ module ForemanDiscovery
         ]
         MANAGER = READER + [
           # core permissions
+          :create_hosts,
+          :build_hosts,
           :assign_organizations,
           :assign_locations,
+          :view_architectures,
+          :view_domains,
+          :view_environments,
+          :view_hostgroups,
+          :view_media,
+          :view_models,
+          :view_operatingsystems,
+          :view_provisioning_templates,
+          :view_ptables,
+          :view_puppetclasses,
+          :view_realms,
+          :view_smart_proxies,
+          :view_subnets,
           # discovered_hosts
           :submit_discovered_hosts,
           :provision_discovered_hosts,

--- a/test/functional/discovered_hosts_controller_test.rb
+++ b/test/functional/discovered_hosts_controller_test.rb
@@ -98,13 +98,42 @@ class DiscoveredHostsControllerTest < ActionController::TestCase
     host = Host::Discovered.import_host(@facts)
     domain = FactoryGirl.create(:domain)
     hostgroup = FactoryGirl.create(:hostgroup, :with_subnet, :with_environment, :with_rootpass, :with_os, :domain => domain)
+    hostgroup.medium.organizations << host.organization
+    hostgroup.medium.locations << host.location
+    hostgroup.ptable.organizations << host.organization
+    hostgroup.ptable.locations << host.location
+    hostgroup.domain.organizations << host.organization
+    hostgroup.domain.locations << host.location
+    hostgroup.subnet.organizations << host.organization
+    hostgroup.subnet.locations << host.location
+    domain.subnets << hostgroup.subnet
     get :edit, {
       :id => host.id,
       :host => {
         :hostgroup_id => hostgroup.id
       } }, set_session_user_default_manager
-    assert_select '#host_operatingsystem_id [selected]' do |elements|
-      assert_equal hostgroup.operatingsystem.id.to_s, elements.first[:value]
+    # all inherit buttons are pressed
+    assert_select('button[name=is_overridden_btn]') do |e|
+      e.attribute("class") =~ /active/
+    end
+    # particular fields are set
+    assert_select '#host_hostgroup_id [selected]' do |e|
+      assert_equal hostgroup.id.to_s, e.first[:value]
+    end
+    assert_select '#host_architecture_id [selected]' do |e|
+      assert_equal hostgroup.architecture_id.to_s, e.first[:value]
+    end
+    assert_select '#host_operatingsystem_id [selected]' do |e|
+      assert_equal hostgroup.operatingsystem_id.to_s, e.first[:value]
+    end
+    assert_select '#host_medium_id [selected]' do |e|
+      assert_equal hostgroup.medium_id.to_s, e.first[:value]
+    end
+    assert_select '#host_ptable_id [selected]' do |e|
+      assert_equal hostgroup.ptable_id.to_s, e.first[:value]
+    end
+    assert_select '#host_interfaces_attributes_0_domain_id [selected]' do |e|
+      assert_equal hostgroup.domain_id.to_s, e.first[:value]
     end
   end
 


### PR DESCRIPTION
@orrabin reproduced a bug you reported, can you test?

When you were testing similar PR
https://github.com/theforeman/foreman_discovery/pull/252 you verified it
without need of adding the permission. But I believe the permission will not be
added automatically and we need a migration.

For this PR I needed to manually add the permission in the Role via UI to get
it working. Can you confirm? In that case, we need a migration similar to
a6826bee71d7818959aca7dbbba035fb94a8c204
