### PR TITLE
Fixes #19944 - Move default role permissions to seeds

### DIFF
--- a/db/migrate/20160818091421_add_permissions_from_default_roles.rb
+++ b/db/migrate/20160818091421_add_permissions_from_default_roles.rb
@@ -1,12 +1,6 @@
 class AddPermissionsFromDefaultRoles < ActiveRecord::Migration
   def up
-    default_permissions = Foreman::Plugin.find("foreman_discovery").default_roles
-    ["Discovery Reader", "Discovery Manager"].each do |role_name|
-      role = Role.find_by_name(role_name) || next
-      default_permissions[role_name].each do |permission|
-        role.add_permissions!(permission) unless role.permission_names.include?(permission.to_sym)
-      end
-    end
+    # Moved to seeds see http://projects.theforeman.org/issues/17585
   end
 
   def down

--- a/db/seeds.d/90_add_permissions_from_default_roles.rb
+++ b/db/seeds.d/90_add_permissions_from_default_roles.rb
@@ -1,0 +1,10 @@
+default_permissions = Foreman::Plugin.find("foreman_discovery").default_roles
+
+["Discovery Reader", "Discovery Manager"].each do |role_name|
+  role = Role.find_by_name(role_name) || next
+  default_permissions[role_name].each do |permission|
+    role.add_permissions!(permission) unless role.permission_names.include?(permission.to_sym)
+  end
+  role.update_attributes :origin => "discovery", :description => "Discovery plugin built-in role"
+  role.save!
+end


### PR DESCRIPTION
Happy to use a new issue if you feel that's warranted. I still hit this issue even after the migration was moved. Perhaps this has to do with some sort of state reloading but the base cause of the failure can occur again. If ever the Role or Filter models in Foreman are updated, without the migration for them having been run first (which in the current code won't happen) then this will call a function that could call a code path that references non-existent database fields and error out in the same way. I feel these are better served being in the seeds because they are ensuring a consistent data state and not manipulating the tables themselves.