### PR TITLE
Fixes #24776 - kexec templates taxonomy and locking

### DIFF
--- a/db/seeds.d/50_discovery_templates.rb
+++ b/db/seeds.d/50_discovery_templates.rb
@@ -1,4 +1,6 @@
 kind = TemplateKind.unscoped.where(:name => 'kexec').first_or_create
+organizations = Organization.unscoped.all
+locations = Location.unscoped.all
 
 ProvisioningTemplate.without_auditing do
   [['redhat_kexec.erb', 'Red Hat'], ['debian_kexec.erb', 'Debian']].each do |tmpl_names|
@@ -12,8 +14,10 @@ ProvisioningTemplate.without_auditing do
       :template => content,
       :default  => true,
       :vendor   => "Foreman Discovery",
-      :locked   => false
+      :locked   => true
     }
+    tmpl.organizations = organizations if SETTINGS[:organizations_enabled]
+    tmpl.locations = locations if SETTINGS[:locations_enabled]
     tmpl.save!(:validate => false) if tmpl.changes.present?
   end
 end


### PR DESCRIPTION
Taxonomy was always unset and templates were not locked. @ares