### PR TITLE
Refs #19944 - locked seed error fixed

### DIFF
--- a/db/seeds.d/90_add_permissions_from_default_roles.rb
+++ b/db/seeds.d/90_add_permissions_from_default_roles.rb
@@ -5,6 +5,8 @@ default_permissions = Foreman::Plugin.find("foreman_discovery").default_roles
   default_permissions[role_name].each do |permission|
     role.add_permissions!(permission) unless role.permission_names.include?(permission.to_sym)
   end
-  role.update_attributes :origin => "discovery", :description => "Discovery plugin built-in role"
+  role.ignore_locking do |r|
+    r.update_attributes :origin => "discovery", :description => "Discovery plugin built-in role"
+  end
   role.save!
 end


### PR DESCRIPTION
Found one issue with the latest patch - initial seed works fine, but if you seed for the 2nd time, it errors out with

```
rake aborted!
ActiveRecord::RecordInvalid: Validation failed: This role is locked from being modified by users.
/home/lzap/work/foreman_discovery/db/seeds.d/90_add_permissions_from_default_roles.rb:9:in `block in <top (required)>'
/home/lzap/work/foreman_discovery/db/seeds.d/90_add_permissions_from_default_roles.rb:3:in `each'
/home/lzap/work/foreman_discovery/db/seeds.d/90_add_permissions_from_default_roles.rb:3:in `<top (required)>'
...
```

This is because it's actually locked and can't be modified anymore. There is a helper block in the Role class.

@dLobato @ehelms