### PR TITLE
Fixes #20564 - ignore locking in migration

### DIFF
--- a/db/seeds.d/90_add_permissions_from_default_roles.rb
+++ b/db/seeds.d/90_add_permissions_from_default_roles.rb
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
 default_permissions = Foreman::Plugin.find("foreman_discovery").default_roles
 
 ["Discovery Reader", "Discovery Manager"].each do |role_name|
-  role = Role.find_by_name(role_name) || next
-  default_permissions[role_name].each do |permission|
-    role.add_permissions!(permission) unless role.permission_names.include?(permission.to_sym)
+  Role.ignore_locking do
+    role = Role.unscoped.find_by_name(role_name) || next
+    default_permissions[role_name].each do |permission|
+      role.add_permissions(permission) unless role.permission_names.include?(permission.to_sym)
+    end
+    role.origin = 'discovery'
+    role.description = 'Discovery plugin built-in role'
+    role.save
   end
-  role.ignore_locking do |r|
-    r.update_attributes :origin => "discovery", :description => "Discovery plugin built-in role"
-  end
-  role.save!
 end


### PR DESCRIPTION
Until there is a way for plugin API to do this for us, we need to ignore locking to prevent this error:

Validation failed: Filters.role is locked for user modifications