### PR TITLE
Fixes #21244 - Rails 5 upgrade test failures

### DIFF
--- a/app/controllers/api/v2/discovered_hosts_controller.rb
+++ b/app/controllers/api/v2/discovered_hosts_controller.rb
@@ -97,7 +97,8 @@ module Api
       param :facts, Hash, :required => true, :desc => N_("hash containing facts for the host with minimum set of facts: discovery_bootif, macaddress_eth0, ipaddress, ipaddress_eth0, interfaces: eth0 (example in case primary interface is named eth0)")
 
       def facts
-        facts = params['facts']
+        # creating a host from facts is not a mass assignment - we store them individually
+        facts = params['facts'].to_unsafe_h
         state = true
         User.as_anonymous_admin do
           @discovered_host = Host::Discovered.import_host(facts)

--- a/app/controllers/foreman_discovery/concerns/hosts_controller_extensions.rb
+++ b/app/controllers/foreman_discovery/concerns/hosts_controller_extensions.rb
@@ -10,7 +10,7 @@ module ForemanDiscovery
       # in the hosts controller like all the _selected methods, taxonomy_scope,
       # etc.. expect a params[:host] to work.
       def set_discovered_params
-        return unless request.path.match(/discovered_hosts/).present?
+        return if params[:discovered_host].nil?
         params[:host] ||= params[:discovered_host]
       end
     end

--- a/test/functional/api/v2/discovered_hosts_controller_test.rb
+++ b/test/functional/api/v2/discovered_hosts_controller_test.rb
@@ -64,7 +64,7 @@ class Api::V2::DiscoveredHostsControllerTest < ActionController::TestCase
           hostgroup_id: hostgroup.id
         }
 
-    assert_match /#{host.name}/, @response.body
+    assert_match(/#{host.name}/, @response.body)
     assert_response :success
 
     # Get the managed host instance from the DB
@@ -105,7 +105,7 @@ class Api::V2::DiscoveredHostsControllerTest < ActionController::TestCase
     taxonomy = { :organizations => [host.organization], :locations => [host.location] }
     rule = FactoryGirl.create(:discovery_rule, {:priority => 1, :search => "facts.somefact = abc", :hostgroup => FactoryGirl.create(:hostgroup, :with_os, :with_rootpass, taxonomy)}.merge(taxonomy))
     post :auto_provision, { :id => host.id }
-    assert_match /Host #{host.name} was provisioned with rule #{rule.name}/, @response.body
+    assert_match(/Host #{host.name} was provisioned with rule #{rule.name}/, @response.body)
     managed_host = Host.unscoped.find(host.id)
     assert managed_host.build
     assert_response :success
@@ -119,7 +119,7 @@ class Api::V2::DiscoveredHostsControllerTest < ActionController::TestCase
     taxonomy = { :organizations => [host.organization], :locations => [host.location] }
     rule = FactoryGirl.create(:discovery_rule, {:priority => 1, :search => "facts.somefact = abc", :hostgroup => FactoryGirl.create(:hostgroup, :with_os, :with_rootpass, taxonomy)}.merge(taxonomy))
     post :auto_provision, { :id => host.id }
-    assert_match /Host #{host.name} was provisioned with rule #{rule.name}/, @response.body
+    assert_match(/Host #{host.name} was provisioned with rule #{rule.name}/, @response.body)
     managed_host = Host.unscoped.find(host.id)
     assert managed_host.build
     assert_response :success
@@ -183,7 +183,7 @@ class Api::V2::DiscoveredHostsControllerTest < ActionController::TestCase
     taxonomy = { :organizations => [host.organization], :locations => [host.location] }
     FactoryGirl.create(:discovery_rule, {:priority => 1, :search => "facts.somefact = abc", :hostgroup => FactoryGirl.create(:hostgroup, :with_os, :with_rootpass, taxonomy)}.merge(taxonomy))
     post :auto_provision_all, {}
-    assert_match /1 discovered hosts were provisioned/, @response.body
+    assert_match(/1 discovered hosts were provisioned/, @response.body)
     managed_host = Host.unscoped.find(host.id)
     assert managed_host.build
     assert_response :success
@@ -194,7 +194,7 @@ class Api::V2::DiscoveredHostsControllerTest < ActionController::TestCase
     facts = @facts.merge({"somefact" => "abc"})
     discover_host_from_facts(facts)
     post :auto_provision_all, {}
-    assert_match /0 discovered hosts were provisioned/, @response.body
+    assert_match(/0 discovered hosts were provisioned/, @response.body)
     assert_response :success
   end
 

--- a/test/functional/api/v2/discovery_rules_controller_test.rb
+++ b/test/functional/api/v2/discovery_rules_controller_test.rb
@@ -38,10 +38,11 @@ class Api::V2::DiscoveryRulesControllerTest < ActionController::TestCase
         :name => "foo",
         :search => "bar",
         :hostgroup_id => hostgroup.id,
-        :organization_ids => [organization_one],
+        :organization_ids => [organization_one.id],
         :location_ids => [location_one.id],
         :hostname => "",
         :priority => 1}}
+      refute_match /error/, response.body
     end
     assert_response :success
   end
@@ -54,7 +55,6 @@ class Api::V2::DiscoveryRulesControllerTest < ActionController::TestCase
 
   test "should update taxonomy for discovery rule" do
     rule = FactoryGirl.create(:discovery_rule)
-    organization = FactoryGirl.create(:organization)
     put :update, { :id => rule.to_param, :discovery_rule => { :organization_ids => [rule.organizations.first.id] } }
     assert_response :success
   end

--- a/test/functional/foreman_discovery/concerns/hosts_controller_extensions_test.rb
+++ b/test/functional/foreman_discovery/concerns/hosts_controller_extensions_test.rb
@@ -7,16 +7,15 @@ module ForemanDiscovery
 
       context 'hosts controller requests from discovered_hosts url' do
         test 'get "host" params from "discovered_hosts" params' do
-          architecture = FactoryGirl.create(:architecture)
+          os = FactoryGirl.create(:operatingsystem, :with_associations)
+          arch_id = os.architectures.first.id
           discovered_host_params = {
-            'discovered_host' => { 'architecture_id' => architecture.id }
+            'discovered_host' => { 'architecture_id' => arch_id }
           }
 
-          @request.stubs(:path).
-            returns(architecture_selected_discovered_hosts_path)
-
+          @request.stubs(:path).returns(architecture_selected_discovered_hosts_path)
           post :architecture_selected, discovered_host_params, set_session_user
-          assert assigns('architecture'), architecture
+          assert_match(/"#{os.id}"/, response.body)
         end
       end
     end


### PR DESCRIPTION
Remaining 2/3 R5 errors fixed, but there is one which wrote @dLobato and I don't understand. The assertion in the test looks incorrect to me, assert takes one parameter, should that be `assert_equal`? In any case, architecture is not being set there. Can you take a look? It's this one:

```ruby
module ForemanDiscovery
  module Concerns
    class HostsControllerTest < ActionController::TestCase
      tests ::HostsController

      context 'hosts controller requests from discovered_hosts url' do
        test 'get "host" params from "discovered_hosts" params' do
          architecture = FactoryGirl.create(:architecture)
          discovered_host_params = {
            'discovered_host' => { 'architecture_id' => architecture.id }
          }

          @request.stubs(:path).
            returns(architecture_selected_discovered_hosts_path)

          post :architecture_selected, discovered_host_params, set_session_user
          assert assigns('architecture'), architecture # THIS FAILS, 1st param is nil
        end
      end
    end
  end
end
```