### PR TITLE
Fixes #21908 - Safemode doesn't allow to access 'resbody' on rescue

### DIFF
--- a/app/views/foreman_discovery/debian_kexec.erb
+++ b/app/views/foreman_discovery/debian_kexec.erb
@@ -18,7 +18,7 @@ Please read kexec(8) man page for more information about semantics.
 -%>
 <%
   mac = @host.facts['discovery_bootif']
-  bootif = '00-' + mac.gsub(':', '-') rescue ''
+  bootif = '00-' + mac.gsub(':', '-') if mac
   ip_cidr = @host.facts['discovery_ip_cidr']
   ip = @host.facts['discovery_ip']
   mask = @host.facts['discovery_netmask']


### PR DESCRIPTION
This fixes the same problem as was reported in bug Bug #12237 but for the debian template