### PR TITLE
Fixes #27340 - fixes tests and attribute set validators removed

### DIFF
--- a/app/models/discovery_attribute_set.rb
+++ b/app/models/discovery_attribute_set.rb
@@ -3,5 +3,4 @@ class DiscoveryAttributeSet < ApplicationRecord
 
   validates :cpu_count, :presence => true, :numericality => {:greater_than_or_equal_to => 0}
   validates :memory, :presence => true,    :numericality => {:greater_than_or_equal_to => 0}
-  validates :host, :presence => true
 end

--- a/app/models/host/discovered.rb
+++ b/app/models/host/discovered.rb
@@ -9,8 +9,7 @@ class Host::Discovered < ::Host::Base
   include ::Hostext::OperatingSystem
 
   has_one :discovery_attribute_set, :foreign_key => :host_id, :dependent => :destroy
-
-  validates :discovery_attribute_set, :presence => true
+  validates_associated :discovery_attribute_set
 
   delegate :memory, :cpu_count, :disk_count, :disks_size, :to => :discovery_attribute_set, :allow_nil => true
   after_destroy :delete_notification

--- a/test/functional/discovered_hosts_controller_test.rb
+++ b/test/functional/discovered_hosts_controller_test.rb
@@ -86,7 +86,7 @@ class DiscoveredHostsControllerTest < ActionController::TestCase
   def test_edit_form_quick_submit
     domain = FactoryBot.create(:domain)
     hostgroup = FactoryBot.create(:hostgroup, :with_subnet, :with_environment, :with_rootpass, :with_os, :domain => domain)
