### PR TITLE
Fixes #22297 - [Discovery rules]Fix the pagination

### DIFF
--- a/app/controllers/discovery_rules_controller.rb
+++ b/app/controllers/discovery_rules_controller.rb
@@ -8,7 +8,7 @@ class DiscoveryRulesController < ApplicationController
 
   def index
     base = resource_base.search_for(params[:search], :order => (params[:order]))
-    @discovery_rules = base.paginate(:page => params[:page]).includes(:hostgroup)
+    @discovery_rules = base.paginate(:page => params[:page], :per_page => params[:per_page]).includes(:hostgroup)
   end
 
   def new


### PR DESCRIPTION
By default 20 items must be displayed on the current page but if you have say 20 items and
want to show only 5 on page, then the pagination does not work correctly.
This patch makes sure that correct number of rows are displayed per page.