### PR TITLE
Fixes #23170 - Numeric input fields does not use the standard style

### DIFF
--- a/app/views/discovery_rules/_form.html.erb
+++ b/app/views/discovery_rules/_form.html.erb
@@ -23,11 +23,17 @@
             <%= text_f f, :hostname,
                        :label_help => render('discovery_rules/template_inline').html_safe,
                        :label_help_options => {:title => _("Hostname for provisioned hosts"), :'data-placement' => 'bottom' } %>
-            <%= number_f f, :max_count, :label => _('Hosts Limit'), :help_inline => _('Maximum hosts provisioned with this rule (0 = unlimited)'), :min => 0, :max => (2**31 - 1) %>
-            <%= number_f f, :priority, :help_inline => _('Rule priority (lower integer means higher priority)'), :min => 0, :max => (2**31 - 1) %>
+            <%= counter_f f, :max_count, :label => _('Hosts Limit'), :help_inline => _('Maximum hosts provisioned with this rule (0 = unlimited)'), :min => 0 %>
+            <%= counter_f f, :priority, :help_inline => _('Rule priority (lower integer means higher priority)'), step: 100, value: 0 %>
             <%= checkbox_f f, :enabled %>
           </div>
           <%= render 'taxonomies/loc_org_tabs', :f => f, :obj => @discovery_rule %>
         </div>
     <%= submit_or_cancel f %>
 <% end %>
+
+<script type="text/javascript" charset="utf-8">
+$(document).ready(function() {
+  $('input.counter_spinner').spinner();
+});
+</script>


### PR DESCRIPTION
Original:
![original - discovery numeric fields](https://user-images.githubusercontent.com/73091/38490386-9d4c9aaa-3bf1-11e8-9fbc-d9e38e08b866.png)

New:
![new - discovery numeric fields](https://user-images.githubusercontent.com/73091/38490394-a38917e0-3bf1-11e8-806d-a5a97639a798.png)
