### PR TITLE
Fixes #23793 - Port robottelo tests for settings

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -261,7 +261,7 @@ Lint/ParenthesesAsGroupedExpression:
   Enabled: false
 
 # Offense count: 176
-Lint/RescueWithoutErrorClass:
+Style/RescueStandardError:
   Enabled: false
 
 # Offense count: 1
@@ -395,12 +395,6 @@ Performance/Caller:
 # Offense count: 9
 # Cop supports --auto-correct.
 Performance/Casecmp:
-  Enabled: false
-
-# Offense count: 32
-# Cop supports --auto-correct.
-# Configuration parameters: AutoCorrect.
-Performance/HashEachMethods:
   Enabled: false
 
 # Offense count: 2
@@ -870,7 +864,7 @@ Style/TernaryParentheses:
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyleForMultiline, SupportedStylesForMultiline.
 # SupportedStylesForMultiline: comma, consistent_comma, no_comma
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
   Enabled: false
 
 # Offense count: 2

--- a/test/functional/api/v2/settings_controller_test.rb
+++ b/test/functional/api/v2/settings_controller_test.rb
@@ -1,0 +1,22 @@
+require 'test_plugin_helper'
+
+class Api::V2::SettingsControllerTest < ActionController::TestCase
+  setup do
+    FactoryBot.create(:setting, :name => 'discovery_prefix', :value => 'mac', :category => 'Setting::Discovered')
+  end
+
+  test_attributes :pid => '2c5ecb7e-87bc-4980-9620-7ae00e3f360e'
+  test "should update hostname prefix without value" do
+    setting = Setting.find_by_name("discovery_prefix")
+    put :update, params: { :id => setting.id, :setting => { :value => '' } }
+    assert_equal JSON.parse(@response.body)['value'], '', "Can't update discovery_prefix setting with empty value"
+  end
+
+  test_attributes :pid => '4969994d-f934-4f0e-9a98-476b87eb0527'
+  test "should update hostname prefix" do
+    value = RFauxFactory.gen_alpha
+    setting = Setting.find_by_name("discovery_prefix")
+    put :update, params: { :id => setting.id, :setting => { :value => value } }
+    assert_equal JSON.parse(@response.body)['value'], value, "Can't update discovery_prefix setting with valid value #{value}"
+  end
+end

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class SettingTest < ActiveSupport::TestCase
+  test "should update hostname prefix with multiple valid values" do
+    setting = FactoryBot.create(:setting, :name => 'discovery_prefix', :value => 'mac', :category => 'Setting::Discovered')
+    RFauxFactory.gen_strings(exclude: [:numeric, :alphanumeric]).values.each do |value|
+      setting.value = value
+      assert setting.valid?, "Can't update discovery_prefix setting with valid value #{value}"
+    end
+  end
+end


### PR DESCRIPTION
Port robottelo tier1 tests for settings

Related Robottelo issue: SatelliteQE/robottelo#5978

Part of robottelo minitest port project: https://github.com/SatelliteQE/robottelo/projects/1

Also contains updates for obsolete configuration found in  .rubocop_todo.yml