### PR TITLE
Fixes #15873 - taxonomy fixed for provisioning test

### DIFF
--- a/test/functional/discovered_hosts_controller_test.rb
+++ b/test/functional/discovered_hosts_controller_test.rb
@@ -98,7 +98,7 @@ class DiscoveredHostsControllerTest < ActionController::TestCase
   def test_edit_form_submit_parameters
     host = Host::Discovered.import_host(@facts)
     domain = FactoryGirl.create(:domain)
-    hostgroup = FactoryGirl.create(:hostgroup, :with_subnet, :with_environment, :with_rootpass, :with_os, :domain => domain)
+    hostgroup = FactoryGirl.create(:hostgroup, :with_subnet, :with_environment, :with_rootpass, :with_os, :domain => domain, :organizations => [host.organization], :locations => [host.location])
     hostgroup.medium.organizations << host.organization
     hostgroup.medium.locations << host.location
     hostgroup.ptable.organizations << host.organization


### PR DESCRIPTION
And one more to have all tests green @dLobato thanks.

In order to test that, you need to revert
755b23aad215d5dddf90b7570a84f2bcb3de52f1 which is not compatible with 1.12
version. I will do that in stable 6.0 branch once I branch when this is merged.
