### PR TITLE
Fixes #25606 - fixed URL in discovery mailer

### DIFF
--- a/app/views/discovered_mailer/_discovered_host.html.erb
+++ b/app/views/discovered_mailer/_discovered_host.html.erb
@@ -1,6 +1,6 @@
 <% td_style = "text-align: left; border-collapse: collapse; background-color: #FFFFFF; padding: 4px; border: 1px solid #cccccc;" %>
 <td style="<%= td_style%>">
-  <%= link_to host, discovered_host_path(:id => host, :host => @url.host, :port => @url.port, :only_path => false, :protocol => @url.scheme) %>
+  <%= link_to host, discovered_host_url(:id => host, :host => @url.host, :port => @url.port, :only_path => false, :protocol => @url.scheme) %>
 </td>
 <td style="<%= td_style%>"><%= host.try(:hardware_model_name) || 'N/A' %></td>
 <td style="<%= td_style%>"><%= host.ip %></td>

--- a/app/views/discovered_mailer/discovered_summary.text.erb
+++ b/app/views/discovered_mailer/discovered_summary.text.erb
@@ -14,7 +14,7 @@
     <%= _('Disk count') %> <%= discovery_attribute(host, :disk_count) %>
     <%= _('Disks size') %> <%= number_to_human_size(discovery_attribute(host, :disks_size, 0) * 1024 * 1024) %>
 
-    (<%= discovered_host_path(:id => host, :host => @url.host, :port => @url.port, :only_path => false, :protocol => @url.scheme) %>)
+    (<%= discovered_host_url(:id => host, :host => @url.host, :port => @url.port, :only_path => false, :protocol => @url.scheme) %>)
     -
   <% end %>
 <% else %>


### PR DESCRIPTION
Tests were passing because we were only testing for the presence of the base URL, which is at the end of the mail anyway. This now creates new discovered host and perform the test correctly. FYI you can't use `_path` helpers in mails, links must be all absolute (via `_url` helpers).