### PR TITLE
Fixes #15732 - Fixed unavailable operating system

### DIFF
--- a/app/helpers/discovered_hosts_helper.rb
+++ b/app/helpers/discovered_hosts_helper.rb
@@ -1,5 +1,4 @@
 module DiscoveredHostsHelper
-
   def attach_flags(interface)
     flags = ""
     flags += "flag-primary " if interface[:primary]

--- a/lib/foreman_discovery/engine.rb
+++ b/lib/foreman_discovery/engine.rb
@@ -26,10 +26,6 @@ module ForemanDiscovery
       end
     end
 
-    initializer 'foreman_discovery.helper' do |app|
-      ActionView::Base.send :include, DiscoveredHostsHelper
-    end
-
     initializer 'foreman_discovery.register_gettext', :after => :load_config_initializers do |app|
       locale_dir = File.join(File.expand_path('../../..', __FILE__), 'locale')
       locale_domain = 'foreman_discovery'
@@ -107,6 +103,7 @@ module ForemanDiscovery
           :view_organizations,
           :view_locations,
           :view_hosts,
+          :view_operatingsystems,
           # discovered_hosts
           :view_discovered_hosts,
           # discovered_rules
@@ -180,9 +177,6 @@ module ForemanDiscovery
 
       # Include subnet extensions
       ::Subnet.send :include, DiscoverySubnet
-
-      # Include helper for dashboard
-      ::DashboardHelper.send(:include, DiscoveredHostsHelper)
     end
 
     rake_tasks do

--- a/test/functional/discovered_hosts_controller_test.rb
+++ b/test/functional/discovered_hosts_controller_test.rb
@@ -95,19 +95,16 @@ class DiscoveredHostsControllerTest < ActionController::TestCase
   end
 
   def test_edit_form_submit_parameters
-    disable_taxonomies do
-      host = Host::Discovered.import_host(@facts)
-      domain = FactoryGirl.create(:domain)
-      hostgroup = FactoryGirl.create(:hostgroup, :with_subnet, :with_environment, :with_rootpass, :with_os, :domain => domain)
-      get :edit, {
-        :id => host.id,
-        :host => {
-          :hostgroup_id => hostgroup.id
-        } }, set_session_user_default_manager
-
-      assert_select '#host_operatingsystem_id [selected]' do |elements|
-        assert_equal hostgroup.operatingsystem.id.to_s, elements.first[:value]
-      end
+    host = Host::Discovered.import_host(@facts)
+    domain = FactoryGirl.create(:domain)
+    hostgroup = FactoryGirl.create(:hostgroup, :with_subnet, :with_environment, :with_rootpass, :with_os, :domain => domain)
+    get :edit, {
+      :id => host.id,
+      :host => {
+        :hostgroup_id => hostgroup.id
+      } }, set_session_user_default_manager
+    assert_select '#host_operatingsystem_id [selected]' do |elements|
+      assert_equal hostgroup.operatingsystem.id.to_s, elements.first[:value]
     end
   end
 


### PR DESCRIPTION
1. Added default operating system view role to discovery reader.
2. Removed unnecessary helper calls, since all helpers are added [automagically](https://github.com/rails/rails/blob/a4b5582/actionpack/lib/action_controller/metal/helpers.rb#L95)
3. Removed no taxonomies scope from the test.
