### PR TITLE
Fixes #19501 - [PatternFly Consistent] capitalize the first letter of every word

### DIFF
--- a/app/views/discovered_hosts/_discovered_host_modal.html.erb
+++ b/app/views/discovered_hosts/_discovered_host_modal.html.erb
@@ -21,8 +21,8 @@
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-            <input type="submit" class="btn btn-default" value="<%= _('Quick create') %>" name="quick_submit" />
-            <input type="submit" class="btn btn-primary" value="<%= _('Create host') %>" />
+            <input type="submit" class="btn btn-default" value="<%= _('Quick Create') %>" name="quick_submit" />
+            <input type="submit" class="btn btn-primary" value="<%= _('Create Host') %>" />
           </div>
       <% end %>
     </div>

--- a/app/views/discovered_hosts/_discovered_hosts_list.html.erb
+++ b/app/views/discovered_hosts/_discovered_hosts_list.html.erb
@@ -1,5 +1,5 @@
 <%= javascript "host_checkbox" %>
-<% title _('Discovered hosts') %>
+<% title _('Discovered Hosts') %>
 <table class="table table-bordered table-striped table-condensed" >
   <tr>
     <th class="ca"><%= check_box_tag "check_all", "", false, { :onclick => "toggleCheck()", :'check-title' => _("Select all items in this page"), :'uncheck-title'=> _("items selected. Uncheck to Clear") } %></th>
@@ -8,8 +8,8 @@
     <th class="hidden-tablet hidden-xs"><%= sort :ip, :as => _('IP Address') %></th>
     <th class="hidden-tablet hidden-xs"><%= sort :cpu_count, :as => _('CPUs') %></th>
     <th class="hidden-tablet hidden-xs"><%= sort :memory, :as => _('Memory') %></th>
-    <th class="hidden-tablet hidden-xs"><%= sort :disk_count, :as => _('Disk count') %></th>
-    <th class="hidden-tablet hidden-xs"><%= sort :disks_size, :as => _('Disks size') %></th>
+    <th class="hidden-tablet hidden-xs"><%= sort :disk_count, :as => _('Disk Count') %></th>
+    <th class="hidden-tablet hidden-xs"><%= sort :disks_size, :as => _('Disks Size') %></th>
     <% Setting::Discovered.discovery_fact_column_array.each do |fact_column| %>
       <th class="hidden-tablet hidden-xs"><%= fact_column.capitalize %></th>
     <% end %>
@@ -20,7 +20,7 @@
       <th class="hidden-tablet hidden-xs"><%= sort :organization, :as => _('Organization') %></th>
     <% end -%>
     <th class="hidden-tablet hidden-xs"><%= sort :subnet, :as => _("Subnet") %></th>
-    <th class="hidden-tablet hidden-xs"><%= sort :last_report, :as => _("Last facts upload") %></th>
+    <th class="hidden-tablet hidden-xs"><%= sort :last_report, :as => _("Last Facts Upload") %></th>
     <th></th>
   </tr>
   <% @hosts.each do |host| -%>

--- a/app/views/discovery_rules/_form.html.erb
+++ b/app/views/discovery_rules/_form.html.erb
@@ -23,7 +23,7 @@
             <%= text_f f, :hostname,
                        :label_help => render('discovery_rules/template_inline').html_safe,
                        :label_help_options => {:title => _("Hostname for provisioned hosts"), :'data-placement' => 'bottom' } %>
-            <%= number_f f, :max_count, :label => _('Hosts limit'), :help_inline => _('Maximum hosts provisioned with this rule (0 = unlimited)'), :min => 0, :max => (2**31 - 1) %>
+            <%= number_f f, :max_count, :label => _('Hosts Limit'), :help_inline => _('Maximum hosts provisioned with this rule (0 = unlimited)'), :min => 0, :max => (2**31 - 1) %>
             <%= number_f f, :priority, :help_inline => _('Rule priority (lower integer means higher priority)'), :min => 0, :max => (2**31 - 1) %>
             <%= checkbox_f f, :enabled %>
           </div>

--- a/app/views/discovery_rules/index.html.erb
+++ b/app/views/discovery_rules/index.html.erb
@@ -6,8 +6,8 @@
     <th><%= sort :name, :as => s_("DiscoveryRule|Name") %></th>
     <th><%= sort :priority, :as => s_("DiscoveryRule|Priority") %></th>
     <th><%= sort :search, :as => s_("DiscoveryRule|Query") %></th>
-    <th><%= _("Host group") %></th>
-    <th><%= _("Hosts/limit") %></th>
+    <th><%= _("Host Group") %></th>
+    <th><%= _("Hosts/Limit") %></th>
     <th><%= sort :enabled, :as => s_("DiscoveryRule|Enabled") %></th>
     <th></th>
   </tr>


### PR DESCRIPTION
Based on PatternFly Terminology and Wording Guideline[1], suggest all the headline style to keep consistent to capitalize the first letter of every word.

[1]http://www.patternfly.org/styles/terminology-and-wording/#capitalization