### PR TITLE
Refs #12634 - PXEGrub 1 and 2 are locked too

### DIFF
--- a/app/models/setting/discovered.rb
+++ b/app/models/setting/discovered.rb
@@ -30,7 +30,9 @@ class Setting::Discovered < ::Setting
         self.set('discovery_facts_network', N_("Regex to organize facts for network section"), "", N_("Network facts")),
         self.set('discovery_facts_ipmi', N_("Regex to organize facts for ipmi section"), "", N_("IPMI facts")),
         self.set('discovery_lock', N_("Automatically generate PXE configuration to pin a newly discovered host to discovery"), false, N_("Lock PXE")),
-        self.set('discovery_lock_template', N_("PXE template to be used when pinning a host to discovery"), 'pxelinux_discovery', N_("Locked template name"),nil,{ :collection => Proc.new {Hash[ProvisioningTemplate.all.map{|template| [template[:name], template[:name]]}]} }),
+        self.set('discovery_pxelinux_lock_template', N_("PXELinux template to be used when pinning a host to discovery"), 'pxelinux_discovery', N_("Locked PXELinux template name"), nil, { :collection => Proc.new {Hash[ProvisioningTemplate.where(:template_kind => TemplateKind.find_by_name(:snippet)).map{|template| [template[:name], template[:name]]}]} }),
+        self.set('discovery_pxegrub_lock_template', N_("PXEGrub template to be used when pinning a host to discovery"), 'pxegrub_discovery', N_("Locked PXEGrub template name"), nil, { :collection => Proc.new {Hash[ProvisioningTemplate.where(:template_kind => TemplateKind.find_by_name(:snippet)).map{|template| [template[:name], template[:name]]}]} }),
+        self.set('discovery_pxegrub2_lock_template', N_("PXEGrub2 template to be used when pinning a host to discovery"), 'pxegrub2_discovery', N_("Locked PXEGrub2 template name"), nil, { :collection => Proc.new {Hash[ProvisioningTemplate.where(:template_kind => TemplateKind.find_by_name(:snippet)).map{|template| [template[:name], template[:name]]}]} }),
         self.set('discovery_always_rebuild_dns', N_("Force DNS entries creation when provisioning discovered host"), true, N_("Force DNS")),
       ].compact.each { |s| self.create s.update(:category => "Setting::Discovered")}
     end
@@ -64,7 +66,7 @@ class Setting::Discovered < ::Setting
   end
 
   def self.discovery_lock?
-    Foreman::Cast.to_bool(Setting['discovery_lock']) && !Setting['discovery_lock_template'].blank? && ProvisioningTemplate.exists?(:name => Setting['discovery_lock_template'])
+    Foreman::Cast.to_bool(Setting['discovery_lock'])
   end
 
   def self.from_array(setting)

--- a/db/migrate/20160805104605_rename_lock_template_setting.rb
+++ b/db/migrate/20160805104605_rename_lock_template_setting.rb
@@ -1,0 +1,14 @@
+class RenameLockTemplateSetting < ActiveRecord::Migration
+  def change
+    reversible do |dir|
+      dir.up do
+        setting = Setting.find_by_name("discovery_lock_template")
+        setting.destroy if setting
+      end
+      dir.down do
+        setting = Setting.find_by_name("discovery_pxelinux_lock_template")
+        setting.destroy if setting
+      end
+    end
+  end
+end

--- a/test/functional/api/v2/discovered_hosts_controller_test.rb
+++ b/test/functional/api/v2/discovered_hosts_controller_test.rb
@@ -23,30 +23,7 @@ class Api::V2::DiscoveredHostsControllerTest < ActionController::TestCase
       "memorysize_mb"     => "42000.42",
       "discovery_version" => "3.0.0",
     }
-    FactoryGirl.create(:setting,
-                       :name => 'discovery_auto',
-                       :value => true,
-                       :category => 'Setting::Discovered')
-    FactoryGirl.create(:setting,
-                       :name => 'discovery_reboot',
-                       :value => true,
-                       :category => 'Setting::Discovered')
-    FactoryGirl.create(:setting,
-                       :name => 'discovery_hostname',
-                       :value => 'discovery_bootif',
-                       :category => 'Setting::Discovered')
-    FactoryGirl.create(:setting,
-                       :name => 'discovery_prefix',
-                       :value => 'mac',
-                       :category => 'Setting::Discovered')
-    FactoryGirl.create(:setting,
-                       :name => 'discovery_organization',
-                       :value => Organization.first.name,
-                       :category => 'Setting::Discovered')
-    FactoryGirl.create(:setting,
-                       :name => 'discovery_location',
-                       :value => Location.first.name,
-                       :category => 'Setting::Discovered')
+    set_default_settings
     ::ForemanDiscovery::NodeAPI::PowerService.any_instance.stubs(:reboot).returns(true)
   end
 

--- a/test/functional/api/v2/discovery_rules_controller_test.rb
+++ b/test/functional/api/v2/discovery_rules_controller_test.rb
@@ -3,15 +3,7 @@ require 'test_helper'
 class Api::V2::DiscoveryRulesControllerTest < ActionController::TestCase
   setup do
     User.current = User.find_by_login "admin"
