### PR TITLE
Fixes #20215 - Fix the accordian for Expand All button

### DIFF
--- a/app/helpers/discovered_hosts_helper.rb
+++ b/app/helpers/discovered_hosts_helper.rb
@@ -20,8 +20,7 @@ module DiscoveredHostsHelper
         ),
         select_action_button( _("Select Action"), {}, provision_button(host, hash_for_edit_discovered_host_path(:id => host)), actions.map { |action| display_link_if_authorized(action[0] , action[1], action[2] || {}) }.flatten ),
       button_group(
-        link_to(_("Expand All"),"#",:class => "btn btn-default",:onclick => "$('.glyphicon-plus-sign').toggleClass('glyphicon glyphicon-minus-sign glyphicon glyphicon-plus-sign');
-                $('.facts-panel').addClass('collapse in').height('auto');"
+        link_to(_("Expand All"),"#", :id => "expand_all", :class => "btn btn-default"
         )
       ),
       button_group(

--- a/app/views/discovered_hosts/show.html.erb
+++ b/app/views/discovered_hosts/show.html.erb
@@ -69,7 +69,7 @@
               </a>
             </h4>
           </div>
-          <div id="<%= @categories_names[index].to_s + "panel" %>" class="panel-collapse collapse facts-panel <%= "in" if @categories_names[index].to_s.include?"Storage"%>" role="tabpanel">
+          <div id="<%= @categories_names[index].to_s + "panel" %>" class="panel-collapse collapse facts-panel" role="tabpanel">
             <table class="table table-bordered  table-condensed table-fixed">
             <% val.sort.each do |key, value|  %>
                 <tr class="">
@@ -99,5 +99,13 @@
     $('.flag-provision').append(flags_provision);
     $('.primary-flag').tooltip();
     $('.provision-flag').tooltip();
+
+    $('#expand_all').on('click', function () {
+      $('#accordion .panel-collapse').collapse('toggle');
+      $(this).text(function(i, text){
+          return text === "Expand All" ? "Collapse All" : "Expand All";
+      })
+    });
+
   });
 </script>


### PR DESCRIPTION
This patch ensures that :
a) The `Expand All` button also performs collapse.
b) The accordian sign changes when `Expand All` button is clicked.
c) Also, the button text is changed from `Exapand All` to `Collapse All` as required.