### PR TITLE
Fixes #16081 - FactValue returns value for .host

### DIFF
--- a/app/models/concerns/fact_value_extensions.rb
+++ b/app/models/concerns/fact_value_extensions.rb
@@ -4,5 +4,10 @@ module FactValueExtensions
   included do
     belongs_to :discovered_host, :class_name => "Host::Discovered", :foreign_key => :host_id
     scoped_search :in => :discovered_host, :on => :id, :complete_enabled => false, :only_explicit => true, :rename => :discovered_host
+
+    def host
+      return discovered_host if discovered_host.present?
+      super
+    end
   end
 end

--- a/test/factories/discovery_rule_related.rb
+++ b/test/factories/discovery_rule_related.rb
@@ -10,12 +10,29 @@ FactoryGirl.define do
   end
 end
 
-# Not used yet, we need to refactor core first
 FactoryGirl.define do
   factory :discovered_host, class: 'Host::Discovered' do
     sequence(:name) { |n| "host#{n}" }
     sequence(:ip)   { |n| IPAddr.new(n, Socket::AF_INET).to_s }
     sequence(:mac)  { |n| "02:23:45:67:" + n.to_s(16).rjust(4, '0').insert(2, ':') }
-    fact_values
+
+    after(:build) do |discovered_host|
+      attribute_set = DiscoveryAttributeSet.new(:host => discovered_host,
+                                                :memory => '1',
+                                                :cpu_count => '4')
+      discovered_host.discovery_attribute_set = attribute_set
+    end
+
+    trait :with_facts do
+      transient do
+        fact_count 20
+      end
+
+      after(:create) do |discovered_host, evaluator|
+        evaluator.fact_count.times do
+          FactoryGirl.create(:fact_value, :discovered_host => discovered_host)
+        end
+      end
+    end
   end
 end

--- a/test/unit/fact_value_extensions_test.rb
+++ b/test/unit/fact_value_extensions_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class FactValueExtensionsTest < ActiveSupport::TestCase
+  describe '.host' do
+    test 'returns discovered_host' do
+      discovered_host = FactoryGirl.create(:discovered_host, :with_facts, :fact_count => 1)
+      fact_value = discovered_host.fact_values.first
+      assert fact_value.discovered_host, fact_value.host
+    end
+  end
+end


### PR DESCRIPTION
The /fact_values page in Foreman has a helper that expects
fact_value.host at several places:

app/helpers/fact_values_helper.rb#L18
app/helpers/fact_values_helper.rb#L29

However, fact values for discovered hosts will not respond to that
method.
You can call fact_value.host_id just fine, but not fact_value.host.

That causes a 500 on any /fact_values page that needs to show discovered
hosts facts
