### PR TITLE
Fixes #19412,#19732 - kexec path and seed fixed

### DIFF
--- a/app/views/foreman_discovery/debian_kexec.erb
+++ b/app/views/foreman_discovery/debian_kexec.erb
@@ -31,6 +31,7 @@ Please read kexec(8) man page for more information about semantics.
   options << "locale=#{@host.params['lang'] || 'en_US'}"
 -%>
 {
+  "comment": "WARNING: Both kernel and initram are not set in preview mode due to http://projects.theforeman.org/issues/19737",
   "kernel": "<%= @kexec_kernel %>",
   "initram": "<%= @kexec_initrd %>",
   "append": "url=<%= foreman_url('provision') + "&static=yes" %> interface=<%= mac %> netcfg/get_ipaddress=<%= ip %> netcfg/get_netmask=<%= mask %> netcfg/get_gateway=<%= gw %> netcfg/get_nameservers=<%= dns %> netcfg/disable_dhcp=true netcfg/get_hostname=<%= @host.name %> BOOTIF=<%= bootif %> <%= options.join(' ') %>",

--- a/app/views/foreman_discovery/redhat_kexec.erb
+++ b/app/views/foreman_discovery/redhat_kexec.erb
@@ -37,6 +37,7 @@ Please read kexec(8) man page for more information about semantics.
   append = @host.facts['append']
 -%>
 {
+  "comment": "WARNING: Both kernel and initram are not set in preview mode due to http://projects.theforeman.org/issues/19737",
   "kernel": "<%= @kexec_kernel %>",
   "initram": "<%= @kexec_initrd %>",
 <% if (@host.operatingsystem.name == 'Fedora' and @host.operatingsystem.major.to_i > 16) or

--- a/db/seeds.d/50_discovery_templates.rb
+++ b/db/seeds.d/50_discovery_templates.rb
@@ -1,9 +1,9 @@
-kind = TemplateKind.where(:name => 'kexec').first_or_create
+kind = TemplateKind.unscoped.where(:name => 'kexec').first_or_create
 
 ProvisioningTemplate.without_auditing do
   [['redhat_kexec.erb', 'Red Hat'], ['debian_kexec.erb', 'Debian']].each do |tmpl_names|
     content = File.read(File.join(ForemanDiscovery::Engine.root, 'app', 'views', 'foreman_discovery', tmpl_names[0]))
-    tmpl = ProvisioningTemplate.where(:name => "Discovery #{tmpl_names[1]} kexec").first_or_create(
+    tmpl = ProvisioningTemplate.unscoped.where(:name => "Discovery #{tmpl_names[1]} kexec").first_or_create(
       :template_kind_id => kind.id,
       :snippet => false,
       :template => content

--- a/db/seeds.d/60_discovery_proxy_feature.rb
+++ b/db/seeds.d/60_discovery_proxy_feature.rb
@@ -1,2 +1,2 @@
-f = Feature.where(:name => 'Discovery').first_or_create
+f = Feature.unscoped.where(:name => 'Discovery').first_or_create
 raise "Unable to create proxy feature: #{format_errors f}" if f.nil? || f.errors.any?

--- a/db/seeds.d/70_discovery_mail_notification.rb
+++ b/db/seeds.d/70_discovery_mail_notification.rb
@@ -6,4 +6,4 @@ discovery_mail_notification = {
     :subscription_type => 'report',
 }
 
-MailNotification.where(discovery_mail_notification).first_or_create
+MailNotification.unscoped.where(discovery_mail_notification).first_or_create

--- a/lib/foreman_discovery/engine.rb
+++ b/lib/foreman_discovery/engine.rb
@@ -164,9 +164,11 @@ module ForemanDiscovery
         # add dashboard widget
         widget 'discovery_widget', :name=>N_('Discovered Hosts'), :sizex => 6, :sizey =>1
 
-        # add template helpers
+        # allowed helpers and variables
         allowed_template_helpers :rand
         allowed_template_variables :kexec_kernel, :kexec_initrd
+
+        template_labels 'kexec' => N_('Discovery Kexec template')
 
         # apipie API documentation
         # Only available in 1.8, otherwise it has to be in the initializer below

--- a/test/unit/discovered_extensions_test.rb
+++ b/test/unit/discovered_extensions_test.rb
@@ -1,6 +1,6 @@
 require 'test_plugin_helper'
 
-class FindDiscoveryRulesTest < ActiveSupport::TestCase
+class DiscoveredExtensionsTest < ActiveSupport::TestCase
   include Foreman::Controller::DiscoveredExtensions
 
   setup do

--- a/test/unit/managed_extensions_test.rb
+++ b/test/unit/managed_extensions_test.rb
@@ -1,0 +1,76 @@
+require 'test_plugin_helper'
+
+class ManagedExtensionsTest < ActiveSupport::TestCase
+  class StubHost < ApplicationRecord
+    include Host::ManagedExtensions
+
+    # prevent from Could not find table exception
+    def self.table_name
+      'hosts'
+    end
+  end
+
+  setup do
+    set_default_settings
+
+    @host = StubHost.new
+    @host.legacy_api = false
+    @host.type = "Host::Discovered"
+    @host.stubs(:old).returns(@host)
+    @facts = {}
+    @host.stubs(:facts).returns(@facts)
+    @post_queue = mock('Post Queue')
+    @host.stubs(:post_queue).returns(@post_queue)
+    @operatingsystem = mock('OS')
+    @host.stubs(:operatingsystem).returns(@operatingsystem)
+    @host.stubs(:provisioning_template).returns('A template')
+    @host.stubs(:medium).returns('http://a_medium')
+    @host.stubs(:architecture).returns(FactoryGirl.create(:architecture))
+    @kexec_json = {
+      :kernel => "http://a_host/vmlinuz",
+      :initrd => "http://a_host/someimage.img"
+    }
+    @host.stubs(:unattended_render).returns(@kexec_json.to_json)
+  end
+
+  test "queue_reboot enques reboot command when there is no kexec fact" do
+    @host.stubs(:type_changed?).returns(true)
+    @host.stubs(:new_record?).returns(false)
+    @host.id = 130513
+    ::Host::Base.stubs(:find).with(@host.id).returns(@host)
+    @post_queue.expects(:create).with(has_entry(:action, [@host, :setReboot])).once
+    @host.queue_reboot
+  end
+
+  test "queue_reboot enques reboot command when there is no kexec template" do
+    @host.stubs(:type_changed?).returns(true)
+    @host.stubs(:new_record?).returns(false)
+    @host.id = 130513
+    ::Host::Base.stubs(:find).with(@host.id).returns(@host)
+    @facts['discovery_kexec'] = "Kexec version X.Y.Z"
+    @host.stubs(:provisioning_template).returns(nil)
+    @post_queue.expects(:create).with(has_entry(:action, [@host, :setReboot])).once
+    @host.queue_reboot
+  end
+
+  test "queue_reboot enques kexec command" do
+    @host.stubs(:type_changed?).returns(true)
+    @host.stubs(:new_record?).returns(false)
+    @host.id = 130513
+    ::Host::Base.stubs(:find).with(@host.id).returns(@host)
+    @facts['discovery_kexec'] = "Kexec version X.Y.Z"
+    @post_queue.expects(:create).with(has_entry(:action, [@host, :setKexec])).once
+    @host.queue_reboot
+  end
+
+  test "setReboot calls reboot API" do
+    Host::Discovered.any_instance.expects(:reboot).once
+    @host.setReboot
+  end
+
+  test "setKexec calls boot_files_uri and kexec API" do
+    Host::Discovered.any_instance.expects(:kexec).once
+    @operatingsystem.expects(:boot_files_uri).with(@host.medium, @host.architecture, @host)
+    @host.setKexec
+  end
+end


### PR DESCRIPTION
Two issues fixed, both needed patches for 9.1 release.

First, Katello made a change in boot_files_uri method and requires host to be set, otherwise it returns original media URL which is blank. Adding host parameter fixes that.

Second, due to taxonomy changes, multiple seeding was creating multiple templates records as we do not validate the records allowing multiple entries with same name.

These two are remaining items for 9.1: http://projects.theforeman.org/versions/188

@dLobato @ares