### PR TITLE
Refs #18801 - append example extra options to kexec

### DIFF
--- a/app/views/foreman_discovery/debian_kexec.erb
+++ b/app/views/foreman_discovery/debian_kexec.erb
@@ -8,9 +8,13 @@ oses:
 <%#
 This template is used to pass command line options to kexec when reloading
 kernel on a discovered host instead of rebooting. This is useful in PXE-less
-environments. The template must generate JSON format with three items:
-"kernel", "initram" and "append". Read kexec(8) man page for more
-information about semantics.
+environments. The template must generate JSON format with the following items
+"kernel", "initram", "append" and "extra". The kexec command is composed in
+the following way:
+
+kexec --force --reset-vga --append=$append --initrd=$initram $extra $kernel
+
+Please read kexec(8) man page for more information about semantics.
 -%>
 <%
   mac = @host.facts['discovery_bootif']
@@ -29,5 +33,6 @@ information about semantics.
 {
   "kernel": "<%= @kexec_kernel %>",
   "initram": "<%= @kexec_initrd %>",
-  "append": "url=<%= foreman_url('provision') + "&static=yes" %> interface=<%= mac %> netcfg/get_ipaddress=<%= ip %> netcfg/get_netmask=<%= mask %> netcfg/get_gateway=<%= gw %> netcfg/get_nameservers=<%= dns %> netcfg/disable_dhcp=true netcfg/get_hostname=<%= @host.name %> BOOTIF=<%= bootif %> <%= options.join(' ') %>"
+  "append": "url=<%= foreman_url('provision') + "&static=yes" %> interface=<%= mac %> netcfg/get_ipaddress=<%= ip %> netcfg/get_netmask=<%= mask %> netcfg/get_gateway=<%= gw %> netcfg/get_nameservers=<%= dns %> netcfg/disable_dhcp=true netcfg/get_hostname=<%= @host.name %> BOOTIF=<%= bootif %> <%= options.join(' ') %>",
+  "extra": ["--args-linux"]
 }

--- a/app/views/foreman_discovery/redhat_kexec.erb
+++ b/app/views/foreman_discovery/redhat_kexec.erb
@@ -18,9 +18,13 @@ oses:
 <%#
 This template is used to pass command line options to kexec when reloading
 kernel on a discovered host instead of rebooting. This is useful in PXE-less
-environments. The template must generate JSON format with three items:
-"kernel", "initram" and "append". Read kexec(8) man page for more
-information about semantics.
+environments. The template must generate JSON format with the following items
+"kernel", "initram", "append" and "extra". The kexec command is composed in
+the following way:
+
+kexec --force --reset-vga --append=$append --initrd=$initram $extra $kernel
+
+Please read kexec(8) man page for more information about semantics.
 -%>
 <%
   mac = @host.facts['discovery_bootif']
@@ -37,8 +41,9 @@ information about semantics.
   "initram": "<%= @kexec_initrd %>",
 <% if (@host.operatingsystem.name == 'Fedora' and @host.operatingsystem.major.to_i > 16) or
     (@host.operatingsystem.name != 'Fedora' and @host.operatingsystem.major.to_i >= 7) -%>
-  "append": "ks=<%= foreman_url('provision') + "&static=yes" %> inst.ks.sendmac <%= "ip=#{ip}::#{gw}:#{mask}:::none nameserver=#{dns} ksdevice=bootif BOOTIF=#{bootif} nomodeset #{append}" %>"
+  "append": "ks=<%= foreman_url('provision') + "&static=yes" %> inst.ks.sendmac <%= "ip=#{ip}::#{gw}:#{mask}:::none nameserver=#{dns} ksdevice=bootif BOOTIF=#{bootif} nomodeset #{append}" %>",
 <% else -%>
-  "append": "ks=<%= foreman_url('provision') + "&static=yes" %> kssendmac nicdelay=5 <%= "ip=#{ip} netmask=#{mask} gateway=#{gw} dns=#{dns} ksdevice=#{mac} BOOTIF=#{bootif} nomodeset #{append}" %>"
+  "append": "ks=<%= foreman_url('provision') + "&static=yes" %> kssendmac nicdelay=5 <%= "ip=#{ip} netmask=#{mask} gateway=#{gw} dns=#{dns} ksdevice=#{mac} BOOTIF=#{bootif} nomodeset #{append}" %>",
 <% end -%>
+  "extra": ["--args-linux"]
 }


### PR DESCRIPTION
This is a patch that adds example extra options to kexec templates. The added
option is actually required to exec RHEL5 and older systems.

Please test with:

https://github.com/theforeman/smart_proxy_discovery_image/pull/5