### PR TITLE
Fixes #18106 - include host common filters

### DIFF
--- a/app/controllers/concerns/foreman/controller/parameters/discovered_host.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/discovered_host.rb
@@ -1,6 +1,7 @@
 module Foreman::Controller::Parameters::DiscoveredHost
   extend ActiveSupport::Concern
   include Foreman::Controller::Parameters::HostBase
+  include Foreman::Controller::Parameters::HostCommon
 
   class_methods do
     def discovered_host_params_filter
@@ -8,6 +9,7 @@ module Foreman::Controller::Parameters::DiscoveredHost
         filter.permit :discovery_rule_id
 
         add_host_base_params_filter(filter)
+        add_host_common_params_filter(filter)
       end
     end
   end


### PR DESCRIPTION
Host common filters were removed due to

http://projects.theforeman.org/issues/17706

but proper fix was to include the `BelongsToProxies` concern. This was done in

http://projects.theforeman.org/issues/16722

So in this patch I am putting the filters back. Katello plugin and facet
building mechanism needs to access attributes.