### PR TITLE
Fixes #23193 - Entered organization is lost after discovery

### DIFF
--- a/app/controllers/discovered_hosts_controller.rb
+++ b/app/controllers/discovered_hosts_controller.rb
@@ -71,6 +71,7 @@ class DiscoveredHostsController < ::ApplicationController
     @host = ::ForemanDiscovery::HostConverter.to_managed(@host, true, true, managed_host_params_host)
     forward_url_options
 
+    @override_taxonomy = true
     perform_update(@host)
   end
 


### PR DESCRIPTION
Pull request to attempt to fix #23193 as requested here: https://community.theforeman.org/t/entered-organization-is-lost-after-discovery/8726/11