### PR TITLE
Fixes #19414 - Correct action on host form

### DIFF
--- a/app/helpers/discovered_hosts_helper.rb
+++ b/app/helpers/discovered_hosts_helper.rb
@@ -95,4 +95,9 @@ module DiscoveredHostsHelper
             :toggle => 'modal',
             :target => "#fixedPropertiesSelector-#{host.id}"})
   end
+
+  def host_path(host)
+    return super unless controller_name == 'discovered_hosts'
+    discovered_host_path(host)
+  end
 end


### PR DESCRIPTION
Since the host edit form is reused for provisioning, we need to override
the default action which points to the hosts edit form action.