### PR TITLE
Fixes #18791 - ActiveModel::ForbiddenAttributesError fixed

### DIFF
--- a/app/services/foreman_discovery/host_converter.rb
+++ b/app/services/foreman_discovery/host_converter.rb
@@ -8,7 +8,7 @@ class ForemanDiscovery::HostConverter
     host.clear_association_cache
     host.type = 'Host::Managed'
 
-    host.attributes = host.apply_inherited_attributes(added_attributes)
+    host.attributes = host.apply_inherited_attributes(added_attributes.to_h)
     host.set_hostgroup_defaults if host.hostgroup_id.present?
 
     # the following flags can be skipped when parameters are set to false


### PR DESCRIPTION
When Katello is installed, calling `apply_inherited_attributes` adds extra
field `content_facet_attributes` which is not permitted for hosts. I think we
should permit it in core, as a whole hash, because this parameter is created in
runtime. This patch is a quick and dirty solution that solves blocking issue
that is in 8.0.0 and 8.0.1 releases - provisioning do not work at all with
Katello plugin installed.

Example how it looks like when added_attributes is {"hostgroup_id"=>"1",
"location_id"=>"2", "organization_id"=>"1"}. Then apply_inherited_attributes
returns {"hostgroup_id"=>"1", "location_id"=>"2", "organization_id"=>"1",
"puppet_proxy_id"=>1, "puppet_ca_proxy_id"=>1, "environment_id"=>1,
"compute_profile_id"=>nil, "realm_id"=>nil,
"content_facet_attributes"=>{"kickstart_repository_id"=>nil,
"content_view_id"=>2, "lifecycle_environment_id"=>2, "content_source_id"=>nil}}