### PR TITLE
Fixes #16528 - Added foreign key dependency

### DIFF
--- a/db/migrate/20161006094714_add_constraints_on_subnets_smart_proxies.rb
+++ b/db/migrate/20161006094714_add_constraints_on_subnets_smart_proxies.rb
@@ -1,0 +1,17 @@
+class AddConstraintsOnSubnetsSmartProxies < ActiveRecord::Migration
+  def change
+    # turn off Foreign Key checks
+    if ActiveRecord::Base.connection.adapter_name == 'PostgreSQL'
+      ActiveRecord::Migration.execute "SET CONSTRAINTS ALL DEFERRED;"
+    elsif ActiveRecord::Base.connection.adapter_name.downcase.starts_with? 'mysql'
+      ActiveRecord::Migration.execute "SET FOREIGN_KEY_CHECKS=0;"
+    end
+
+    add_foreign_key "subnets", "smart_proxies", :name => "subnets_discovery_id_fk", :column => "discovery_id"
+    
+    # turn on Foreign Key checks in MySQL only
+    if ActiveRecord::Base.connection.adapter_name.downcase.starts_with? 'mysql'
+      ActiveRecord::Migration.execute "SET FOREIGN_KEY_CHECKS=1;"
+    end
+  end
+end


### PR DESCRIPTION
In foreman db, there is a missing key constraint from subnet.discovery_id to smart_proxies.id. That means, if a subnet refers a Discovery Capsule and I delete the capsule/proxy, no warning is raised.

Add a key constraint similar to e.g. "subnet.tftp_id -> smart_proxies.id".
