### PR TITLE
Fixes #19440 - Integration test provisioning discovered hosts

### DIFF
--- a/test/functional/discovered_hosts_controller_test.rb
+++ b/test/functional/discovered_hosts_controller_test.rb
@@ -4,6 +4,7 @@ class DiscoveredHostsControllerTest < ActionController::TestCase
   setup :initialize_host
 
   setup do
+    assert discovered_notification_blueprint
     @request.env['HTTP_REFERER'] = '/discovery_rules'
     FactoryBot.create(:subnet, :network => "192.168.100.1", :mask => "255.255.255.0", :locations => [location_one], :organizations => [organization_one])
     @facts = {
@@ -82,9 +83,13 @@ class DiscoveredHostsControllerTest < ActionController::TestCase
 
   def test_edit_form_quick_submit
     disable_taxonomies do
-      host = discover_host_from_facts(@facts)
       domain = FactoryBot.create(:domain)
       hostgroup = FactoryBot.create(:hostgroup, :with_subnet, :with_environment, :with_rootpass, :with_os, :domain => domain)
+      new_ip = hostgroup.subnet.ipaddr
+      host = discover_host_from_facts(@facts.merge({
+                                                     'ipaddress' => new_ip,
+                                                     'ipaddress_eth0' => new_ip
+                                                   }))
       get :edit, {
         :id => host.id,
         :quick_submit => true,

--- a/test/integration/discovered_hosts_test.rb
+++ b/test/integration/discovered_hosts_test.rb
@@ -1,0 +1,151 @@
+require 'test_plugin_helper'
+require 'integration_test_helper'
+
+class DiscoveredHostsTest < IntegrationTestWithJavascript
+  let(:discovered_host) { FactoryBot.create(:discovered_host, :with_facts) }
+  let(:discovered_hosts) { Host::Discovered.all }
+
+  extend Minitest::OptionalRetry
+
+  setup do
+    assert discovered_notification_blueprint
+    discovered_host.save!
+    visit discovered_hosts_path
+  end
+
+  teardown do
+    Host::Discovered.destroy_all
+  end
+
+  describe 'Reboot all' do
+    test 'triggers reboot on all discovered_hosts' do
+      Host::Discovered.any_instance
+                      .expects(:reboot)
+                      .at_least(discovered_hosts.count)
+      select_all_hosts
+      page.find_link('Reboot All').click
+    end
+  end
+
+  describe 'Autoprovision all' do
+    test 'converts all discovered to managed hosts' do
+      select_all_hosts
+      page.find_link('Auto Provision All').click
+      wait_for_ajax
+      assert page.has_text?('Discovered hosts are provisioning now')
+    end
+  end
+
+  describe 'Delete hosts' do
+    test 'it removes all hosts' do
+      select_all_hosts
+      page.find_link('Select Action').click
+      page.find_link('Delete hosts').click
+      wait_for_ajax
+      assert page.has_text?('The following hosts are about to be changed')
+      page.find_button('Submit').click
+      wait_for_ajax
+      assert page.has_text?('Destroyed selected hosts')
+    end
+  end
+
+  describe 'using Create Host link' do
+    setup do
+      page.find("#host_ids_#{discovered_host.id}")
+          .query_scope
+          .find_link('Provision').click
+    end
+
+    test 'and forwards to editing it' do
+      create_host
+      assert_equal edit_discovered_host_path(id: discovered_host),
+                   current_path
+    end
+
+    context 'with a Hostgroup selected' do
+      let(:discovery_hostgroup) { Hostgroup.first }
+
+      test 'it passes it on' do
+        select_from('host_hostgroup_id', discovery_hostgroup.id)
+        create_host
+        assert_param discovery_hostgroup.id.to_s,
+                     'host.hostgroup_id'
+      end
+    end
+
+    context 'with a Location selected' do
+      let(:discovery_location) { Location.first }
+
+      test 'it passes it on' do
+        select_from('host_location_id', discovery_location.id)
+        create_host
+        assert_param discovery_location.id.to_s,
+                     'host.location_id'
+      end
+    end
+
+    context 'with a Organization selected' do
+      let(:discovery_organization) { Organization.first }
+
+      test 'it passes it on' do
+        select_from('host_organization_id', discovery_organization.id)
+        create_host
+        assert_param discovery_organization.id.to_s,
+                     'host.organization_id'
+      end
+    end
+  end
+
+  describe 'edit form' do
+    test 'it is a host form' do
+      visit edit_discovered_host_path(discovered_host)
+      assert page.find("form#edit_host_#{discovered_host.id}")
+    end
+
+    context 'with a hostgroup passed' do
+      let(:hostgroup_environment) { FactoryBot.create(:environment) }
+      let(:hostgroup_domain) { FactoryBot.create(:domain) }
+      let(:hostgroup) do
+        FactoryBot.create(:hostgroup, :with_os,
+                           environment: hostgroup_environment,
+                           domain: hostgroup_domain)
+      end
+
+      setup do
+        visit edit_discovered_host_path(discovered_host,
+                                        'host[hostgroup_id]' => hostgroup.id)
+        page.find("a[href='#os']").click
+        assert_selected '#host_hostgroup_id', hostgroup.id
+      end
+
+      it 'sets inherited attributes' do
+        %i[environment architecture operatingsystem].each do |attribute|
+          assert_selected "#host_#{attribute}_id", hostgroup.send(attribute).id
+        end
+
+        page.find('a[href="#network"]').click
+        page.find_button('Edit').click
+        assert_selected '#host_interfaces_attributes_0_domain_id',
+                        hostgroup.domain.id
+      end
+    end
+  end
+
+  private
+
+  def select_all_hosts
+    page.find('#check_all').click
+  end
+
+  def select_from(element_id, id)
+    page.find_by_id(element_id, visible: false)
+        .find("option[value='#{id}']", visible: false)
+        .select_option
+  end
+
+  def create_host
+    page.find("#fixedPropertiesSelector-#{discovered_host.id}")
+        .find_button('Create Host').click
+    wait_for_ajax
+  end
+end

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -6,7 +6,3 @@ require 'test_helper_discovery'
 # Add plugin to FactoryBot's paths
 FactoryBot.definition_file_paths << File.join(File.dirname(__FILE__), 'factories')
 FactoryBot.reload
-# load notification seeds.
-require File.join(
-  File.dirname(__FILE__), '..', 'db', 'seeds.d', '80_discovery_ui_notification'
-)

--- a/test/unit/ui_notifications/destroy_host_test.rb
+++ b/test/unit/ui_notifications/destroy_host_test.rb
@@ -1,6 +1,12 @@
 require 'test_plugin_helper'
 
 class DestroyHostNotificationTest < ActiveSupport::TestCase
+  alias_method  :blueprint, :discovered_notification_blueprint
+
+  setup do
+    assert blueprint
+  end
+
   test 'destorying discovered host should remove notification' do
     host = FactoryBot.create(:discovered_host)
     assert_difference('blueprint.notifications.count', -1) do
@@ -8,14 +14,18 @@ class DestroyHostNotificationTest < ActiveSupport::TestCase
     end
   end
 
-  test 'do not remove notification if others discovered hosts exists' do
-    host1 = FactoryBot.create(:discovered_host)
+  test 'do not remove notification if other discovered hosts exists' do
+    assert_difference('blueprint.notifications.count') do
+      FactoryBot.create(:discovered_host)
+    end
     assert_equal 1, blueprint.notifications.count
-    host2 = FactoryBot.create(:discovered_host)
-    assert_equal 1, blueprint.notifications.count
-    host2.destroy
-    assert_equal 1, blueprint.notifications.count
-    host1.destroy
+    assert_no_difference('blueprint.notifications.count') do
+      FactoryBot.create(:discovered_host)
+    end
+    assert_no_difference('blueprint.notifications.count') do
+      Host::Discovered.all.last.destroy
+    end
+    Host::Discovered.destroy_all
     assert_equal 0, blueprint.notifications.count
   end
 
@@ -34,11 +44,5 @@ class DestroyHostNotificationTest < ActiveSupport::TestCase
     new_host = ::ForemanDiscovery::HostConverter.to_managed(host1, false, false)
     assert new_host.save!
     assert_equal 1, blueprint.notifications.count
-  end
-
-  private
-
-  def blueprint
-    NotificationBlueprint.find_by(name: 'new_discovered_host')
   end
 end

--- a/test/unit/ui_notifications/new_host_test.rb
+++ b/test/unit/ui_notifications/new_host_test.rb
@@ -1,10 +1,16 @@
 require 'test_plugin_helper'
 
 class NewHostNotificationTest < ActiveSupport::TestCase
-  test 'new discovered host should generate a notification' do
+  alias_method  :blueprint, :discovered_notification_blueprint
+
+  setup do
     assert blueprint
-    FactoryBot.create :discovered_host
-    assert_equal 1, blueprint.notifications.count
+  end
+
+  test 'new discovered host should generate a notification' do
+    assert_difference('blueprint.notifications.count') do
+      FactoryBot.create :discovered_host
+    end
   end
 
   test 'multiple discovered hosts should generate only one notification' do
@@ -16,11 +22,5 @@ class NewHostNotificationTest < ActiveSupport::TestCase
     ForemanDiscovery::UINotifications::NewHost.deliver!(host2)
     assert_equal 1, blueprint.notifications.count
     assert_not_equal expired_at, blueprint.notifications.first.expired_at
-  end
-
-  private
-
-  def blueprint
-    NotificationBlueprint.find_by(name: 'new_discovered_host')
   end
 end


### PR DESCRIPTION
This is a start to add integration tests and to have a base for scenarios of bugs.
The first tests cover the provisioning modal and ensure it passes on the parameters, including the hostgroup_id, as a prerequisite for setting inherited values like the domain[1]

The test data still needs to be rewritten to use the factories for hostgroup, location and organization.

I would like to add a few more tests for the overview page, before it is done.
Are there any other tests that might be good to have right away?

[1] http://projects.theforeman.org/issues/19445