### PR TITLE
Fixes #21935 - Notifications for org admins too

### DIFF
--- a/app/services/foreman_discovery/ui_notifications/new_host.rb
+++ b/app/services/foreman_discovery/ui_notifications/new_host.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ForemanDiscovery
   module UINotifications
     # Adds notification upon newly discovered Hosts
@@ -17,7 +18,8 @@ module ForemanDiscovery
       def add_notification
         Notification.create!(
           initiator: initiator,
-          audience: ::Notification::AUDIENCE_ADMIN,
+          audience: ::Notification::AUDIENCE_SUBJECT,
+          subject: subject,
           notification_blueprint: blueprint
         )
       end

--- a/test/unit/ui_notifications/destroy_host_test.rb
+++ b/test/unit/ui_notifications/destroy_host_test.rb
@@ -7,8 +7,9 @@ class DestroyHostNotificationTest < ActiveSupport::TestCase
     assert blueprint
   end
 
-  test 'destorying discovered host should remove notification' do
+  test 'destroying discovered host should remove notification' do
     host = FactoryBot.create(:discovered_host)
+    ForemanDiscovery::UINotifications::NewHost.deliver!(host)
     assert_difference('blueprint.notifications.count', -1) do
       host.destroy
     end
@@ -16,11 +17,13 @@ class DestroyHostNotificationTest < ActiveSupport::TestCase
 
   test 'do not remove notification if other discovered hosts exists' do
     assert_difference('blueprint.notifications.count') do
-      FactoryBot.create(:discovered_host)
+      host = FactoryBot.create(:discovered_host)
+      ForemanDiscovery::UINotifications::NewHost.deliver!(host)
     end
     assert_equal 1, blueprint.notifications.count
     assert_no_difference('blueprint.notifications.count') do
-      FactoryBot.create(:discovered_host)
+      host = FactoryBot.create(:discovered_host)
+      ForemanDiscovery::UINotifications::NewHost.deliver!(host)
     end
     assert_no_difference('blueprint.notifications.count') do
       Host::Discovered.all.last.destroy
@@ -31,6 +34,7 @@ class DestroyHostNotificationTest < ActiveSupport::TestCase
 
   test 'discovered host type change should update notifications' do
     host = FactoryBot.create(:discovered_host)
+    ForemanDiscovery::UINotifications::NewHost.deliver!(host)
     assert_equal 1, blueprint.notifications.count
     new_host = ::ForemanDiscovery::HostConverter.to_managed(host, false, false)
     assert new_host.save!
@@ -39,10 +43,16 @@ class DestroyHostNotificationTest < ActiveSupport::TestCase
 
   test 'type change should not removing notifications for discovered hosts' do
     host1 = FactoryBot.create(:discovered_host)
-    FactoryBot.create(:discovered_host)
+    ForemanDiscovery::UINotifications::NewHost.deliver!(host1)
+    host2 = FactoryBot.create(:discovered_host)
+    ForemanDiscovery::UINotifications::NewHost.deliver!(host2)
     assert_equal 1, blueprint.notifications.count
     new_host = ::ForemanDiscovery::HostConverter.to_managed(host1, false, false)
     assert new_host.save!
     assert_equal 1, blueprint.notifications.count
+  end
+
+  def parse_json_fixture(relative_path)
+    return JSON.parse(File.read(File.expand_path(File.dirname(__FILE__) + relative_path)))
   end
 end

--- a/test/unit/ui_notifications/new_host_test.rb
+++ b/test/unit/ui_notifications/new_host_test.rb
@@ -8,8 +8,11 @@ class NewHostNotificationTest < ActiveSupport::TestCase
   end
 
   test 'new discovered host should generate a notification' do
+    set_default_settings
+    FactImporter.any_instance.expects(:ensure_no_active_transaction).
+      returns(true).at_least_once
     assert_difference('blueprint.notifications.count') do
-      FactoryBot.create :discovered_host
+      discover_host_from_facts(parse_json_fixture('/../facts.json')['facts'])
     end
   end
 
@@ -22,5 +25,9 @@ class NewHostNotificationTest < ActiveSupport::TestCase
     ForemanDiscovery::UINotifications::NewHost.deliver!(host2)
     assert_equal 1, blueprint.notifications.count
     assert_not_equal expired_at, blueprint.notifications.first.expired_at
+  end
+
+  def parse_json_fixture(relative_path)
+    return JSON.parse(File.read(File.expand_path(File.dirname(__FILE__) + relative_path)))
   end
 end


### PR DESCRIPTION
Before this commit, the notifications for new discovered host were only
seen by admins (global admins). However, the organization admins should
also be able to see these notifications.