### PR TITLE
fixes #19032 - widget truncates with ellipsis

### DIFF
--- a/app/views/dashboard/_discovery_widget_host.html.erb
+++ b/app/views/dashboard/_discovery_widget_host.html.erb
@@ -1,4 +1,4 @@
-<td><%= discovery_status_icon(host) %>&#8239;<%= link_to trunc_with_tooltip(h(host.name)), discovered_host_path(host) %></td>
-<td class="hidden-tablet hidden-xs"><%= host.try(:hardware_model_name) || 'N/A' %></td>
+<td class="ellipsis"><%= discovery_status_icon(host) %>&#8239;<%= link_to(host.name, discovered_host_path(host)) %></td>
+<td class="hidden-tablet hidden-xs ellipsis"><%= host.try(:hardware_model_name) || _('N/A') %></td>
 <td class="hidden-tablet hidden-xs"><%= discovery_attribute(host, :cpu_count) %></td>
 <td class="hidden-tablet hidden-xs"><%= number_to_human_size(discovery_attribute(host, :memory, 0) * 1024 * 1024) %></td>

--- a/app/views/dashboard/_discovery_widget_host_list.html.erb
+++ b/app/views/dashboard/_discovery_widget_host_list.html.erb
@@ -1,9 +1,9 @@
-<table class="table table-striped ellipsis">
+<table class="table table-striped table-fixed">
   <thead>
-  <th><%= _('Host') %></th>
-  <th><%= _('Model') %></th>
-  <th><%= _('CPUs') %></th>
-  <th><%= _('Memory') %></th>
+  <th width="30%"><%= _('Host') %></th>
+  <th class="hidden-tablet hidden-xs"><%= _('Model') %></th>
+  <th class="hidden-tablet hidden-xs"><%= _('CPUs') %></th>
+  <th class="hidden-tablet hidden-xs"><%= _('Memory') %></th>
   </thead>
   <tbody>
   <% hosts.each do |host| %>


### PR DESCRIPTION
`ellipsis` should be defined on the field, not the whole table. The table needs to be fixed for ellipsis to work. `hidden-xs` works now as well as it hides the whole column.