### PR TITLE
Fixes #17585 - moved permission migration after override

### DIFF
--- a/db/migrate/20160719124942_add_missing_view_permissions.rb
+++ b/db/migrate/20160719124942_add_missing_view_permissions.rb
@@ -1,18 +1,9 @@
 class AddMissingViewPermissions < ActiveRecord::Migration
   def up
-    permissions = [
-      "view_architectures", "view_domains", "view_environments", "view_hosts",
-      "view_hostgroups", "view_media", "view_models", "view_operatingsystems",
-      "view_provisioning_templates", "view_ptables", "view_puppetclasses",
-      "view_realms", "view_smart_proxies", "view_subnets"
-    ]
-    role = Role.find_by_name("Discovery Reader")
-    role.add_permissions!(permissions) if role
-    role = Role.find_by_name("Discovery Manager")
-    role.add_permissions!(permissions + ["create_hosts"]) if role
+    # migration renamed to db/migrate/20160818091421_add_missing_view_permissions2.rb
   end
 
   def down
-    # not implemented
+    # migration renamed to db/migrate/20160818091421_add_missing_view_permissions2.rb
   end
 end

--- a/db/migrate/20160818091421_add_permissions_from_default_roles.rb
+++ b/db/migrate/20160818091421_add_permissions_from_default_roles.rb
@@ -1,0 +1,15 @@
+class AddPermissionsFromDefaultRoles < ActiveRecord::Migration
+  def up
+    default_permissions = Foreman::Plugin.find("foreman_discovery").default_roles
+    ["Discovery Reader", "Discovery Manager"].each do |role_name|
+      role = Role.find_by_name(role_name) || next
+      default_permissions[role_name].each do |permission|
+        role.add_permissions!(permission) unless role.permission_names.include?(permission.to_sym)
+      end
+    end
+  end
+
+  def down
+    # not implemented
+  end
+end


### PR DESCRIPTION
When upgrading Foreman from 1.11 to 1.13, this migration fails with.

```
undefined method `override=' for #<Filter:0x0000000e6f82c8>/opt/rh/sclo-ror42/root/usr/share/gems/gems/activemodel-4.2.5.1/lib/active_model/attribute_methods.rb:433:in `method_missing'
/usr/share/foreman/app/models/filter.rb:216:in `enforce_override_flag'
```

This patch makes sure the migration is triggered *after* the one in core that
is causing this (adding the override flag):

    db/migrate/20160818091420_add_override_flag_to_filter.rb

I considered using fake objects but it's quite complex code for this one and it
is not worth the effort (for an example see https://github.com/theforeman/foreman/blob/develop/db/migrate/20140219183343_migrate_permissions.rb - I'd need to implement all of these).

This will cause the migration to occur twice basically, but it is idempotent.
The permissions API no longer adds duplicities.