### PR TITLE
Fixes #22932 - unprocessible contains backtrace

### DIFF
--- a/app/controllers/api/v2/discovered_hosts_controller.rb
+++ b/app/controllers/api/v2/discovered_hosts_controller.rb
@@ -109,8 +109,7 @@ module Api
         end
         process_response state
       rescue Exception => e
-        logger.warn "Host discovery failed, facts: #{facts}"
-        logger.debug e.message + "\n" + e.backtrace.join("\n")
+        Foreman::Logging.exception("Host discovery failed, facts: #{facts}", e)
         render :json => {'message'=>e.to_s}, :status => :unprocessable_entity
       end
 


### PR DESCRIPTION
To avoid increasing to DEBUG mode when troubleshooting failed discoveries.