### PR TITLE
Fixes #15788 - Discovery widget crashes for hosts w/o reports

### DIFF
--- a/app/helpers/discovered_hosts_helper.rb
+++ b/app/helpers/discovered_hosts_helper.rb
@@ -61,7 +61,7 @@ module DiscoveredHostsHelper
       status_glyph = 'glyphicon-plus-sign'
       status_message = _('New in the last 24 hours')
       status_color = '#89A54E'
-    elsif host.last_report < 7.days.ago
+    elsif host.last_report.present? && host.last_report < 7.days.ago
       status_glyph = 'glyphicon-exclamation-sign'
       status_message = _('Not reported in more than 7 days')
       status_color = '#AA4643'


### PR DESCRIPTION
The widget is calling 'host.last_report < 7.days.ago' - which fails with
"ActionView::Template::Error (undefined method `<' for nil:NilClass')"
if the host has no reports. This crashes the whole dashboard page.
