### PR TITLE
Fixes #23488 - Port robottelo tests for discovery_rule

### DIFF
--- a/test/functional/api/v2/discovery_rules_controller_test.rb
+++ b/test/functional/api/v2/discovery_rules_controller_test.rb
@@ -31,6 +31,23 @@ class Api::V2::DiscoveryRulesControllerTest < ActionController::TestCase
     assert_equal "Location 1", discovery_rule['locations'].first['name']
   end
 
+  test_attributes :pid => 'b8ae7a80-b9a8-4924-808c-482a2b4102c4'
+  test "should create discovery rule with name" do
+    min_required_attr = { :name => 'new_rule', :search => 'CPU_Count = 1', :hostgroup_id => hostgroups(:unusual).id }
+    assert_difference('DiscoveryRule.unscoped.count') do
+      post :create, params: {:discovery_rule => min_required_attr}
+    end
+    assert_response :success
+    response = JSON.parse(@response.body)
+    assert response.key?('name')
+    assert_equal min_required_attr[:name], response['name']
+    assert response.key?('hostgroup_id')
+    assert_equal min_required_attr[:hostgroup_id], response['hostgroup_id']
+    assert response.key?('search')
+    assert_equal min_required_attr[:search], response['search']
+  end
+
+  test_attributes :pid => '121e0a30-8a24-47d7-974d-998886ed1ea7'
   test "should create discovery rule with taxonomy" do
     assert_difference('DiscoveryRule.unscoped.count') do
       hostgroup = FactoryBot.create(:hostgroup, :with_os, :with_rootpass, :organizations => [organization_one], :locations => [location_one])
@@ -45,6 +62,12 @@ class Api::V2::DiscoveryRulesControllerTest < ActionController::TestCase
       refute_match /error/, response.body
     end
     assert_response :success
+    response = JSON.parse(@response.body)
+    assert response.key?('id')
+    discovery_rule = DiscoveryRule.unscoped.find(response['id'])
+    refute discovery_rule.nil?
+    assert_equal organization_one.id, discovery_rule.organizations.first.id
+    assert_equal location_one.id, discovery_rule.locations.first.id
   end
 
   test "should update discovery rule" do
@@ -53,17 +76,120 @@ class Api::V2::DiscoveryRulesControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test_attributes :pid => '769c0739-538b-4451-af7b-deb2ecd3dc0d'
+  test "should update discovery rule name" do
+    rule = FactoryBot.create(:discovery_rule)
+    new_name = 'new_rule_name'
+    put :update, params: { :id => rule.to_param, :discovery_rule => { :name => new_name } }
+    assert_response :success
+    rule.reload
+    assert_equal new_name, rule.name
+  end
+
   test "should update taxonomy for discovery rule" do
     rule = FactoryBot.create(:discovery_rule)
     put :update, params: { :id => rule.to_param, :discovery_rule => { :organization_ids => [rule.organizations.first.id] } }
     assert_response :success
   end
 
+  test_attributes :pid => '0f8ec302-f9de-4713-87b7-0f1aca515149'
+  test "should update taxonomies for discovery rule" do
+    min_required_attr = { :name => 'new_rule', :search => 'CPU_Count = 1', :hostgroup_id => hostgroups(:unusual).id }
+    rule = DiscoveryRule.new(min_required_attr)
+    assert rule.save
+    assert rule.organizations.empty?
+    assert rule.locations.empty?
+    hostgroup = FactoryBot.create(:hostgroup, :with_os, :with_rootpass, :organizations => [organization_one], :locations => [location_one])
+    put :update, params: { :id => rule.to_param, :discovery_rule => {
+      :organization_ids => [organization_one.id],
+      :location_ids => [location_one.id],
+      :hostgroup_id => hostgroup.id
+    }}
+    assert_response :success
+    rule.reload
+    assert_equal [organization_one.id], rule.organizations.map {|org| org.id}
+    assert_equal [location_one.id], rule.locations.map {|loc| loc.id}
+  end
+
+  test_attributes :pid => '2c5ecb7e-87bc-4980-9620-7ae00e3f360e'
+  test "should update search rule" do
+    rule = FactoryBot.create(:discovery_rule)
+    new_search = 'Location = Default_Location'
+    put :update, params: { :id => rule.to_param, :discovery_rule => { :search => new_search } }
+    assert_response :success
+    rule.reload
+    assert_equal new_search, rule.search
+  end
+
+  test_attributes :pid => '33084060-2866-46b9-bfab-23d91aea73d8'
+  test "should update host limit" do
+    rule = FactoryBot.create(:discovery_rule)
+    new_max_count = 150
+    assert_not_equal new_max_count, rule.max_count
+    put :update, params: { :id => rule.to_param, :discovery_rule => { :max_count => new_max_count } }
+    assert_response :success
+    rule.reload
+    assert_equal new_max_count, rule.max_count
+  end
+
+  test_attributes :pid => '330aa943-167b-46dd-b434-1a6e5fe8f283'
+  test "test_positive_disable" do
+    rule = FactoryBot.create(:discovery_rule)
+    assert rule.enabled
+    put :update, params: { :id => rule.to_param, :discovery_rule => { :enabled => false } }
+    assert_response :success
+    rule.reload
+    refute rule.enabled
+  end
+
+  test_attributes :pid => '9fdba953-dcc7-4532-9204-17a45b0d9e05'
   test "should destroy discovery rule" do
     rule = FactoryBot.create(:discovery_rule)
     assert_difference('DiscoveryRule.unscoped.count', -1) do
       delete :destroy, params: { :id => rule.to_param }
     end
     assert_response :success
