### PR TITLE
Rails 5.2 upgrade config/as_deprecation_whitelist.yaml

### DIFF
--- a/config/as_deprecation_whitelist.yaml
+++ b/config/as_deprecation_whitelist.yaml
@@ -1,0 +1,343 @@
+---
+- message: "#table_exists? currently checks both tables and views. This behavior is
+    deprecated and will be changed with Rails 5.1 to only check tables. Use #data_source_exists?
+    instead."
+- message: "#tables currently returns both tables and views. This behavior is deprecated
+    and will be changed with Rails 5.1 to only return tables. Use #data_sources instead."
+- message: The behavior of `attribute_change` inside of after callbacks will be changing
+    in the next version of Rails. The new return value will reflect the behavior of
+    calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute` instead.
+  callstack: app/models/concerns/strip_whitespace.rb:9:in `strip_spaces'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: 
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: app/controllers/hosts_controller.rb:828:in `block in update_multiple_proxy'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: app/models/concerns/encryptable.rb:41:in `block in encrypt_setters'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: app/models/concerns/foreman/sti.rb:26:in `save'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: app/models/concerns/foreman/sti.rb:26:in `save'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: app/models/concerns/strip_whitespace.rb:9:in `strip_spaces'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: app/models/host.rb:15:in `method_missing'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: app/models/host/managed.rb:597:in `associate!'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: app/models/host/managed.rb:603:in `disassociate!'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: app/models/host/managed.rb:753:in `refresh_global_status!'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/controllers/api/v2/audits_controller_test.rb:23:in `block in <class:AuditsControllerTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/controllers/environments_controller_test.rb:152:in `block (2 levels)
+    in <class:EnvironmentsControllerTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/controllers/hosts_controller_test.rb:308:in `block in setup_user_and_host'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/controllers/hosts_controller_test.rb:338:in `block (2 levels) in
+    <class:HostsControllerTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/controllers/hosts_controller_test.rb:352:in `block (2 levels) in
+    <class:HostsControllerTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/factories/disable_auditing.rb:13:in `block (3 levels) in <top (required)>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/factories/disable_auditing.rb:13:in `block (3 levels) in <top (required)>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/factories/disable_auditing.rb:15:in `block (2 levels) in <top (required)>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/concerns/audit_extensions_test.rb:103:in `block (2 levels)
+    in <class:AuditExtensionsTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/domain_test.rb:65:in `block (2 levels) in <class:DomainTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/host_test.rb:1132:in `block (2 levels) in <class:HostTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/host_test.rb:116:in `block in <class:HostTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/host_test.rb:1186:in `block (2 levels) in <class:HostTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/host_test.rb:1224:in `block (2 levels) in <class:HostTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/host_test.rb:1237:in `block (2 levels) in <class:HostTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/host_test.rb:1258:in `block (2 levels) in <class:HostTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/host_test.rb:1918:in `block (3 levels) in <class:HostTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/host_test.rb:242:in `block (2 levels) in <class:HostTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/host_test.rb:2540:in `block in <class:HostTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/host_test.rb:255:in `block (2 levels) in <class:HostTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/host_test.rb:268:in `block (2 levels) in <class:HostTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/host_test.rb:2769:in `block in <class:HostTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/host_test.rb:2782:in `block in <class:HostTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/host_test.rb:2795:in `block in <class:HostTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/host_test.rb:283:in `block (2 levels) in <class:HostTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/host_test.rb:3022:in `block (2 levels) in <class:HostTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/host_test.rb:58:in `block in <class:HostTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/host_test.rb:690:in `block (2 levels) in <class:HostTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/host_test.rb:708:in `block (2 levels) in <class:HostTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/medium_test.rb:80:in `block in <class:MediumTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/medium_test.rb:97:in `block in <class:MediumTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/nic_test.rb:392:in `block (3 levels) in <class:NicTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/orchestration/dns_test.rb:117:in `block (2 levels) in <class:DnsOrchestrationTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/orchestration/dns_test.rb:139:in `block (2 levels) in <class:DnsOrchestrationTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/orchestration/dns_test.rb:153:in `block (2 levels) in <class:DnsOrchestrationTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/orchestration/dns_test.rb:192:in `block (3 levels) in <class:DnsOrchestrationTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/orchestration/dns_test.rb:226:in `block (2 levels) in <class:DnsOrchestrationTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/orchestration/dns_test.rb:239:in `block (2 levels) in <class:DnsOrchestrationTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/orchestration/dns_test.rb:308:in `block (2 levels) in <class:DnsOrchestrationTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/orchestration/dns_test.rb:323:in `block (2 levels) in <class:DnsOrchestrationTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/models/orchestration/dns_test.rb:51:in `block (2 levels) in <class:DnsOrchestrationTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/unit/compute_resource_host_associator_test.rb:16:in `block in <class:ComputeResourceHostAssociatorTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/unit/compute_resource_host_associator_test.rb:29:in `block in <class:ComputeResourceHostAssociatorTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/unit/facet_test.rb:123:in `block (2 levels) in <class:FacetTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/unit/has_many_common_test.rb:61:in `block in <class:HasManyCommonTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/unit/has_many_common_test.rb:81:in `block in <class:HasManyCommonTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/unit/host_token_test.rb:11:in `block (3 levels) in <class:HostTokenTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/unit/interface_cleaner_test.rb:17:in `block in <class:InterfaceCleanerTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/unit/interface_cleaner_test.rb:32:in `block in <class:InterfaceCleanerTest>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: test/unit/interface_cleaner_test.rb:56:in `block in <class:InterfaceCleanerTest>'
+- message: The behavior of `changed_attributes` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_changes.transform_values(&:first)`
+    instead.
+  callstack: app/models/concerns/strip_whitespace.rb:9:in `strip_spaces'
+- message: The behavior of `changed` inside of after callbacks will be changing in
+    the next version of Rails. The new return value will reflect the behavior of calling
+    the method after `save` returned (e.g. the opposite of what it returns now). To
+    maintain the current behavior, use `saved_changes.keys` instead.
+  callstack: app/models/concerns/strip_whitespace.rb:9:in `strip_spaces'
+- message: The behavior of `changes` inside of after callbacks will be changing in
+    the next version of Rails. The new return value will reflect the behavior of calling
+    the method after `save` returned (e.g. the opposite of what it returns now). To
+    maintain the current behavior, use `saved_changes` instead.
+  callstack: app/models/concerns/strip_whitespace.rb:9:in `strip_spaces'
+- message: Using a dynamic :controller segment in a route is deprecated and will be
+    removed in Rails 5.2.
+  callstack: config/routes.rb:17:in `block in <top (required)>'
+- message: You are using a deprecated behavior, it will be removed in version 1.18,
+    please migrate notice() to success() or info()
+  callstack: app/controllers/concerns/application_shared.rb:15:in `set_timezone'
+- message: You didn't set `secret_key_base`. Read the upgrade documentation to learn
+    more about this new config option.
+  callstack: 
+- message: You didn't set `secret_key_base`. Read the upgrade documentation to learn
+    more about this new config option.
+  callstack: test/test_helper.rb:36:in `before_setup'


### PR DESCRIPTION
This should help with getting develop tests green until Rails 5.2 upgrade is complete.