### PR TITLE
Fixes #20290 - kexec now produces valid JSON output

### DIFF
--- a/app/models/host/managed_extensions.rb
+++ b/app/models/host/managed_extensions.rb
@@ -50,7 +50,7 @@ module Host::ManagedExtensions
     json = JSON.parse(unattended_render(template))
     ::Foreman::Exception.new(N_("Kernel kexec URL is invalid: '%s'"), json['kernel']) unless json['kernel'] =~ /\Ahttp.+\Z/
     ::Foreman::Exception.new(N_("Init RAM kexec URL is invalid: '%s'"), json['initrd']) unless json['initrd'] =~ /\Ahttp.+\Z/
-    old.becomes(Host::Discovered).kexec json.to_s
+    old.becomes(Host::Discovered).kexec json.to_json
     true
   rescue ::Foreman::Exception => e
     Foreman::Logging.exception("Unable to kexec", e)

--- a/test/unit/managed_extensions_test.rb
+++ b/test/unit/managed_extensions_test.rb
@@ -69,7 +69,7 @@ class ManagedExtensionsTest < ActiveSupport::TestCase
   end
 
   test "setKexec calls boot_files_uri and kexec API" do
-    Host::Discovered.any_instance.expects(:kexec).once
+    Host::Discovered.any_instance.expects(:kexec).with() { |json| JSON.parse(json) }.once
     @operatingsystem.expects(:boot_files_uri).with(@host.medium, @host.architecture, @host)
     @host.setKexec
   end


### PR DESCRIPTION
This is unfortunate, kexec is not working at all in 1.15/9.1.1 because I added `to_s` method call which creates ruby string representation instead of `to_json` which is implicit. I did not spot this via Template preview feature because kexec templates are not rendered using normal stack, we call renderer explicitly - this needs improval in the future.

This one liner fixes it. To test this, you need to initiate provisioning via kexec and validate JSON or let a VM to really kexec. I will do minor release for this later on.