### PR TITLE
Fixes #16890 - prevent discovery of managed hosts

### DIFF
--- a/test/unit/host_discovered_test.rb
+++ b/test/unit/host_discovered_test.rb
@@ -121,6 +121,15 @@ class HostDiscoveredTest < ActiveSupport::TestCase
     assert_match(/Unable to detect primary interface using MAC/, exception.message)
   end
 
+  test "should not create discovered host when managed host exists" do
+    FactoryGirl.create(:host, :mac => 'E4:1F:13:CC:36:58')
+    raw = parse_json_fixture('/facts.json')
+    exception = assert_raises(::Foreman::Exception) do
+      Host::Discovered.import_host(raw['facts'])
+    end
+    assert_match(/Host already exists as managed/, exception.message)
+  end
+
   test "should create discovered host with prefix" do
     raw = parse_json_fixture('/facts.json')
     Setting[:discovery_prefix] = 'test'


### PR DESCRIPTION
Users were reporting inconsistent records, I implemented dirty workaround the other day:

https://github.com/theforeman/foreman_discovery/pull/311

Now I found the root cause finally, when existing (managed) host was there,
discovery process treated it as discovered host and made some changes
incorrecty. This patch prevents that, adds a test and removes the dirty
workaround.