### PR TITLE
Fixes #19444 - Seperate host and provision template

### DIFF
--- a/app/controllers/discovered_hosts_controller.rb
+++ b/app/controllers/discovered_hosts_controller.rb
@@ -56,7 +56,7 @@ class DiscoveredHostsController < ::ApplicationController
     if params[:quick_submit]
       perform_update(@host, _('Successfully provisioned %s') % @host.name)
     else
-      render :template => 'hosts/edit'
+      render :template => 'discovered_hosts/edit'
     end
   end
 
@@ -78,7 +78,7 @@ class DiscoveredHostsController < ::ApplicationController
         taxonomy_scope
         load_vars_for_ajax
         offer_to_overwrite_conflicts
-        process_error :object => host, :render => 'hosts/edit'
+        process_error :object => host, :render => 'discovered_hosts/edit'
       end
     end
   end

--- a/app/views/discovered_hosts/edit.html.erb
+++ b/app/views/discovered_hosts/edit.html.erb
@@ -1,0 +1,3 @@
+<% title(_("Provision %s") % @host) %>
+
+<%= render :partial => 'hosts/form' %>


### PR DESCRIPTION
When provisioning a discovered host, we don't need the buttons that are
available when editing an existing on such as "unmanage host". Also
changes the form title to "Provision <host>" instead of "Edit <host>".