### PR TITLE
Fixes #26100 - drop foreman_organization and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,15 @@ see the [API README](README.api.md)
 We use [RedMine instance](http://projects.theforeman.org/projects/discovery/issues)
 instead of github.com issues. Please report issues there.
 
-## Grace Note: Testing
+## Testing
 
-If you only wish to test the plugin code itself, you don't need to create the PXE boot
-image above, or have a TFTP server to run it from. Simply POST a hash of Host Facts to
-`/api/v2/discovered_hosts/facts` to create a Discovered Host in the UI.
+There are unit and integration tests in the repository, to run them execute the following in the *Foreman core* directory:
+
+	bundle exec rake test:discovery
+
+It is possible to execute a single test, however the path must be *absolute* (e.g. use `$HOME` variable):
+
+	bundle exec rake test:discovery TEST=~/work/foreman_discovery/test/unit/host_discovered_test.rb
 
 # Copyright
 

--- a/app/services/foreman_discovery/import_hooks/subnet_and_taxonomy.rb
+++ b/app/services/foreman_discovery/import_hooks/subnet_and_taxonomy.rb
@@ -39,7 +39,8 @@ module ForemanDiscovery
       end
 
       def suggested_location
-        Location.find_by_title(facts["foreman_location"] || facts["discovery_location"]) ||
+        logger.warn("Do not use 'foreman_location' fact for discovery and use 'discovery_location' instead") if facts["foreman_location"]
+        Location.find_by_title(facts["discovery_location"]) ||
           Location.find_by_title(Setting[:discovery_location]) ||
           host.subnet.try(:locations).try(:first) ||
           Location.first
@@ -51,7 +52,8 @@ module ForemanDiscovery
       end
 
       def suggested_organization
-        Organization.find_by_title(facts["foreman_organization"] || facts["discovery_organization"]) ||
+        logger.warn("Do not use 'foreman_organization' fact for discovery and use 'discovery_organization' instead") if facts["foreman_organization"]
+        Organization.find_by_title(facts["discovery_organization"]) ||
           Organization.find_by_title(Setting[:discovery_organization]) ||
           host.subnet.try(:organizations).try(:first) ||
           Organization.first


### PR DESCRIPTION
Tests to make sure this regression does not happen again:

https://github.com/theforeman/foreman/pull/6478

In order to make the tests effective, this patch also removes
"foreman_organization" and "foreman_location" taxonomy detection, this can be
easily changed by users to the same fact but with different name:
"discovery_organization" and "discovery_location".