### PR TITLE
Fixes #20387 - Clean the redundant code for auto complete search

### DIFF
--- a/app/controllers/discovered_hosts_controller.rb
+++ b/app/controllers/discovered_hosts_controller.rb
@@ -145,21 +145,6 @@ class DiscoveredHostsController < ::ApplicationController
     redirect_to(discovered_hosts_path)
   end
 
-  def auto_complete_search
-    begin
-      @items = Host::Discovered.complete_for(params[:search])
-      @items = @items.map do |item|
-        category = (['and','or','not','has'].include?(item.to_s.sub(/^.*\s+/,''))) ? 'Operators' : ''
-        part = item.to_s.sub(/^.*\b(and|or)\b/i) {|match| match.sub(/^.*\s+/,'')}
-        completed = item.to_s.chomp(part)
-        {:completed => completed, :part => part, :label => item, :category => category}
-      end
-    rescue ScopedSearch::QueryNotSupported => e
-      @items = [{:error =>e.to_s}]
-    end
-    render :json => @items
-  end
-
   def auto_provision
     if rule = find_discovery_rule(@host)
       if perform_auto_provision(@host, rule)


### PR DESCRIPTION
This commit shall improve the usability by removing the extra spaces prefixed to the search string. 