### PR TITLE
Fixes #15548 - Discovered host supports template methods

### DIFF
--- a/app/models/host/discovered.rb
+++ b/app/models/host/discovered.rb
@@ -2,6 +2,7 @@ class Host::Discovered < ::Host::Base
   include ScopedSearchExtensions
   include Foreman::Renderer
   include BelongsToProxies
+  include ::Hostext::OperatingSystem
 
   belongs_to :hostgroup
   has_one    :discovery_attribute_set, :foreign_key => :host_id, :dependent => :destroy


### PR DESCRIPTION
Mixes in Hostext::OperatingSystem from core, so that the methods used to
resolve what templates belong to a Host, can be used in Discovered::Host
too.

This fixes the 'Resolve' button on the provision discovered host form.