-
-    FactoryGirl.create(:setting,
-                       :name => 'discovery_hostname',
-                       :value => 'discovery_bootif',
-                       :category => 'Setting::Discovered')
-    FactoryGirl.create(:setting,
-                       :name => 'discovery_prefix',
-                       :value => 'mac',
-                       :category => 'Setting::Discovered')
+    set_default_settings
   end
 
   test "should get index" do

--- a/test/functional/discovered_hosts_controller_test.rb
+++ b/test/functional/discovered_hosts_controller_test.rb
@@ -15,22 +15,7 @@ class DiscoveredHostsControllerTest < ActionController::TestCase
       "physicalprocessorcount" => "42",
       "discovery_version"      => "3.0.0",
     }
-    FactoryGirl.create(:setting,
-                       :name => 'discovery_always_rebuild_dns',
-                       :value => true,
-                       :category => 'Setting::Discovered')
-    FactoryGirl.create(:setting,
-                       :name => 'discovery_reboot',
-                       :value => true,
-                       :category => 'Setting::Discovered')
-    FactoryGirl.create(:setting,
-                       :name => 'discovery_hostname',
-                       :value => 'discovery_bootif',
-                       :category => 'Setting::Discovered')
-    FactoryGirl.create(:setting,
-                       :name => 'discovery_prefix',
-                       :value => 'mac',
-                       :category => 'Setting::Discovered')
+    set_default_settings
     ::ForemanDiscovery::NodeAPI::PowerService.any_instance.stubs(:reboot).returns(true)
   end
 

--- a/test/test_helper_discovery.rb
+++ b/test/test_helper_discovery.rb
@@ -26,3 +26,20 @@ end
 def extract_form_errors(response)
   response.body.scan(/error-message[^<]*</)
 end
+
+def set_default_settings
+  FactoryGirl.create(:setting, :name => 'discovery_fact', :value => 'discovery_bootif', :category => 'Setting::Discovered')
+  FactoryGirl.create(:setting, :name => 'discovery_hostname', :value => 'discovery_bootif', :category => 'Setting::Discovered')
+  FactoryGirl.create(:setting, :name => 'discovery_auto', :value => true, :category => 'Setting::Discovered')
+  FactoryGirl.create(:setting, :name => 'discovery_reboot', :value => true, :category => 'Setting::Discovered')
+  FactoryGirl.create(:setting, :name => 'discovery_organization', :value => Organization.first.name, :category => 'Setting::Discovered')
+  FactoryGirl.create(:setting, :name => 'discovery_location', :value => Location.first.name, :category => 'Setting::Discovered')
+  FactoryGirl.create(:setting, :name => 'discovery_prefix', :value => 'mac', :category => 'Setting::Discovered')
+  FactoryGirl.create(:setting, :name => 'discovery_clean_facts', :value => false, :category => 'Setting::Discovered')
+  FactoryGirl.create(:setting, :name => 'discovery_lock', :value => 'false', :category => 'Setting::Discovered')
+  FactoryGirl.create(:setting, :name => 'discovery_lock_template', :value => 'pxelinux_discovery', :category => 'Setting::Discovered')
+  FactoryGirl.create(:setting, :name => 'discovery_pxelinux_lock_template', :value => 'pxelinux_discovery', :category => 'Setting::Discovered')
+  FactoryGirl.create(:setting, :name => 'discovery_pxegrub_lock_template', :value => 'pxegrub_discovery', :category => 'Setting::Discovered')
+  FactoryGirl.create(:setting, :name => 'discovery_pxegrub2_lock_template', :value => 'pxegrub2_discovery', :category => 'Setting::Discovered')
+  FactoryGirl.create(:setting, :name => 'discovery_always_rebuild_dns', :value => true, :category => 'Setting::Discovered')
+end

--- a/test/unit/discovered_extensions_test.rb
+++ b/test/unit/discovered_extensions_test.rb
@@ -11,15 +11,7 @@ class FindDiscoveryRulesTest < ActiveSupport::TestCase
       "macaddress_eth0"  => "AA:BB:CC:DD:EE:FF",
       "discovery_bootif" => "AA:BB:CC:DD:EE:FF",
     }
-
-    FactoryGirl.create(:setting,
-                       :name => 'discovery_hostname',
-                       :value => 'discovery_bootif',
-                       :category => 'Setting::Discovered')
-    FactoryGirl.create(:setting,
-                       :name => 'discovery_prefix',
-                       :value => 'mac',
-                       :category => 'Setting::Discovered')
+    set_default_settings
   end
 
   test "no rule is found for empty rule set" do

--- a/test/unit/discovery_taxonomy_extensions_test.rb
+++ b/test/unit/discovery_taxonomy_extensions_test.rb
@@ -2,14 +2,7 @@ require 'test_helper'
 
 class DiscoveryTaxonomyExtensionsTest < ActiveSupport::TestCase
   setup do
-    FactoryGirl.create(:setting,
-                       :name => 'discovery_hostname',
-                       :value => 'discovery_bootif',
-                       :category => 'Setting::Discovered')
-    FactoryGirl.create(:setting,
-                       :name => 'discovery_prefix',
-                       :value => 'mac',
-                       :category => 'Setting::Discovered')
+    set_default_settings
   end
 
   test 'deleting location does not hard fail if there is associated discovered host' do


### PR DESCRIPTION
When https://github.com/theforeman/foreman/pull/3679 is merged, discovery will
no longer work when Lock PXE setting is turned on. This fixes it.