-    new_ip = hostgroup.subnet.ipaddr
+    new_ip = hostgroup.subnet.ipaddr.to_s
     host = discover_host_from_facts(@facts.merge({
                                                     'ipaddress' => new_ip,
                                                     'ipaddress_eth0' => new_ip

--- a/test/integration/discovered_hosts_test.rb
+++ b/test/integration/discovered_hosts_test.rb
@@ -9,6 +9,7 @@ class DiscoveredHostsTest < IntegrationTestWithJavascript
     assert discovered_notification_blueprint
     discovered_host.save!
     visit discovered_hosts_path
+    page.evaluate_script("document.getElementById('fixedPropertiesSelector-#{discovered_host.id}').classList.remove('fade')")
   end
 
   teardown do
@@ -64,15 +65,14 @@ class DiscoveredHostsTest < IntegrationTestWithJavascript
 
     test 'and forwards to editing it' do
       create_host
-      assert_equal edit_discovered_host_path(id: discovered_host),
-                   current_path
+      assert_current_path edit_discovered_host_path(id: discovered_host), ignore_query: true
     end
 
     context 'with a Hostgroup selected' do
       let(:discovery_hostgroup) { Hostgroup.first }
 
       test 'it passes it on' do
-        select_from('host_hostgroup_id', discovery_hostgroup.id)
+        select2(discovery_hostgroup.name, from: 'host_hostgroup_id')
         create_host
         assert_param discovery_hostgroup.id.to_s,
                      'host.hostgroup_id'
@@ -83,7 +83,7 @@ class DiscoveredHostsTest < IntegrationTestWithJavascript
       let(:discovery_location) { Location.first }
 
       test 'it passes it on' do
-        select_from('host_location_id', discovery_location.id)
+        select2(discovery_location.name, from: 'host_location_id')
         create_host
         assert_param discovery_location.id.to_s,
                      'host.location_id'
@@ -94,7 +94,7 @@ class DiscoveredHostsTest < IntegrationTestWithJavascript
       let(:discovery_organization) { Organization.first }
 
       test 'it passes it on' do
-        select_from('host_organization_id', discovery_organization.id)
+        select2(discovery_organization.name, from: 'host_organization_id')
         create_host
         assert_param discovery_organization.id.to_s,
                      'host.organization_id'
@@ -145,12 +145,6 @@ class DiscoveredHostsTest < IntegrationTestWithJavascript
 
   def select_host_checkbox(id)
     page.find("#host_ids_#{id}").click
-  end
-
-  def select_from(element_id, id)
-    page.find_by_id(element_id, visible: false)
-        .find("option[value='#{id}']", visible: false)
-        .select_option
   end
 
   def create_host

--- a/test/unit/discovery_attribute_set_test.rb
+++ b/test/unit/discovery_attribute_set_test.rb
@@ -18,34 +18,38 @@ class DiscoveryAttributeSetTest < ActiveSupport::TestCase
 
   test "can search discovered hosts by cpu" do
     host = discover_host_from_facts(@facts)
-    results = Host::Discovered.search_for("cpu_count = #{host.facts_hash['physicalprocessorcount'].to_i}")
+    results = Host::Discovered.unscoped.search_for("cpu_count = #{host.facts_hash['physicalprocessorcount'].to_i}")
     assert_equal 1, results.count
-    results = Host::Discovered.search_for("cpu_count > #{host.facts_hash['physicalprocessorcount'].to_i}")
+    results = Host::Discovered.unscoped.search_for("cpu_count > #{host.facts_hash['physicalprocessorcount'].to_i}")
     assert_equal 0, results.count
   end
 
   test "can search discovered hosts by memory" do
     host = discover_host_from_facts(@facts)
-    results = Host::Discovered.search_for("memory = #{host.facts_hash['memorysize_mb'].to_f.ceil}")
+    results = Host::Discovered.unscoped.search_for("memory = #{host.facts_hash['memorysize_mb'].to_f.ceil}")
     assert_equal 1, results.count
-    results = Host::Discovered.search_for("memory > #{host.facts_hash['memorysize_mb'].to_f.ceil}")
+    results = Host::Discovered.unscoped.search_for("memory > #{host.facts_hash['memorysize_mb'].to_f.ceil}")
     assert_equal 0, results.count
   end
 
   test "can search discovered hosts by disk_count" do
     host = discover_host_from_facts(@facts)
-    results = Host::Discovered.search_for("disk_count = 1")
+    results = Host::Discovered.unscoped.search_for("disk_count = 1")
     assert_equal 1, results.count
-    results = Host::Discovered.search_for("disk_count = 3")
+    results = Host::Discovered.unscoped.search_for("disk_count = 3")
     assert_equal 0, results.count
   end
 
   test "can search discovered hosts by disks_size" do
+    excluded = Setting[:excluded_facts]
+    Setting[:excluded_facts] = ["test"]
     host = discover_host_from_facts(@facts)
     disks_size = (host.facts_hash['blockdevice_sda_size'].to_f / 1024 / 1024).ceil
-    results = Host::Discovered.search_for("disks_size = #{disks_size}")
+    results = Host::Discovered.unscoped.search_for("disks_size = #{disks_size}")
     assert_equal 1, results.count
-    results = Host::Discovered.search_for("disks_size > #{disks_size}")
+    results = Host::Discovered.unscoped.search_for("disks_size > #{disks_size}")
     assert_equal 0, results.count
+  ensure
+    Setting[:excluded_facts] = excluded
   end
 end

--- a/test/unit/managed_extensions_test.rb
+++ b/test/unit/managed_extensions_test.rb
@@ -65,8 +65,8 @@ class ManagedExtensionsTest < ActiveSupport::TestCase
     end
 
     test "setKexec calls renderer" do
-      Host::Discovered.any_instance.expects(:render_template).with() { |json| JSON.parse(json) }.once
-      Foreman::Renderer.expects(:render).returns({})
+      @host.expects(:render_kexec_template).once.returns({})
+      Host::Discovered.any_instance.expects(:kexec).once
       @host.setKexec
     end
   end


### PR DESCRIPTION
The initial discovery upload fails with 422 ActiveRecord::RecordNotSaved: Failed to save the new associated discovery_attribute_set. The problem is that Rails presence validator errors out when host_id is not set when discovered host is not yet saved. This happens because update call calls save when host_id is not yet set.

As a consequence, discovery_attribute_set is not set however discovered host is saved with null reference, therefore subsequent discovery fact upload already has host.id set therefore this should save. Unfortunately due to the other validator (:discovery_attribute_set, :presence => true) it won't because then it fails with a different error 422 Validation failed: Discovery attribute set can't be blank.

This patch removes the unnecessary validators because the code is ready today that attributes association can be blank. This was added because when discovery fails, it is set to blank anyway. This could be prevented by utilizing SQL transactions, however we've been there and it caused huge pains in our orchestration and it was reverted. I left a note about this in the codebase.