### PR TITLE
Fixes #19737 - kernel/initrd kexec shown in preview

### DIFF
--- a/app/models/host/managed_extensions.rb
+++ b/app/models/host/managed_extensions.rb
@@ -45,7 +45,6 @@ module Host::ManagedExtensions
     template = provisioning_template(:kind => 'kexec')
     raise ::Foreman::Exception.new(N_("Kexec template not associated with operating system")) unless template
     @host = self
-    @kexec_kernel, @kexec_initrd = operatingsystem.boot_files_uri(@host.medium, @host.architecture, @host)
     # try to parse JSON and error out early
     json = JSON.parse(unattended_render(template))
     ::Foreman::Exception.new(N_("Kernel kexec URL is invalid: '%s'"), json['kernel']) unless json['kernel'] =~ /\Ahttp.+\Z/

--- a/app/views/foreman_discovery/debian_kexec.erb
+++ b/app/views/foreman_discovery/debian_kexec.erb
@@ -1,6 +1,6 @@
 <%#
 kind: kexec
-name: Debian kexec
+name: Discovery Debian kexec
 oses:
 - Debian
 - Ubuntu
@@ -32,9 +32,8 @@ Please read kexec(8) man page for more information about semantics.
   options << "inst.stage2=#{@host.operatingsystem.medium_uri(@host)}" if @host.operatingsystem.name.match(/Atomic/i)
 -%>
 {
-  "comment": "WARNING: Both kernel and initram are not set in preview mode due to http://projects.theforeman.org/issues/19737",
-  "kernel": "<%= @kexec_kernel %>",
-  "initram": "<%= @kexec_initrd %>",
+  "kernel": "<%= @kernel_uri %>",
+  "initram": "<%= @initrd_uri %>",
   "append": "url=<%= foreman_url('provision') + "&static=yes" %> interface=<%= mac %> netcfg/get_ipaddress=<%= ip %> netcfg/get_netmask=<%= mask %> netcfg/get_gateway=<%= gw %> netcfg/get_nameservers=<%= dns %> netcfg/disable_dhcp=true netcfg/get_hostname=<%= @host.name %> BOOTIF=<%= bootif %> <%= options.compact.join(' ') %>",
   "extra": []
 }

--- a/app/views/foreman_discovery/redhat_kexec.erb
+++ b/app/views/foreman_discovery/redhat_kexec.erb
@@ -1,6 +1,6 @@
 <%#
 kind: kexec
-name: Red Hat kexec
+name: Discovery Red Hat kexec
 oses:
 - CentOS 4
 - CentOS 5
@@ -39,9 +39,8 @@ Please read kexec(8) man page for more information about semantics.
   options << "inst.stage2=#{@host.operatingsystem.medium_uri(@host)}" if @host.operatingsystem.name.match(/Atomic/i)
 -%>
 {
-  "comment": "WARNING: Both kernel and initram are not set in preview mode due to http://projects.theforeman.org/issues/19737",
-  "kernel": "<%= @kexec_kernel %>",
-  "initram": "<%= @kexec_initrd %>",
+  "kernel": "<%= @kernel_uri %>",
+  "initram": "<%= @initrd_uri %>",
 <% if (@host.operatingsystem.name == 'Fedora' and @host.operatingsystem.major.to_i > 16) or
     (@host.operatingsystem.name != 'Fedora' and @host.operatingsystem.major.to_i >= 7) -%>
   "append": "ks=<%= foreman_url('provision') + "&static=yes" %> inst.ks.sendmac <%= "ip=#{ip}::#{gw}:#{mask}:::none nameserver=#{dns} ksdevice=bootif BOOTIF=#{bootif} nomodeset " + options.compact.join(' ') %>",

--- a/db/seeds.d/50_discovery_templates.rb
+++ b/db/seeds.d/50_discovery_templates.rb
@@ -19,6 +19,7 @@ ProvisioningTemplate.without_auditing do
       :vendor   => "Foreman Discovery",
       :locked   => true
     }
+    tmpl.template = content
     tmpl.organizations = organizations
     tmpl.locations = locations
     tmpl.save!(:validate => false) if tmpl.changes.present?

--- a/test/unit/managed_extensions_test.rb
+++ b/test/unit/managed_extensions_test.rb
@@ -63,10 +63,4 @@ class ManagedExtensionsTest < ActiveSupport::TestCase
     Host::Discovered.any_instance.expects(:reboot).once
     @host.setReboot
   end
-
-  test "setKexec calls boot_files_uri and kexec API" do
-    Host::Discovered.any_instance.expects(:kexec).with() { |json| JSON.parse(json) }.once
-    @operatingsystem.expects(:boot_files_uri).with(@host.medium, @host.architecture, @host)
-    @host.setKexec
-  end
 end


### PR DESCRIPTION
This cleans up code a bit. Needs core PR: https://github.com/theforeman/foreman/pull/6010

Edit: The core PR was merged into Foreman 1.20, so this patch can be backported into Discovery 14.0 series as well.