### PR TITLE
Fixes #17648 - Added support for attributes inheritance

### DIFF
--- a/app/controllers/api/v2/discovered_hosts_controller.rb
+++ b/app/controllers/api/v2/discovered_hosts_controller.rb
@@ -77,9 +77,9 @@ module Api
       end
 
       def update
-        @host = ::ForemanDiscovery::HostConverter.to_managed(@discovered_host)
+        @host = ::ForemanDiscovery::HostConverter.to_managed(@discovered_host, true, true, discovered_host_params)
         forward_request_url
-        update_response = @host.update_attributes(discovered_host_params)
+        update_response = @host.save
         process_response update_response
       end
 

--- a/app/controllers/discovered_hosts_controller.rb
+++ b/app/controllers/discovered_hosts_controller.rb
@@ -50,9 +50,7 @@ class DiscoveredHostsController < ::ApplicationController
   end
 
   def edit
-    @host = ::ForemanDiscovery::HostConverter.to_managed(@host, true, false) unless @host.nil?
-    @host.attributes = @host.apply_inherited_attributes(discovered_host_params_host) unless discovered_host_params_host.empty?
-    @host.set_hostgroup_defaults
+    @host = ::ForemanDiscovery::HostConverter.to_managed(@host, true, false, discovered_host_params_host) unless @host.nil?
     setup_host_class_variables(@host)
     @override_taxonomy = true
     if params[:quick_submit]
@@ -63,9 +61,8 @@ class DiscoveredHostsController < ::ApplicationController
   end
 
   def update
-    @host = ::ForemanDiscovery::HostConverter.to_managed(@host)
+    @host = ::ForemanDiscovery::HostConverter.to_managed(@host, true, true, discovered_host_params_host)
     forward_url_options
-    @host.attributes = discovered_host_params_host
 
     perform_update(@host)
   end

--- a/app/services/foreman_discovery/host_converter.rb
+++ b/app/services/foreman_discovery/host_converter.rb
@@ -3,9 +3,13 @@ class ForemanDiscovery::HostConverter
   # Converts discovered host to managed host without uptading the database.
   # Record must be saved explicitly (using save! or update_attributes! or similar).
   # Creates shallow copy.
-  def self.to_managed(original_host, set_managed = true, set_build = true)
+  def self.to_managed(original_host, set_managed = true, set_build = true, added_attributes = {})
     host = original_host.becomes(::Host::Managed)
     host.type = 'Host::Managed'
+
+    host.attributes = host.apply_inherited_attributes(added_attributes)
+    host.set_hostgroup_defaults if host.hostgroup_id.present?
+
     # the following flags can be skipped when parameters are set to false
     if set_managed
       host.managed = set_managed


### PR DESCRIPTION
Changed HostConverter.to_managed to automatically call attribute inheritance mechanism when a new set of attributes is introduced.