### PR TITLE
fixes #19409 - auto provision now uses anonymous admin

### DIFF
--- a/app/controllers/api/v2/discovered_hosts_controller.rb
+++ b/app/controllers/api/v2/discovered_hosts_controller.rb
@@ -96,10 +96,12 @@ module Api
       def facts
         facts = params['facts']
         state = true
-        @discovered_host = Host::Discovered.import_host(facts)
-        Rails.logger.warn "Discovered facts import unsuccessful, skipping auto provisioning" unless @discovered_host
-        if Setting['discovery_auto'] && @discovered_host && rule = find_discovery_rule(@discovered_host)
-          state = perform_auto_provision(@discovered_host, rule)
+        User.as_anonymous_admin do
+          @discovered_host = Host::Discovered.import_host(facts)
+          Rails.logger.warn 'Discovered facts import unsuccessful, skipping auto provisioning' unless @discovered_host
+          if Setting['discovery_auto'] && @discovered_host && (rule = find_discovery_rule(@discovered_host))
+            state = perform_auto_provision(@discovered_host, rule)
+          end
         end
         process_response state
       rescue Exception => e


### PR DESCRIPTION
with the introduction of Bug fix #16982: CVE-2016-7078 - User with no organizations or locations can see all resources added.
Discovery queries without a current user fail, this fixes that.