### PR TITLE
Refs #20564 - Ignore locking in migration

### DIFF
--- a/db/migrate/20150714144500_review_discovery_permissions.rb
+++ b/db/migrate/20150714144500_review_discovery_permissions.rb
@@ -1,12 +1,14 @@
 class ReviewDiscoveryPermissions < ActiveRecord::Migration
   def up
-    if (mgr = Role.find_by_name("Discovery Manager"))
-      perms = []
-      perms << "submit_discovered_hosts" if Permission.find_by_name("edit_discovered_hosts")
-      perms << "auto_provision_discovered_hosts" if Permission.find_by_name("provision_discovered_hosts")
-      perms << "create_discovery_rules" if Permission.find_by_name("new_discovery_rules")
-      perms << "destroy_discovery_rules" if Permission.find_by_name("delete_discovery_rules")
-      mgr.add_permissions!(perms)
+    Role.ignore_locking do
+      if (mgr = Role.find_by_name("Discovery Manager"))
+        perms = []
+        perms << "submit_discovered_hosts" if Permission.find_by_name("edit_discovered_hosts")
+        perms << "auto_provision_discovered_hosts" if Permission.find_by_name("provision_discovered_hosts")
+        perms << "create_discovery_rules" if Permission.find_by_name("new_discovery_rules")
+        perms << "destroy_discovery_rules" if Permission.find_by_name("delete_discovery_rules")
+        mgr.add_permissions!(perms)
+      end
     end
     Permission.find_by_name("new_discovery_rules").try(:destroy)
   end


### PR DESCRIPTION
`rake db:migate` still failed with "Validation failed: Filters.role is locked for user modifications".