### PR TITLE
Fixes #19647 - added taxonomy to rules API

### DIFF
--- a/app/views/api/v2/discovery_rules/main.json.rabl
+++ b/app/views/api/v2/discovery_rules/main.json.rabl
@@ -8,3 +8,15 @@ attribute :max_count => :hosts_limit
 child :hosts do
   extends "api/v2/discovered_hosts/base"
 end
+
+if SETTINGS[:organizations_enabled]
+  child :organizations => :organizations do
+    attributes :id, :name
+  end
+end
+
+if SETTINGS[:locations_enabled]
+  child :locations => :locations do
+    attributes :id, :name
+  end
+end

--- a/test/functional/api/v2/discovery_rules_controller_test.rb
+++ b/test/functional/api/v2/discovery_rules_controller_test.rb
@@ -23,10 +23,13 @@ class Api::V2::DiscoveryRulesControllerTest < ActionController::TestCase
     assert_equal 1, discovery_rules['total']
   end
 
-  test "should show discovery rule" do
+  test "should show discovery rule with taxonomy" do
     rule = FactoryGirl.create(:discovery_rule)
     get :show, { :id => rule.to_param }
     assert_response :success
+    discovery_rule = ActiveSupport::JSON.decode(@response.body)
+    assert_equal "Organization 1", discovery_rule['organizations'].first['name']
+    assert_equal "Location 1", discovery_rule['locations'].first['name']
   end
 
   test "should create discovery rule with taxonomy" do


### PR DESCRIPTION
Already have it for create/update, but showing and listing was not doing this. Now:

```
[lzap@lzapx foreman_discovery]$ curl-foreman /api/v2/discovery_rules/
{
    "total": 1,
    "subtotal": 1,
    "page": 1,
    "per_page": 100,
    "search": null,
    "sort": {
        "by": null,
        "order": null
    },
    "results": [
        {
            "name": "always",
            "enabled": true,
            "hostgroup_id": 1,
            "hostgroup_name": "CentOS 7.0",
            "hostname": "somehost-<%= rand(999999) %>",
            "priority": 200,
            "search": "cpu_count > 0",
            "hosts_limit": 0,
            "id": 1,
            "hosts": [

            ],
            "organizations": [
                {
                    "id": 1,
                    "name": "MyOrg"
                },
                {
                    "id": 4,
                    "name": "OtherOrg"
                }
            ],
            "locations": [
                {
                    "id": 2,
                    "name": "MyLoc"
                },
                {
                    "id": 3,
                    "name": "SecondLoc"
                }
            ]
        }
    ]
}
[lzap@lzapx foreman_discovery]$ curl-foreman /api/v2/discovery_rules/1
{
    "name": "always",
    "enabled": true,
    "hostgroup_id": 1,
    "hostgroup_name": "CentOS 7.0",
    "hostname": "somehost-<%= rand(999999) %>",
    "priority": 200,
    "search": "cpu_count > 0",
    "hosts_limit": 0,
    "id": 1,
    "hosts": [

    ],
    "organizations": [
        {
            "id": 1,
            "name": "MyOrg",
            "title": "MyOrg",
            "description": null
        },
        {
            "id": 4,
            "name": "OtherOrg",
            "title": "OtherOrg",
            "description": ""
        }
    ],
    "locations": [
        {
            "id": 2,
            "name": "MyLoc",
            "title": "MyLoc",
            "description": null
        },
        {
            "id": 3,
            "name": "SecondLoc",
            "title": "SecondLoc",
            "description": ""
        }
    ]
}
```