### PR TITLE
Fixes #19924 - Consistently use 'default manager' in tests

### DIFF
--- a/test/test_helper_discovery.rb
+++ b/test/test_helper_discovery.rb
@@ -1,4 +1,8 @@
-def set_session_user_with_perms perms
+def set_session_user(user)
+  SETTINGS[:login] ? {:user => user.id, :expires_at => 5.minutes.from_now} : {}
+end
+
+def user_with_perms(perms)
   perms = perms.collect{|p| Permission.find_by_name(p) || Permission.create(:name => p) }
   perms.each do |p|
     p.resource_type = 'Host' if p.name =~ /discovered_hosts$/
@@ -11,16 +15,36 @@ def set_session_user_with_perms perms
   end
   user = FactoryGirl.create :user, :with_mail, :admin => false
   user.roles << role
-  user.save!
-  SETTINGS[:login] ? {:user => user.id, :expires_at => 5.minutes.from_now} : {}
+  user.save
+  user
+end
+
+def as_default_manager
+  as_user(default_manager) do
+    yield
+  end
+end
+
+def as_default_reader
+  as_user(default_reader) do
+    yield
+  end
+end
+
+def default_manager
+  @default_manager ||= user_with_perms(Foreman::Plugin.find('foreman_discovery').default_roles['Discovery Manager'])
+end
+
+def default_reader
+  @default_reader ||= user_with_perms(Foreman::Plugin.find('foreman_discovery').default_roles['Discovery Reader'])
 end
 
 def set_session_user_default_reader
-  set_session_user_with_perms Foreman::Plugin.find('foreman_discovery').default_roles['Discovery Reader']
+  set_session_user(default_reader)
 end
 
 def set_session_user_default_manager
-  set_session_user_with_perms Foreman::Plugin.find('foreman_discovery').default_roles['Discovery Manager']
+  set_session_user(default_manager)
 end
 
 def extract_form_errors(response)
@@ -47,7 +71,19 @@ end
 def setup_hostgroup(host)
   domain = FactoryGirl.create(:domain)
   subnet = FactoryGirl.create(:subnet_ipv4, :network => "192.168.100.0")
-  hostgroup = FactoryGirl.create(:hostgroup, :with_environment, :with_rootpass, :with_puppet_orchestration, :with_os, :subnet => subnet, :domain => domain, :organizations => [host.organization], :locations => [host.location])
+  environment = FactoryGirl.create(:environment, :organizations => [host.organization], :locations => [host.location])
+  medium = FactoryGirl.create(:medium, :organizations => [host.organization], :locations => [host.location])
+  os = FactoryGirl.create(:operatingsystem, :with_ptables, :with_archs, :media => [medium])
+  hostgroup = FactoryGirl.create(
+    :hostgroup, :with_rootpass, :with_puppet_orchestration,
+    :operatingsystem => os,
+    :architecture => os.architectures.first,
+    :ptable => os.ptables.first,
+    :medium => os.media.first,
+    :environment => environment,
+    :subnet => subnet,
+    :domain => domain,
+    :organizations => [host.organization], :locations => [host.location])
   domain.subnets << hostgroup.subnet
   hostgroup.medium.organizations |= [host.organization]
   hostgroup.medium.locations |= [host.location]


### PR DESCRIPTION
Tests were using 'users(:admin)' to create certain objects like Host.
The controller was using a newly created used with 'Default Manager'
permissions to act on these objects, but they are not always visible to
non admin users.

Particularly most tests failed because host.owner is users(:admin)
('secret_admin') which is not visible to a user with Default Discovery
Manager permissions