### PR TITLE
Fixes #23693 - removed --args-linux

### DIFF
--- a/app/views/foreman_discovery/debian_kexec.erb
+++ b/app/views/foreman_discovery/debian_kexec.erb
@@ -35,5 +35,5 @@ Please read kexec(8) man page for more information about semantics.
   "kernel": "<%= @kexec_kernel %>",
   "initram": "<%= @kexec_initrd %>",
   "append": "url=<%= foreman_url('provision') + "&static=yes" %> interface=<%= mac %> netcfg/get_ipaddress=<%= ip %> netcfg/get_netmask=<%= mask %> netcfg/get_gateway=<%= gw %> netcfg/get_nameservers=<%= dns %> netcfg/disable_dhcp=true netcfg/get_hostname=<%= @host.name %> BOOTIF=<%= bootif %> <%= options.join(' ') %>",
-  "extra": ["--args-linux"]
+  "extra": []
 }

--- a/app/views/foreman_discovery/redhat_kexec.erb
+++ b/app/views/foreman_discovery/redhat_kexec.erb
@@ -46,5 +46,5 @@ Please read kexec(8) man page for more information about semantics.
 <% else -%>
   "append": "ks=<%= foreman_url('provision') + "&static=yes" %> kssendmac nicdelay=5 <%= "ip=#{ip} netmask=#{mask} gateway=#{gw} dns=#{dns} ksdevice=#{mac} BOOTIF=#{bootif} nomodeset #{append}" %>",
 <% end -%>
-  "extra": ["--args-linux"]
+  "extra": []
 }


### PR DESCRIPTION
I added the extra options as an ability to provide free-form options to kexec and provided an "example" option which turned out not to work at all. It must be empty by default.

Please squash into one commit, I am on the road this week.