### PR TITLE
fixes #17873 - clear association cache when converting host

### DIFF
--- a/app/services/foreman_discovery/host_converter.rb
+++ b/app/services/foreman_discovery/host_converter.rb
@@ -5,6 +5,7 @@ class ForemanDiscovery::HostConverter
   # Creates shallow copy.
   def self.to_managed(original_host, set_managed = true, set_build = true)
     host = original_host.becomes(::Host::Managed)
+    host.clear_association_cache
     host.type = 'Host::Managed'
     # the following flags can be skipped when parameters are set to false
     if set_managed


### PR DESCRIPTION
I thought I had seen everything, but this really takes the cake.
Details on the issue, to cut it short:

When rendering foreman_url for the PXELinux templates in some cases:

```ruby
proxy = @host.try(:subnet).try(:tftp)
```
and
```ruby
primary_interface = @host.try(:interfaces).try(:find) {|i| i.primary? }
proxy = primary_interface.try(:subnet).try(:tftp)
```

should return the same, but they don't. This is, because the subnet through primary interface association is not up to date.

I wasn't able to come up with a test for this. Suggestions welcome.