### PR TITLE
Fixes #3862 - audit host discovery

### DIFF
--- a/app/models/host/discovered.rb
+++ b/app/models/host/discovered.rb
@@ -1,4 +1,9 @@
 class Host::Discovered < ::Host::Base
+  audited :except => [:last_report]
+  has_associated_audits
+  # redefine audits relation because of the type change (by default the relation will look for auditable_type = 'Host::Managed')
+  has_many :audits, -> { where(:auditable_type => 'Host::Base') }, :foreign_key => :auditable_id, :class_name => 'Audited::Audit'
+
   include ScopedSearchExtensions
   include Foreman::Renderer
   include BelongsToProxies


### PR DESCRIPTION
I think it makes sense because if a host is provisioned manually by user, then the audit trail does not make much sense - it starts with "user X edited host Y" while this was actually discovered host provisioning.