### PR TITLE
Fixes #15793 - quick provisioning sets build mode

### DIFF
--- a/app/controllers/discovered_hosts_controller.rb
+++ b/app/controllers/discovered_hosts_controller.rb
@@ -71,6 +71,7 @@ class DiscoveredHostsController < ::ApplicationController
 
   def perform_update(host, success_message = nil)
     Taxonomy.no_taxonomy_scope do
+      ::ForemanDiscovery::HostConverter.set_build_clean_facts(host)
       if host.save
         success_options = { :success_redirect => host_path(host), :redirect_xhr => request.xhr? }
         success_options[:success_msg] = success_message if success_message

--- a/app/models/setting/discovered.rb
+++ b/app/models/setting/discovered.rb
@@ -17,7 +17,7 @@ class Setting::Discovered < ::Setting
     Setting.transaction do
       [
         self.set('discovery_fact', N_("Fact name to use for primary interface detection"), "discovery_bootif", N_("Interface fact")),
-        self.set('discovery_clean_facts', N_("Clean all reported facts during provisioning"), false, N_("Clean all facts")),
+        self.set('discovery_clean_facts', N_("Clean all reported facts during provisioning (except discovery facts)"), false, N_("Clean all facts")),
         self.set('discovery_hostname', N_("List of facts to use for the hostname (separated by comma, first wins)"), "discovery_bootif", N_("Hostname facts")),
         self.set('discovery_auto', N_("Automatically provision newly discovered hosts, according to the provisioning rules"), false, N_("Auto provisioning")),
         self.set('discovery_reboot', N_("Automatically reboot or kexec discovered host during provisioning"), true, N_("Reboot")),

--- a/test/functional/api/v2/discovered_hosts_controller_test.rb
+++ b/test/functional/api/v2/discovered_hosts_controller_test.rb
@@ -96,6 +96,8 @@ class Api::V2::DiscoveredHostsControllerTest < ActionController::TestCase
                        :organizations => [host.organization], :locations => [host.location])
     post :auto_provision, { :id => host.id }
     assert_match /Host #{host.name} was provisioned with rule #{rule.name}/, @response.body
+    managed_host = Host.find(host.id)
+    assert managed_host.build
     assert_response :success
   end
 
@@ -109,6 +111,8 @@ class Api::V2::DiscoveredHostsControllerTest < ActionController::TestCase
                        :organizations => [host.organization], :locations => [host.location])
     post :auto_provision, { :id => host.id }
     assert_match /Host #{host.name} was provisioned with rule #{rule.name}/, @response.body
+    managed_host = Host.find(host.id)
+    assert managed_host.build
     assert_response :success
   end
 
@@ -174,6 +178,8 @@ class Api::V2::DiscoveredHostsControllerTest < ActionController::TestCase
                        :locations => [host.location])
     post :auto_provision_all, {}
     assert_match /1 discovered hosts were provisioned/, @response.body
+    managed_host = Host.find(host.id)
+    assert managed_host.build
     assert_response :success
   end
 

--- a/test/functional/discovered_hosts_controller_test.rb
+++ b/test/functional/discovered_hosts_controller_test.rb
@@ -87,9 +87,10 @@ class DiscoveredHostsControllerTest < ActionController::TestCase
           :hostgroup_id => hostgroup.id
         } }, set_session_user_default_manager
 
-      actual_host = Host.find(host.id)
-      assert_redirected_to host_url(actual_host)
-      assert_equal hostgroup.id, actual_host.hostgroup_id
+      managed_host = Host.find(host.id)
+      assert managed_host.build
+      assert_redirected_to host_url(managed_host)
+      assert_equal hostgroup.id, managed_host.hostgroup_id
       assert_match /Successfully/, flash[:notice]
     end
   end

--- a/test/unit/host_discovered_test.rb
+++ b/test/unit/host_discovered_test.rb
@@ -235,33 +235,33 @@ class HostDiscoveredTest < ActiveSupport::TestCase
     assert Token.where(:host_id => h.id).empty?
   end
 
-  test "discovery facts are deleted after provisioning when set by user" do
+  test "all non-discovery facts are deleted after provisioning" do
     Setting[:discovery_clean_facts] = true
     raw = parse_json_fixture('/facts.json')['facts']
     raw.merge!({
       'delete_me' => "content",
-      'discovery_delete_me_as_well' => "content",
+      'discovery_keep_me' => "content",
       })
     host = Host::Discovered.import_host(raw)
     host.save
     managed = ::ForemanDiscovery::HostConverter.to_managed(host)
     managed.clear_facts
     assert_nil managed.facts_hash['delete_me']
-    assert_nil managed.facts_hash['discovery_delete_me_as_well']
+    assert_equal "content", managed.facts_hash['discovery_keep_me']
   end
 
-  test "discovery facts are preserved after provisioning" do
+  test "all facts are preserved after provisioning" do
     raw = parse_json_fixture('/facts.json')['facts']
     raw.merge!({
-      'delete_me' => "content",
-      'discovery_dont_delete_me' => "content",
+      'keep_me' => "content",
+      'discovery_keep_me' => "content",
       })
     host = Host::Discovered.import_host(raw)
     host.save
     managed = ::ForemanDiscovery::HostConverter.to_managed(host)
     managed.clear_facts
-    assert_nil managed.facts_hash['delete_me']
-    assert_equal "content", managed.facts_hash['discovery_dont_delete_me']
+    assert_equal "content", managed.facts_hash['keep_me']
+    assert_equal "content", managed.facts_hash['discovery_keep_me']
   end
 
   test "normalization of MAC into a discovered host hostname" do


### PR DESCRIPTION
Regression introduced by our modal dialog.

Needed for successful testing of

https://github.com/theforeman/foreman_discovery/pull/226