+    assert_raise(ActiveRecord::RecordNotFound) { DiscoveryRule.unscoped.find(rule.id) }
+  end
+
+  test_attributes :pid => '415379b7-0134-40b9-adb1-2fe0adb1ac36'
+  test "should not create with too long name" do
+    assert_difference('DiscoveryRule.unscoped.count', 0) do
+      post :create, params: {:discovery_rule => {
+        :name => RFauxFactory.gen_alpha(256),
+        :search => 'CPU_Count = 1',
+        :hostgroup_id => hostgroups(:unusual).id
+      }}
+    end
+    assert_response :unprocessable_entity
+    assert_include @response.body, 'Name is too long (maximum is 255 characters)'
+  end
+
+  test_attributes :pid => '84503d8d-86f6-49bf-ab97-eff418d3e3d0'
+  test "should not create with invalid host limit" do
+    assert_difference('DiscoveryRule.unscoped.count', 0) do
+      post :create, params: {:discovery_rule => {
+        :name => 'new_rule',
+        :search => 'CPU_Count = 1',
+        :hostgroup_id => hostgroups(:unusual).id,
+        :max_count => 'invalid max_count type'
+      }}
+    end
+    assert_response :unprocessable_entity
+    assert_include @response.body, 'Max count is not a number'
+  end
+
+  test_attributes :pid => '4ec7d76a-22ba-4c3e-952c-667a6f0a5728'
+  test "should not create with invalid priority" do
+    assert_difference('DiscoveryRule.unscoped.count', 0) do
+      post :create, params: {:discovery_rule => {
+        :name => 'new_rule',
+        :search => 'CPU_Count = 1',
+        :hostgroup_id => hostgroups(:unusual).id,
+        :priority => 'invalid priority type'
+      }}
+    end
+    assert_response :unprocessable_entity
+    assert_include @response.body, 'Priority is not a number'
   end
 end

--- a/test/unit/discovery_rule_test.rb
+++ b/test/unit/discovery_rule_test.rb
@@ -5,6 +5,9 @@ class DiscoveryRuleTest < ActiveSupport::TestCase
     @hostgroup = FactoryBot.create(:hostgroup)
   end
 
+  should allow_values(*valid_name_list).for(:name)
+  should_not allow_values(*invalid_name_list).for(:name)
+
   context "#validates attribute" do
     setup do
       @huge_name = "x" * 256

--- a/test/unit/discovery_rule_test.rb
+++ b/test/unit/discovery_rule_test.rb
@@ -55,6 +55,12 @@ class DiscoveryRuleTest < ActiveSupport::TestCase
     end
   end
 
+  test_attributes :pid => 'b8ae7a80-b9a8-4924-808c-482a2b4102c4'
+  test "should create discovery rule with name and minimum required attributes" do
+    rule = DiscoveryRule.new(:name => 'new_rule', :search => 'cpu_count = 1', :hostgroup_id => hostgroups(:unusual).id)
+    assert_valid rule
+  end
+
   test "should be able to create a rule without entering hosts limit" do
     rule = DiscoveryRule.new :name => "myrule",
       :search => "cpu_count > 1",
@@ -95,6 +101,19 @@ class DiscoveryRuleTest < ActiveSupport::TestCase
     assert_equal "must be present.", rule.errors[:hostgroup].first
   end
 
+  test_attributes :pid => '4ec7d76a-22ba-4c3e-952c-667a6f0a5728'
+  test "should not create with invalid priority type" do
+    rule = DiscoveryRule.new(
+      :name => 'new_rule',
+      :search => 'cpu_count = 1',
+      :hostgroup_id => hostgroups(:unusual).id,
+      :priority => 'invalid priority type'
+    )
+    refute_valid rule
+    assert rule.errors.key?(:priority)
+    assert_equal "is not a number", rule.errors[:priority].first
+  end
+
   test "should not be able to create a rule with priority bigger than 2^31" do
     rule = DiscoveryRule.new :name => "myrule",
       :search => "cpu_count > 1",
@@ -104,6 +123,19 @@ class DiscoveryRuleTest < ActiveSupport::TestCase
       :location_ids => [location_one.id]
     refute_valid rule
     assert_equal "must be less than 2147483648", rule.errors[:priority].first
+  end
+
+  test_attributes :pid => '84503d8d-86f6-49bf-ab97-eff418d3e3d0'
+  test "should not create with invalid max count type" do
+    rule = DiscoveryRule.new(
+      :name => 'new_rule',
+      :search => 'cpu_count = 1',
+      :hostgroup_id => hostgroups(:unusual).id,
+      :max_count => 'invalid max_count type'
+    )
+    refute_valid rule
+    assert rule.errors.key?(:max_count)
+    assert_equal "is not a number", rule.errors[:max_count].first
   end
 
   test "should not be able to create a rule with max count bigger than 2^31" do


### PR DESCRIPTION
Port robottelo tier1 tests for discovery_rule

Related Robottelo issue: https://github.com/SatelliteQE/robottelo/issues/5948

part of robottelo minitest port project: https://github.com/SatelliteQE/robottelo/projects/1