### PR TITLE
Fixes #23224 - keep_subnet flag to prevent subnet override

### DIFF
--- a/app/services/foreman_discovery/fact_parser.rb
+++ b/app/services/foreman_discovery/fact_parser.rb
@@ -13,8 +13,14 @@ module ForemanDiscovery
         {:mac => bootif_mac, :fact => FacterUtils::bootif_name, :filter => Setting[:ignored_interface_identifiers]}))
     end
 
+    # ignores 'ignore_puppet_facts_for_provisioning' setting
     def parse_interfaces?
-      true # to make 'ignore_puppet_facts_for_provisioning' setting non-effective
+      true
+    end
+
+    # ignores 'update_subnets_from_facts' setting
+    def get_facts_for_interface(interface)
+      super.merge(keep_subnet: true)
     end
   end
 end

--- a/lib/foreman_discovery/engine.rb
+++ b/lib/foreman_discovery/engine.rb
@@ -43,7 +43,7 @@ module ForemanDiscovery
 
     initializer 'foreman_discovery.register_plugin', :before => :finisher_hook do |app|
       Foreman::Plugin.register :foreman_discovery do
-        requires_foreman '>= 1.18.0'
+        requires_foreman '>= 1.19.0'
 
         # discovered hosts permissions
         security_block :discovery do

--- a/test/unit/host_discovered_test.rb
+++ b/test/unit/host_discovered_test.rb
@@ -32,6 +32,14 @@ class HostDiscoveredTest < ActiveSupport::TestCase
     assert_equal subnet, host.primary_interface.subnet
   end
 
+  test "should setup subnet when update_subnets_from_facts is true" do
+    Setting[:update_subnets_from_facts] = true
+    subnet = FactoryBot.create(:subnet_ipv4, :name => 'Subnet99', :network => '10.35.27.0', :organizations => [organization_one], :locations => [location_one])
+    Subnet.expects(:subnet_for).with('10.35.27.3').returns(subnet)
+    host = discover_host_from_facts(@facts)
+    assert_equal subnet, host.primary_interface.subnet
+  end
+
   test "should setup subnet with org and loc set via settings" do
     org = FactoryBot.create(:organization, :name => "subnet_org")
     loc = FactoryBot.create(:location, :name => "subnet_loc")


### PR DESCRIPTION
Setting "Update subnets from facts" makes discovery impossible if taxonomy does not match the host leading to "Subnet is not defined for host's organization". Discovery uses standard core Puppet parser to recognize all interfaces, therefore discovery users must have all subnet taxonomy aligned with discovered host taxonomy, even if they don't plan to use all interfaces.

This patch adds flag keep_subnet which is added by discovery, when present subnet is never updated. This prevents the misbehavior when the flag is set.

This patch needs core change:

https://github.com/theforeman/foreman/pull/5635