### PR TITLE
Fixes #19402 - Correct method for bulk host actions

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,11 +14,11 @@ Rails.application.routes.draw do
         post 'auto_provision'
       end
       collection do
-        get 'multiple_destroy'
+        post 'multiple_destroy'
         post 'submit_multiple_destroy'
-        get  'select_multiple_organization'
+        post  'select_multiple_organization'
         post 'update_multiple_organization'
-        get  'select_multiple_location'
+        post  'select_multiple_location'
         post 'update_multiple_location'
         get  'auto_complete_search'
         post 'auto_provision_all'

--- a/test/functional/discovered_hosts_controller_test.rb
+++ b/test/functional/discovered_hosts_controller_test.rb
@@ -37,6 +37,15 @@ class DiscoveredHostsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  def test_show_multiple_actions
+    host = Host::Discovered.import_host(@facts)
+    [:multiple_destroy, :select_multiple_organization, :select_multiple_location].each do |path|
+      xhr :post, path, {:host_ids => [host.id]}, set_session_user
+      assert_response :success
+      assert response.body =~ /#{host.name}/
+    end
+  end
+
   def test_show_page_categories
     host = Host::Discovered.import_host(@facts)
     get :show, {:id => host.id}, set_session_user_default_reader


### PR DESCRIPTION
In order to prevent url length limits, host bulk actions were changed
from GET to POST. This corrects the routes to use the updated method.