### PR TITLE
Fixes #21941 - Add validation for Host Group

### DIFF
--- a/app/models/discovery_rule.rb
+++ b/app/models/discovery_rule.rb
@@ -11,6 +11,7 @@ class DiscoveryRule < ApplicationRecord
   validates :hostname, :format => { :with => /\A[a-zA-Z<]/, :message => N_("must start with a letter or ERB.") },
     :allow_blank => true
   validates :hostgroup_id, :presence => true
+  validates :hostgroup, :presence => {:message => N_("must be present.")}
   validates :max_count, :numericality => { :only_integer => true, :greater_than_or_equal_to => 0, :less_than => 2**31 }
   validates :priority, :presence => true, :numericality => { :only_integer => true, :greater_than_or_equal_to => 0, :less_than => 2**31 }
   validates_lengths_from_database

--- a/db/migrate/20171222120314_add_constraints_on_discovery_rules_hostgroups.rb
+++ b/db/migrate/20171222120314_add_constraints_on_discovery_rules_hostgroups.rb
@@ -1,0 +1,8 @@
+ class AddConstraintsOnDiscoveryRulesHostgroups < ActiveRecord::Migration[4.2]
+  
+   def change
+    DiscoveryRule.unscoped.where("hostgroup_id IS NULL OR hostgroup_id NOT IN (?)", Hostgroup.unscoped.all.pluck(:id)).delete_all
+    add_foreign_key "discovery_rules", "hostgroups", name: "discovery_rules_hostgroup_id_fk", :column => "hostgroup_id"
+  end
+
+ end

--- a/test/unit/discovery_rule_test.rb
+++ b/test/unit/discovery_rule_test.rb
@@ -72,13 +72,24 @@ class DiscoveryRuleTest < ActiveSupport::TestCase
     assert_valid rule
   end
 
-  test "should not be able to create a rule without a hostgroup" do
+  test "should not be able to create a rule without a hostgroup-id" do
     rule = DiscoveryRule.new :name => "myrule",
       :search => "cpu_count > 1",
       :organization_ids => [organization_one.id],
       :location_ids => [location_one.id]
     refute_valid rule
     assert_equal "can't be blank", rule.errors[:hostgroup_id].first
+  end
+
+  test "should not be able to create a rule without a valid hostgroup" do
+    rule = DiscoveryRule.new :name => "myrule",
+      :search => "cpu_count > 1",
+      :organization_ids => [organization_one.id],
+      :location_ids => [location_one.id],
+      :hostgroup_id => 99999
+    refute_valid rule
+
+    assert_equal "must be present.", rule.errors[:hostgroup].first
   end
 
   test "should not be able to create a rule with priority bigger than 2^31" do


### PR DESCRIPTION
We are just checking whether the `hostgroup_id` is being passed from hammer but we are not checking whether that hostgroup_id has a corresponding hostgroup in the database or not. 

This patch makes sure, only valid hostgroup_id's are passed which correspond to a valid hostgroup.