### PR TITLE
Refs #27340 - fixed begin-rescue in a unit test

### DIFF
--- a/test/unit/discovery_attribute_set_test.rb
+++ b/test/unit/discovery_attribute_set_test.rb
@@ -41,15 +41,17 @@ class DiscoveryAttributeSetTest < ActiveSupport::TestCase
   end
 
   test "can search discovered hosts by disks_size" do
-    excluded = Setting[:excluded_facts]
-    Setting[:excluded_facts] = ["test"]
-    host = discover_host_from_facts(@facts)
-    disks_size = (host.facts_hash['blockdevice_sda_size'].to_f / 1024 / 1024).ceil
-    results = Host::Discovered.unscoped.search_for("disks_size = #{disks_size}")
-    assert_equal 1, results.count
-    results = Host::Discovered.unscoped.search_for("disks_size > #{disks_size}")
-    assert_equal 0, results.count
-  ensure
-    Setting[:excluded_facts] = excluded
+    begin
+      excluded = Setting[:excluded_facts]
+      Setting[:excluded_facts] = ["test"]
+      host = discover_host_from_facts(@facts)
+      disks_size = (host.facts_hash['blockdevice_sda_size'].to_f / 1024 / 1024).ceil
+      results = Host::Discovered.unscoped.search_for("disks_size = #{disks_size}")
+      assert_equal 1, results.count
+      results = Host::Discovered.unscoped.search_for("disks_size > #{disks_size}")
+      assert_equal 0, results.count
+    ensure
+      Setting[:excluded_facts] = excluded
+    end
   end
 end


### PR DESCRIPTION
When I was fixing tests, I have missed this. It is passing on more modern Ruby versions however not on Jenkins.