### PR TITLE
Fixes #27335 - getting rid of Rails 6 incomp

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
   post 'os_selected_discovered_hosts'           => 'hosts#os_selected'
   post 'medium_selected_discovered_hosts'       => 'hosts#medium_selected'
 
+  get 'discovered_hosts/help', :action => :welcome, :controller => 'discovered_hosts'
+
   constraints(:id => /[^\/]+/) do
     resources :discovered_hosts, :except => [:new, :create] do
       member do

--- a/extra/discover-host
+++ b/extra/discover-host
@@ -16,6 +16,7 @@ base = find_base
 version = "3.4.0"
 interfaces = []
 preserve_interfaces = false
+use_facts_endpoint = false
 primary = nil
 bootif = nil
 url = "http://admin:changeme@localhost:3000"
@@ -38,6 +39,10 @@ OptionParser.new do |opts|
 
   opts.on("-x", "--[no-]preserve-interfaces", "Preserve interfaces from JSON") do |v|
     preserve_interfaces = true
+  end
+
+  opts.on("-a", "--facts", "Use host facts endpoint") do |v|
+    use_facts_endpoint = true
   end
 
   opts.on("-pNAME", "--primary=NAME", "Interface to use as primary (defaults to the first one)") do |v|
@@ -85,7 +90,14 @@ unless preserve_interfaces
   end
 end
 puts JSON.pretty_generate(json)
-resource = RestClient::Resource.new(url + "/api/v2/discovered_hosts/facts", verify_ssl: OpenSSL::SSL::VERIFY_NONE)
-response = resource.post({"facts" => json}.to_json, {content_type: :json, accept: :json})
+if use_facts_endpoint
+  endpoint = url + "/api/v2/hosts/facts"
+  payload = {"facts" => json, "name" => json["hostname"] || json["networking"]["fqdn"]}
+else
+  endpoint = url + "/api/v2/discovered_hosts/facts"
+  payload = {"facts" => json}
+end
+resource = RestClient::Resource.new(endpoint, verify_ssl: OpenSSL::SSL::VERIFY_NONE)
+response = resource.post(payload.to_json, {content_type: :json, accept: :json})
 puts response.code
 puts response.body

--- a/lib/foreman_discovery/engine.rb
+++ b/lib/foreman_discovery/engine.rb
@@ -48,7 +48,7 @@ module ForemanDiscovery
         # discovered hosts permissions
         security_block :discovery do
           permission :view_discovered_hosts, {
-            :discovered_hosts          => [:index, :show, :auto_complete_search],
+            :discovered_hosts          => [:index, :show, :auto_complete_search, :welcome],
             :"api/v2/discovered_hosts" => [:index, :show]
           }, :resource_type => 'Host'
           permission :submit_discovered_hosts, {


### PR DESCRIPTION
I have never understood how this "help" pages work. In discovery plugin I have a welcome.html.erb view that renders "No discovered hosts found in this context" page when there are no records and this has been working fine for years.

This suggested patch adds ability to use /discovered_hosts/help URL which was previously not working, but I don't believe there is any link in the discovery plugin to this URL. So I am not sure how useful the route is.