### PR TITLE
Fixes #20269 - Use the  inline messaging warning

### DIFF
--- a/app/views/discovered_hosts/multiple_destroy.html.erb
+++ b/app/views/discovered_hosts/multiple_destroy.html.erb
@@ -1,6 +1,7 @@
 <%= form_tag submit_multiple_destroy_discovered_hosts_path(:host_ids => params[:host_ids]), :onsubmit => "resetSelection()" do -%>
-  <span class="label label-warning"><%= _('Warning') -%></span>
-  <%= _('This might take a while, as all hosts, facts and reports will be destroyed as well') %>
-<% end %><br />
+  <%= alert :class => 'alert-warning',
+  :text => _("This might take a while, as all hosts, facts and reports will be destroyed as well"),
+  :header => '' %>
+<% end %>
 
 <%= render 'selected_hosts', :hosts => @hosts %>


### PR DESCRIPTION
This commit makes sure that the warning message follows the patternfly standards.