### PR TITLE
Fixes #26184 - skip callbacks on host save

### DIFF
--- a/app/helpers/discovered_hosts_helper.rb
+++ b/app/helpers/discovered_hosts_helper.rb
@@ -34,7 +34,7 @@ module DiscoveredHostsHelper
 
     select_action_button( _("Select Action"), {:id => 'submit_multiple'},
       actions.map do |action|
-        link_to_function(action[0], "build_modal(this, '#{action[1]}')", :'data-dialog-title' => _("%s - The following hosts are about to be changed") % action[0]) if authorized_for(action[2])
+        link_to_function(action[0], "tfm.hosts.table.buildModal(this, '#{action[1]}')", :'data-dialog-title' => _("%s - The following hosts are about to be changed") % action[0]) if authorized_for(action[2])
       end.flatten
     )
   end

--- a/app/helpers/discovery_rules_helper.rb
+++ b/app/helpers/discovery_rules_helper.rb
@@ -26,10 +26,10 @@ module DiscoveryRulesHelper
     actions = [display_link_if_authorized(_('Discovered Hosts'), hash_for_discovered_hosts_path.merge(:search => rule.search))]
     actions << display_link_if_authorized(_('Associated Hosts'), hash_for_hosts_path.merge(:search => "discovery_rule = \"#{rule.name}\""))
     if rule.enabled?
-      actions << display_link_if_authorized(_('Disable'), hash_for_disable_discovery_rule_path(:id => rule).merge(:auth_object => rule, :authorizer => authorizer), :confirm => _("Disable rule '%s'?") % rule)
+      actions << display_link_if_authorized(_('Disable'), hash_for_disable_discovery_rule_path(:id => rule).merge(:auth_object => rule, :authorizer => authorizer), :data => { :confirm => _("Disable rule '%s'?") % rule })
     else
-      actions << display_link_if_authorized(_('Enable'), hash_for_enable_discovery_rule_path(:id => rule).merge(:auth_object => rule, :authorizer => authorizer), :confirm => _("Enable rule '%s'?") % rule)
+      actions << display_link_if_authorized(_('Enable'), hash_for_enable_discovery_rule_path(:id => rule).merge(:auth_object => rule, :authorizer => authorizer), :data => { :confirm => _("Enable rule '%s'?") % rule })
     end
-    actions << display_delete_if_authorized(hash_for_discovery_rule_path(:id => rule).merge(:auth_object => rule, :authorizer => authorizer), :confirm => _("Delete rule '%s'?") % rule)
+    actions << display_delete_if_authorized(hash_for_discovery_rule_path(:id => rule).merge(:auth_object => rule, :authorizer => authorizer), :data => { :confirm => _("Delete rule '%s'?") % rule })
   end
 end

--- a/app/models/host/managed_extensions.rb
+++ b/app/models/host/managed_extensions.rb
@@ -70,12 +70,14 @@ module Host::ManagedExtensions
 
   def delete_discovery_attribute_set
     return if new_record?
-    DiscoveryAttributeSet.where(:host_id => self.id).destroy_all if saved_change_to_attribute?(:type)
+
+    DiscoveryAttributeSet.where(:host_id => self.id).destroy_all if saved_change_to_attribute?(:type) && type_previously_changed?
   end
 
   def update_notifications
     return if new_record?
-    return unless saved_change_to_attribute?(:type)
+    return unless saved_change_to_attribute?(:type) || type_previously_changed?
+
     ForemanDiscovery::UINotifications::DestroyHost.deliver!(self)
   end
 end

--- a/app/views/discovered_hosts/_discovered_hosts_list.html.erb
+++ b/app/views/discovered_hosts/_discovered_hosts_list.html.erb
@@ -1,8 +1,7 @@
-<%= javascript "host_checkbox" %>
 <% title _('Discovered Hosts') %>
 <table class="<%= table_css_classes('table-condensed') %>" >
   <tr>
-    <th class="ca"><%= check_box_tag "check_all", "", false, { :onclick => "toggleCheck()", :'check-title' => _("Select all items in this page"), :'uncheck-title'=> _("items selected. Uncheck to Clear") } %></th>
+    <th class="ca"><%= check_box_tag "check_all", "", false, { :onclick => "tfm.hosts.table.toggleCheck()", :'check-title' => _("Select all items in this page"), :'uncheck-title'=> _("items selected. Uncheck to Clear") } %></th>
     <th class=''><%= sort :name, :as => _('Name') %></th>
     <th class="hidden-tablet hidden-xs"><%= sort :model, :as => _('Model') %></th>
     <th class="hidden-tablet hidden-xs"><%= sort :ip, :as => _('IP Address') %></th>
@@ -22,7 +21,7 @@
   <% @hosts.each do |host| -%>
     <tr>
       <td class="ca">
