### PR TITLE
Fixes #16750 - *_selected methods expect params[:host]

### DIFF
--- a/app/controllers/foreman_discovery/concerns/hosts_controller_extensions.rb
+++ b/app/controllers/foreman_discovery/concerns/hosts_controller_extensions.rb
@@ -1,0 +1,18 @@
+module ForemanDiscovery
+  module Concerns
+    module HostsControllerExtensions
+      extend ActiveSupport::Concern
+      included do
+        before_action :set_discovered_params
+      end
+
+      # Change params to what the hosts controller expects. Certain methods
+      # in the hosts controller like all the _selected methods, taxonomy_scope,
+      # etc.. expect a params[:host] to work.
+      def set_discovered_params
+        return unless request.path.match(/discovered_hosts/).present?
+        params[:host] ||= params[:discovered_host]
+      end
+    end
+  end
+end

--- a/lib/foreman_discovery/engine.rb
+++ b/lib/foreman_discovery/engine.rb
@@ -8,6 +8,7 @@ module ForemanDiscovery
   class Engine < ::Rails::Engine
 
     # support pre-4 Rails versions
+    config.autoload_paths += Dir["#{config.root}/app/controllers/foreman_discovery/concerns"]
     config.autoload_paths += Dir["#{config.root}/app/controllers/concerns"]
     config.autoload_paths += Dir["#{config.root}/app/helpers/concerns"]
     config.autoload_paths += Dir["#{config.root}/app/models/concerns"]
@@ -200,6 +201,7 @@ module ForemanDiscovery
       ::Nic::Managed.send :include, Nic::ManagedExtensions
 
       # Controller extensions
+      ::HostsController.send :include, ForemanDiscovery::Concerns::HostsControllerExtensions
       ::Api::V2::FactValuesController.send :include, Api::V2::FactValuesControllerExtensions
     end
 

--- a/test/functional/foreman_discovery/concerns/hosts_controller_extensions_test.rb
+++ b/test/functional/foreman_discovery/concerns/hosts_controller_extensions_test.rb
@@ -1,0 +1,25 @@
+require 'test_plugin_helper'
+require 'test_helper_discovery'
+
+module ForemanDiscovery
+  module Concerns
+    class HostsControllerTest < ActionController::TestCase
+      tests ::HostsController
+
+      context 'hosts controller requests from discovered_hosts url' do
+        test 'get "host" params from "discovered_hosts" params' do
+          architecture = FactoryGirl.create(:architecture)
+          discovered_host_params = {
+            'discovered_host' => { 'architecture_id' => architecture.id }
+          }
+
+          @request.stubs(:path).
+            returns(architecture_selected_discovered_hosts_path)
+
+          post :architecture_selected, discovered_host_params, set_session_user
+          assert assigns('architecture'), architecture
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Due to the strong params changes, the methods we override in routes.rb
(architecture_selected, os_selected, medium_selected) do not longer
work.

The reason is that these *_selected methods expect params[:host] to
exist. Other methods like 'taxonomy_scope' also expect params[:host] to
exist.

However, 'discovered_hosts/edit' sends params[:discovered_host], which
is not understood by the HostController.

The discovery plugin should realize that these params will not be
understood by HostController and change them appropriately.

---

This patch merely checks the URL and if it matches 'discovered_hosts' in
some place, it will also set params[:host].
