### PR TITLE
Fixes #25855 - made kexec renderer work

### DIFF
--- a/test/unit/managed_extensions_test.rb
+++ b/test/unit/managed_extensions_test.rb
@@ -10,57 +10,93 @@ class ManagedExtensionsTest < ActiveSupport::TestCase
     end
   end
 
-  setup do
-    set_default_settings
+  let(:kexec_template) { FactoryBot.build(:provisioning_template, :template => File.read(File.expand_path(File.join("..", "..", "..", "app", "views", "foreman_discovery", "redhat_kexec.erb"), __FILE__))) }
 
-    @host = StubHost.new
-    @host.type = "Host::Discovered"
-    @host.stubs(:old).returns(@host)
-    @facts = {}
-    @host.stubs(:facts).returns(@facts)
-    @post_queue = mock('Post Queue')
-    @host.stubs(:post_queue).returns(@post_queue)
-    @operatingsystem = mock('OS')
-    @host.stubs(:operatingsystem).returns(@operatingsystem)
-    @host.stubs(:provisioning_template).returns('A template')
-    @host.stubs(:medium).returns('http://a_medium')
-    @host.stubs(:architecture).returns(FactoryBot.create(:architecture))
-    @kexec_json = {
-      :kernel => "http://a_host/vmlinuz",
-      :initrd => "http://a_host/someimage.img"
-    }
-    @host.stubs(:unattended_render).returns(@kexec_json.to_json)
+  context "stubbed orchestration" do
+    setup do
+      set_default_settings
+
+      @host = StubHost.new
+      @host.type = "Host::Discovered"
+      @host.stubs(:old).returns(@host)
+      @facts = {}
+      @host.stubs(:facts).returns(@facts)
+      @post_queue = mock('Post Queue')
+      @host.stubs(:post_queue).returns(@post_queue)
+      @operatingsystem = mock('OS')
+      @operatingsystem.stubs(:additional_media).returns({})
+      @host.stubs(:operatingsystem).returns(@operatingsystem)
+      @host.stubs(:provisioning_template).returns(kexec_template)
+      @host.stubs(:medium).returns('http://a_medium')
+      @host.stubs(:architecture).returns(FactoryBot.create(:architecture))
+      ::MediumProviders::Default.any_instance.stubs(:validate).returns([])
+    end
+
+    test "queue_reboot enques reboot command when there is no kexec fact" do
+      @host.stubs(:will_save_change_to_attribute?).with(:type, from: 'Host::Discovered').returns(true)
+      @host.stubs(:new_record?).returns(false)
+      @host.id = 130513
+      @post_queue.expects(:create).with(has_entry(:action, [@host, :setReboot])).once
+      @host.queue_reboot
+    end
+
+    test "queue_reboot enques reboot command when there is no kexec template" do
+      @host.stubs(:will_save_change_to_attribute?).with(:type, from: 'Host::Discovered').returns(true)
+      @host.stubs(:new_record?).returns(false)
+      @host.id = 130513
+      @facts['discovery_kexec'] = "Kexec version X.Y.Z"
+      @host.stubs(:provisioning_template).returns(nil)
+      @post_queue.expects(:create).with(has_entry(:action, [@host, :setReboot])).once
+      @host.queue_reboot
+    end
+
+    test "queue_reboot enques kexec command" do
+      @host.stubs(:will_save_change_to_attribute?).with(:type, from: 'Host::Discovered').returns(true)
+      @host.stubs(:new_record?).returns(false)
+      @host.id = 130513
+      @facts['discovery_kexec'] = "Kexec version X.Y.Z"
+      @post_queue.expects(:create).with(has_entry(:action, [@host, :setKexec])).once
+      @host.queue_reboot
+    end
+
+    test "setReboot calls reboot API" do
+      Host::Discovered.any_instance.expects(:reboot).once
+      @host.setReboot
+    end
+
+    test "setKexec calls renderer" do
+      Host::Discovered.any_instance.expects(:kexec).with() { |json| JSON.parse(json) }.once
+      Foreman::Renderer.expects(:render).returns({})
+      @host.setKexec
+    end
   end
 
