### PR TITLE
Fixes #19403 - don't require jquery.cookie

### DIFF
--- a/app/views/discovered_hosts/_discovered_hosts_list.html.erb
+++ b/app/views/discovered_hosts/_discovered_hosts_list.html.erb
@@ -1,4 +1,4 @@
-<%= javascript "jquery.cookie", "host_checkbox" %>
+<%= javascript "host_checkbox" %>
 <% title _('Discovered hosts') %>
 <table class="table table-bordered table-striped table-condensed" >
   <tr>


### PR DESCRIPTION
This is now provided by webpack, no need to explicitly require it.