### PR TITLE
Do not run test:discovery on test rake task

### DIFF
--- a/lib/discovery.rake
+++ b/lib/discovery.rake
@@ -1,21 +1,22 @@
 # Setup Tests
 namespace :test do
   desc "Test Discovery plugin"
-  Rake::TestTask.new(:discovery) do |t|
+  Rake::TestTask.new(:foreman_discovery) do |t|
     test_dir = File.join(File.dirname(__FILE__), '..', 'test')
     t.libs << ["test",test_dir]
     t.pattern = "#{test_dir}/**/*_test.rb"
     t.verbose = true
     t.warning = false
   end
+
+  task :discovery => :foreman_discovery
 end
-Rake::Task[:test].enhance do
-  Rake::Task['test:discovery'].invoke
-end
+
+Rake::Task["test:plugins"].enhance ['test:foreman_discovery']
 
 load 'tasks/jenkins.rake'
 if Rake::Task.task_defined?(:'jenkins:unit')
   Rake::Task["jenkins:unit"].enhance do
-    Rake::Task['test:discovery'].invoke
+    Rake::Task['test:foreman_discovery'].invoke
   end
 end


### PR DESCRIPTION
Everytime I do `rake test` in core, this also runs all plugin tests. This makes
`rake test test/unit/some_test.rb` unusable.

Discovery follows generic patter for all plugins, I would like to discuss a
different possibility in this PR. For now I am removing this, but let's come up
with something better.