-  test "queue_reboot enques reboot command when there is no kexec fact" do
-    @host.stubs(:will_save_change_to_attribute?).with(:type, from: 'Host::Discovered').returns(true)
-    @host.stubs(:new_record?).returns(false)
-    @host.id = 130513
-    @post_queue.expects(:create).with(has_entry(:action, [@host, :setReboot])).once
-    @host.queue_reboot
-  end
+  context "host" do
+    setup do
+      set_default_settings
+      interface = FactoryBot.build(:nic_primary_and_provision, identifier: 'eth0', mac: '00-f0-54-1a-7e-e0', ip: '127.0.0.1')
+      domain = FactoryBot.build(:domain, name: 'snapshotdomain.com')
+      subnet = FactoryBot.build(:subnet_ipv4, name: 'one', network: interface.ip)
+      architecture = Architecture.find_by_name('x86_64')
+      medium = FactoryBot.create(:medium, name: 'CentOS mirror')
+      ptable = FactoryBot.create(:ptable, name: 'ptable')
+      @operatingsystem = FactoryBot.create(:operatingsystem, name: 'Redhat', major: 7, architectures: [architecture], media: [medium], ptables: [ptable]).becomes(::Redhat)
+      @host = FactoryBot.build(:host, :managed, hostname: 'snapshothost', domain: domain, subnet: subnet, architecture: architecture, medium: medium,
+        ptable: ptable, operatingsystem: @operatingsystem, interfaces: [interface])
+      @host.stubs(:provisioning_template).returns(kexec_template)
+    end
 
-  test "queue_reboot enques reboot command when there is no kexec template" do
-    @host.stubs(:will_save_change_to_attribute?).with(:type, from: 'Host::Discovered').returns(true)
-    @host.stubs(:new_record?).returns(false)
-    @host.id = 130513
-    @facts['discovery_kexec'] = "Kexec version X.Y.Z"
-    @host.stubs(:provisioning_template).returns(nil)
-    @post_queue.expects(:create).with(has_entry(:action, [@host, :setReboot])).once
-    @host.queue_reboot
-  end
-
-  test "queue_reboot enques kexec command" do
-    @host.stubs(:will_save_change_to_attribute?).with(:type, from: 'Host::Discovered').returns(true)
-    @host.stubs(:new_record?).returns(false)
-    @host.id = 130513
-    @facts['discovery_kexec'] = "Kexec version X.Y.Z"
-    @post_queue.expects(:create).with(has_entry(:action, [@host, :setKexec])).once
-    @host.queue_reboot
-  end
-
-  test "setReboot calls reboot API" do
-    Host::Discovered.any_instance.expects(:reboot).once
-    @host.setReboot
+    test "kexec template is correctly rendered" do
+      expected = {
+        "append" => "ks=http://foreman.some.host.fqdn/unattended/provision&static=yes inst.ks.sendmac ip=::::::none nameserver= ksdevice=bootif BOOTIF= nomodeset nomodeset",
+        "extra" => []
+      }
+      assert @host.operatingsystem.respond_to?(:pxe_type)
+      assert @host.medium_provider
+      result = @host.render_kexec_template
+      assert_match(/http:\/\/www.example.com.*vmlinuz/, result.delete("kernel"))
+      assert_match(/http:\/\/www.example.com.*initrd.img/, result.delete("initram"))
+      assert_equal expected, result
+    end
   end
 end


### PR DESCRIPTION
Problem: In Foreman 1.20, kexec errors out with undefined method `unattended_render' for #<Host::Managed:0x0000555562464d28>

Analysis: This is due to refactoring, our tests were stubbed and we missed one more place where new renderer framework is used.

Since we will be changing the kexec renderer, thanks to the changes in core we can now get rid of the custom variables in discovery and therefore both preview and real rendering will work the same way: https://github.com/theforeman/foreman_discovery/pull/454 - is needed to get this one working (tests will fail until I can rebase on top of that).