### PR TITLE
Fixes #26759 - snippet can be used in kexec

### DIFF
--- a/app/models/host/managed_extensions.rb
+++ b/app/models/host/managed_extensions.rb
@@ -45,9 +45,7 @@ module Host::ManagedExtensions
     template = provisioning_template(:kind => 'kexec')
     raise ::Foreman::Exception.new(N_("Kexec template not associated with operating system")) unless template
 
-    source = Foreman::Renderer::Source::String.new(name: template.name, content: template.template)
-    scope = Foreman::Renderer.get_scope(host: self, source: source)
-    json = JSON.parse(Foreman::Renderer.render(source, scope))
+    json = JSON.parse(render_template(template: template))
     ::Foreman::Exception.new(N_("Kernel kexec URL is invalid: '%s'"), json['kernel']) unless json['kernel'] =~ /\Ahttp.+\Z/
     ::Foreman::Exception.new(N_("Init RAM kexec URL is invalid: '%s'"), json['initrd']) unless json['initrd'] =~ /\Ahttp.+\Z/
     json

--- a/test/unit/managed_extensions_test.rb
+++ b/test/unit/managed_extensions_test.rb
@@ -65,7 +65,7 @@ class ManagedExtensionsTest < ActiveSupport::TestCase
     end
 
     test "setKexec calls renderer" do
-      Host::Discovered.any_instance.expects(:kexec).with() { |json| JSON.parse(json) }.once
+      Host::Discovered.any_instance.expects(:render_template).with() { |json| JSON.parse(json) }.once
       Foreman::Renderer.expects(:render).returns({})
       @host.setKexec
     end
@@ -88,7 +88,7 @@ class ManagedExtensionsTest < ActiveSupport::TestCase
 
     test "kexec template is correctly rendered" do
       expected = {
-        "append" => "ks=http://foreman.some.host.fqdn/unattended/provision&static=yes inst.ks.sendmac ip=::::::none nameserver= ksdevice=bootif BOOTIF= nomodeset nomodeset",
+        "append" => "ks=http://foreman.some.host.fqdn/unattended/provision&static=yes inst.ks.sendmac ip=::::::none nameserver= ksdevice=bootif BOOTIF= nomodeset nokaslr nomodeset",
         "extra" => []
       }
       assert @host.operatingsystem.respond_to?(:pxe_type)


### PR DESCRIPTION
This makes use of the unattender renderer. Finally we can use the same renderer as in unattended controller to make sure preview is always exactly the same.