### PR TITLE
Adding to table header cell word Actions instead of empty cell

### DIFF
--- a/app/views/discovery_rules/index.html.erb
+++ b/app/views/discovery_rules/index.html.erb
@@ -9,7 +9,7 @@
     <th><%= _("Host Group") %></th>
     <th><%= _("Hosts/Limit") %></th>
     <th><%= sort :enabled, :as => s_("DiscoveryRule|Enabled") %></th>
-    <th></th>
+    <th><%= _("Actions") %></th>
   </tr>
   <% for rule in @discovery_rules %>
     <tr>


### PR DESCRIPTION
The word Actions which is used also in another table headers in foreman, after this correction it will be possible to use the word Actions instead of sixth table header cell. 