### PR TITLE
Fixes #19448 - Show notification if new host discovered

### DIFF
--- a/app/services/foreman_discovery/ui_notifications/new_host.rb
+++ b/app/services/foreman_discovery/ui_notifications/new_host.rb
@@ -7,11 +7,14 @@ module ForemanDiscovery
       private
 
       def create
-        add_notification if update_notifications.zero?
+        User.as_anonymous_admin do
+          blueprint.notifications.any? ? update_notifications : add_notification
+        end
       end
 
       def update_notifications
         blueprint.mass_update_expiry
+        blueprint.mass_set_seen(false)
       end
 
       def add_notification

--- a/test/unit/ui_notifications/new_host_test.rb
+++ b/test/unit/ui_notifications/new_host_test.rb
@@ -18,6 +18,15 @@ class NewHostNotificationTest < ActiveSupport::TestCase
     assert_not_equal expired_at, blueprint.notifications.first.expired_at
   end
 
+  test 'new discovered hosts should show new notification' do
+    host1 = FactoryBot.create :discovered_host
+    ForemanDiscovery::UINotifications::NewHost.deliver!(host1)
+    blueprint.notifications.first.notification_recipients.update_all(seen: true)
+    host2 = FactoryBot.create :discovered_host
+    ForemanDiscovery::UINotifications::NewHost.deliver!(host2)
+    refute blueprint.notifications.first.notification_recipients.first.seen
+  end
+
   private
 
   def blueprint


### PR DESCRIPTION
after marking discovery notification as read, new hosts discovered do
not show a new notification since the read marker is kept.