### PR TITLE
Fixes #22783 - Audit discovery resources

### DIFF
--- a/app/models/discovery_rule.rb
+++ b/app/models/discovery_rule.rb
@@ -1,4 +1,5 @@
 class DiscoveryRule < ApplicationRecord
+  audited :associated_with => :hostgroup
   include Authorizable
   extend FriendlyId
   friendly_id :name


### PR DESCRIPTION
Audit resources - discovery rule, attribute-set & relation with hostgroup