### PR TITLE
Fixes #24236 - Distinguish between organizations while assigning prio…

### DIFF
--- a/app/controllers/discovery_rules_controller.rb
+++ b/app/controllers/discovery_rules_controller.rb
@@ -12,7 +12,7 @@ class DiscoveryRulesController < ApplicationController
   end
 
   def new
-    @discovery_rule = DiscoveryRule.new(:priority => DiscoveryRule.suggest_priority)
+    @discovery_rule = DiscoveryRule.new(priority: DiscoveryRule.suggest_priority)
   end
 
   def create

--- a/db/migrate/20180724144925_remove_unique_index_on_priority.rb
+++ b/db/migrate/20180724144925_remove_unique_index_on_priority.rb
@@ -1,0 +1,5 @@
+class RemoveUniqueIndexOnPriority < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :discovery_rules, :priority
+  end
+end

--- a/test/unit/discovery_rule_test.rb
+++ b/test/unit/discovery_rule_test.rb
@@ -217,4 +217,26 @@ class DiscoveryRuleTest < ActiveSupport::TestCase
       assert_equal DiscoveryRule::STEP, second_new.priority - first_new.priority
     end
   end
+
+  context 'suggest next priority' do
+    setup do
+      @organization = FactoryBot.create(:organization)
+      @location = FactoryBot.create(:location)
+    end
+
+    test 'when there exists a discovery_rule of the given organization' do
+      hostgroup = FactoryBot.create(:hostgroup, organizations: [@organization], locations: [@location] )
+      discovery_rule = FactoryBot.create(:discovery_rule,
+        priority: rand(100),
+        hostgroup: hostgroup,
+        organizations: [@organization],
+        locations: [@location])
+
+      assert_equal DiscoveryRule.suggest_priority(@organization), (discovery_rule.priority + DiscoveryRule::STEP)
+    end
+
+    test 'when there is no discovery_rule of the given organization' do
+      assert_equal DiscoveryRule.suggest_priority(@organization), DiscoveryRule::STEP
+    end
+  end
 end


### PR DESCRIPTION
This patch makes sure there is no conflict between priorities while in different organizations.