### PR TITLE
Fixes #21417 - Host update propagates facets

### DIFF
--- a/app/controllers/api/v2/discovered_hosts_controller.rb
+++ b/app/controllers/api/v2/discovered_hosts_controller.rb
@@ -80,7 +80,7 @@ module Api
       end
 
       def update
-        @host = ::ForemanDiscovery::HostConverter.to_managed(@discovered_host, true, true, discovered_host_params)
+        @host = ::ForemanDiscovery::HostConverter.to_managed(@discovered_host, true, true, managed_host_params)
         forward_request_url
         update_response = @host.save
         process_response update_response

--- a/app/controllers/concerns/foreman/controller/parameters/discovered_host.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/discovered_host.rb
@@ -1,7 +1,6 @@
 module Foreman::Controller::Parameters::DiscoveredHost
   extend ActiveSupport::Concern
-  include Foreman::Controller::Parameters::HostBase
-  include Foreman::Controller::Parameters::HostCommon
+  include Foreman::Controller::Parameters::Host
 
   class_methods do
     def discovered_host_params_filter
@@ -20,5 +19,13 @@ module Foreman::Controller::Parameters::DiscoveredHost
 
   def discovered_host_params_host
     self.class.discovered_host_params_filter.filter_params(params, parameter_filter_context, :host)
+  end
+
+  def managed_host_params_host
+    self.class.host_params_filter.filter_params(params, parameter_filter_context, :host)
+  end
+
+  def managed_host_params
+    self.class.host_params_filter.filter_params(params, parameter_filter_context)
   end
 end

--- a/app/controllers/discovered_hosts_controller.rb
+++ b/app/controllers/discovered_hosts_controller.rb
@@ -66,7 +66,7 @@ class DiscoveredHostsController < ::ApplicationController
   end
 
   def update
-    @host = ::ForemanDiscovery::HostConverter.to_managed(@host, true, true, discovered_host_params_host)
+    @host = ::ForemanDiscovery::HostConverter.to_managed(@host, true, true, managed_host_params_host)
     forward_url_options
 
     perform_update(@host)


### PR DESCRIPTION
Discovery Host update call would filter out Facet parameters on update.
This caused things ContentFacet an SubscriptionFacet used by Katello to
be not propagated over when one provisioned the Host with updates on the
synced media.

This commit fixes that issue by making the host provisioning call use
managed host parameters for updates so that those facets can go through.