### PR TITLE
Added missing auto-provisioning asserts

### DIFF
--- a/test/unit/discovered_extensions_test.rb
+++ b/test/unit/discovered_extensions_test.rb
@@ -181,6 +181,8 @@ class FindDiscoveryRulesTest < ActiveSupport::TestCase
     assert managed_host = perform_auto_provision(host, r1)
     assert_empty managed_host.errors
     assert_equal hostgroup.environment, managed_host.environment
+    assert_equal hostgroup.puppet_proxy, managed_host.puppet_proxy
+    assert_equal hostgroup.puppet_ca_proxy, managed_host.puppet_ca_proxy
   end
 
   def setup_normal_renderer


### PR DESCRIPTION
The test was actually not stressing puppet and ca flags, environment which is
tested is actually not INHERIT enhanced.
