### PR TITLE
Fixes #17260 - remove managed flag before deleting

### DIFF
--- a/app/models/host/discovered.rb
+++ b/app/models/host/discovered.rb
@@ -30,6 +30,10 @@ class Host::Discovered < ::Host::Base
     where(taxonomy_conditions).order("hosts.created_at DESC")
   }
 
+  before_destroy { |record|
+    record.update_attribute(:managed, false)
+  }
+
   def self.import_host facts
     raise(::Foreman::Exception.new(N_("Invalid facts, must be a Hash"))) unless facts.is_a?(Hash)
 


### PR DESCRIPTION
Users are reporting "broken" discovered hosts, they are of type "Discovered",
but managed flag is set to true. This must be caused when host fails
provisioning at some point. We had transactions, but removed them since they
were not working with other plugins correctly.

This does not change the root cause, I am still searching how this was
possible, but I would like to create a short-term patch to allow deletion of
these hosts.