### PR TITLE
Fixes #21407 - fix broken foreign keys

### DIFF
--- a/db/migrate/20161006094714_add_constraints_on_subnets_smart_proxies.rb
+++ b/db/migrate/20161006094714_add_constraints_on_subnets_smart_proxies.rb
@@ -7,6 +7,9 @@ class AddConstraintsOnSubnetsSmartProxies < ActiveRecord::Migration
       ActiveRecord::Migration.execute "SET FOREIGN_KEY_CHECKS=0;"
     end
 
+    # if there's some wrong key already, clean the foreign key first
+    Subnet.unscoped.where(["discovery_id IS NOT NULL AND discovery_id NOT IN (?)", SmartProxy.unscoped.pluck(:id)]).update_all(:discovery_id => nil)
+
     add_foreign_key "subnets", "smart_proxies", :name => "subnets_discovery_id_fk", :column => "discovery_id"
     
     # turn on Foreign Key checks in MySQL only


### PR DESCRIPTION
this fixes the issue for users who have not yet upgraded, for users who ran this migration it worked anyway :-)

to reproduce
1) create a smart proxy with discovery feature
2) create a subnet that you link to it
3) remove the smart proxy, check the subnet has still discovery_id set to that deleted smart proxy in db
4) run this migration