-        <%= check_box_tag "host_ids[]", nil, false, :id => "host_ids_#{host.id}", :disabled => !authorized_for_edit_destroy?, :class => 'host_select_boxes', :onclick => 'hostChecked(this)' -%>
+        <%= check_box_tag "host_ids[]", nil, false, :id => "host_ids_#{host.id}", :disabled => !authorized_for_edit_destroy?, :class => 'host_select_boxes', :onclick => 'tfm.hosts.table.hostChecked(this)' -%>
       </td>
       <%= render :partial => "discovered_host", :locals => {:host => host} %>
       <td class="hidden-tablet hidden-xs"><%= host.location.try(:title) %></td>
@@ -38,7 +37,7 @@
           display_link_if_authorized(_("Auto Provision"), hash_for_auto_provision_discovered_host_path(:id => host), :method => :post),
           display_link_if_authorized(_("Refresh facts"), hash_for_refresh_facts_discovered_host_path(:id => host)),
           display_link_if_authorized(_("Reboot"), hash_for_reboot_discovered_host_path(:id => host), :method => :put),
-          display_delete_if_authorized(hash_for_discovered_host_path(:id => host), :confirm => _("Delete %s?") % host.name, :action => :destroy))%>
+          display_delete_if_authorized(hash_for_discovered_host_path(:id => host), :data => { :confirm => _("Delete %s?") % host.name }, :action => :destroy)) %>
         </td>
       </tr>
     <% end -%>
@@ -56,7 +55,7 @@
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal"><%= _('Cancel') %></button>
-        <button type="button" class="btn btn-primary" onclick="submit_modal_form()"><%= _('Submit') %></button>
+        <button type="button" class="btn btn-primary" onclick="tfm.hosts.table.submitModalForm()"><%= _('Submit') %></button>
       </div>
     </div><!-- /.modal-content -->
   </div><!-- /.modal-dialog -->

--- a/app/views/discovered_hosts/multiple_destroy.html.erb
+++ b/app/views/discovered_hosts/multiple_destroy.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag submit_multiple_destroy_discovered_hosts_path(:host_ids => params[:host_ids]), :onsubmit => "resetSelection()" do -%>
+<%= form_tag submit_multiple_destroy_discovered_hosts_path(:host_ids => params[:host_ids]), :onsubmit => "tfm.hosts.table.resetSelection()" do -%>
   <%= alert :class => 'alert-warning',
   :text => _("This might take a while, as all hosts, facts and reports will be destroyed as well"),
   :header => '' %>

--- a/app/views/discovered_hosts/select_multiple_location.html.erb
+++ b/app/views/discovered_hosts/select_multiple_location.html.erb
@@ -3,7 +3,7 @@
   <div class="col-md-8">
     <%= form_for :location, :url => update_multiple_location_discovered_hosts_path(:host_ids => params[:host_ids]) do |f| %>
       <%= f.select :id, Location.all.map{|e| [e.name, e.id]},{:include_blank => _("Select location")},
-                   :onchange => "toggle_multiple_ok_button(this)" %>
+                   :onchange => "tfm.hosts.table.toggleMultipleOkButton (this)" %>
       <%= f.hidden_field :optimistic_import, :value => "yes" %>
     <% end %>
   </div>

--- a/app/views/discovered_hosts/select_multiple_organization.html.erb
+++ b/app/views/discovered_hosts/select_multiple_organization.html.erb
@@ -3,7 +3,7 @@
   <div class="col-md-8">
     <%= form_for :organization, :url => update_multiple_organization_discovered_hosts_path(:host_ids => params[:host_ids]) do |f| %>
       <%= f.select :id, Organization.all.map{|e| [e.name, e.id]},{:include_blank => _("Select organization")},
-                   :onchange => "toggle_multiple_ok_button(this)" %>
+                   :onchange => "tfm.hosts.table.toggleMultipleOkButton (this)" %>
       <%= f.hidden_field :optimistic_import, :value => "yes" %>
     <% end %>
   </div>

--- a/test/unit/ui_notifications/destroy_host_test.rb
+++ b/test/unit/ui_notifications/destroy_host_test.rb
@@ -41,6 +41,15 @@ class DestroyHostNotificationTest < ActiveSupport::TestCase
     assert_equal 0, blueprint.notifications.count
   end
 
+  test 'discovered host type must not update notifications on plain save' do
+    host = FactoryBot.create(:discovered_host)
+    ForemanDiscovery::UINotifications::NewHost.deliver!(host)
+    assert_equal 1, blueprint.notifications.count
+    host.name = "triggerchange"
+    assert host.save!
+    assert_equal 1, blueprint.notifications.count
+  end
+
   test 'type change should not removing notifications for discovered hosts' do
     host1 = FactoryBot.create(:discovered_host)
     ForemanDiscovery::UINotifications::NewHost.deliver!(host1)


### PR DESCRIPTION
I found the following error in test logs when running core tests:

    Failed to handle notifications - this is most likely a bug: undefined method `notifications' for nil:NilClass

It is caused by the host extension:

    after_save :delete_discovery_attribute_set, :update_notifications

Both methods are called when there is a save on Host::Managed, we need to do this because of the STI. However we should not attempt to delete notifications if `type` was not previously changed. Only when type changed that's the discovery provisioning and that's when we want to delete it.

The same for deleting attribute set - an associated 1:1 record.