### PR TITLE
Fixes #19003 - introduce ApplicationRecord

### DIFF
--- a/app/models/discovery_attribute_set.rb
+++ b/app/models/discovery_attribute_set.rb
@@ -1,4 +1,4 @@
-class DiscoveryAttributeSet < ActiveRecord::Base
+class DiscoveryAttributeSet < ApplicationRecord
   belongs_to :host, :class_name => "Host::Discovered", :foreign_key => :host_id
 
   validates :cpu_count, :presence => true, :numericality => {:greater_than_or_equal_to => 0}

--- a/app/models/discovery_rule.rb
+++ b/app/models/discovery_rule.rb
@@ -1,4 +1,4 @@
-class DiscoveryRule < ActiveRecord::Base
+class DiscoveryRule < ApplicationRecord
   include Authorizable
   extend FriendlyId
   friendly_id :name

--- a/db/migrate/20141223142759_fill_discovery_attribute_sets_for_existing_hosts.rb
+++ b/db/migrate/20141223142759_fill_discovery_attribute_sets_for_existing_hosts.rb
@@ -1,4 +1,4 @@
-class FakeDiscoveredHost < ActiveRecord::Base
+class FakeDiscoveredHost < ApplicationRecord
   self.table_name = 'hosts'
 end
 


### PR DESCRIPTION
Because Rails 5 will require apps to use ApplicationRecord and because this makes things easier for us to redirect orchestration log messages from sql to orch logger, we are making a change in core and introducing this class (#13772).

Most `ActiveRecord::Base` use must be replaced, specifically:

* `app/model/` - model classes
* `db/migrate/` - "fake" reopened classes otherwise TypeError: superclass mismatch for class XYZ
* `test/` - reopened classes otherwise TypeError: superclass mismatch for class XYZ

This requires https://github.com/theforeman/foreman/pull/3729 to be merged in core first. Tests will fail.