### PR TITLE
Fixes #27935 - allow deletion of existing hosts during discovery

### DIFF
--- a/app/models/setting/discovered.rb
+++ b/app/models/setting/discovered.rb
@@ -33,7 +33,7 @@ class Setting::Discovered < ::Setting
       self.set('discovery_pxegrub_lock_template', N_("PXEGrub template to be used when pinning a host to discovery"), 'pxegrub_discovery', N_("Locked PXEGrub template name"), nil, { :collection => Proc.new {Hash[ProvisioningTemplate.where(:template_kind => TemplateKind.find_by_name(:snippet)).map{|template| [template[:name], template[:name]]}]} }),
       self.set('discovery_pxegrub2_lock_template', N_("PXEGrub2 template to be used when pinning a host to discovery"), 'pxegrub2_discovery', N_("Locked PXEGrub2 template name"), nil, { :collection => Proc.new {Hash[ProvisioningTemplate.where(:template_kind => TemplateKind.find_by_name(:snippet)).map{|template| [template[:name], template[:name]]}]} }),
       self.set('discovery_always_rebuild_dns', N_("Force DNS entries creation when provisioning discovered host"), true, N_("Force DNS")),
-      self.set('discovery_error_on_existing', N_("Do not allow to discover existing managed host matching MAC of a provisioning NIC (errors out early)"), false, N_("Error on existing NIC")),
+      self.set('discovery_action_on_existing', N_("Action to take when a host with provisioning MAC already exist"), "Ignore", N_("Action on existing managed host"), nil, { :collection => Proc.new {Hash[["Ignore", "Error", "Delete"].map{|x| [x, x]}]} }),
       self.set('discovery_naming', N_("Discovery hostname naming pattern"), 'Fact', N_("Type of name generator"), nil, {:collection => Proc.new {::Host::Discovered::NAMING_PATTERNS} }),
     ]
   end

--- a/db/migrate/20190925010101_change_error_existing_setting.rb
+++ b/db/migrate/20190925010101_change_error_existing_setting.rb
@@ -1,0 +1,14 @@
+class ChangeErrorExistingSetting < ActiveRecord::Migration[5.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        Setting[:discovery_action_on_existing] = "Error" if Setting[:discovery_error_on_existing]
+        Setting.find_by_name("discovery_error_on_existing").try(:destroy)
+      end
+      dir.down do
+        Setting.find_by_name("discovery_error_on_existing").try(:destroy)
+        Setting.find_by_name("discovery_action_on_existing").try(:destroy)
+      end
+    end
+  end
+end

--- a/test/test_helper_discovery.rb
+++ b/test/test_helper_discovery.rb
@@ -65,7 +65,7 @@ def set_default_settings
   FactoryBot.create(:setting, :name => 'discovery_pxegrub_lock_template', :value => 'pxegrub_discovery', :category => 'Setting::Discovered')
   FactoryBot.create(:setting, :name => 'discovery_pxegrub2_lock_template', :value => 'pxegrub2_discovery', :category => 'Setting::Discovered')
   FactoryBot.create(:setting, :name => 'discovery_always_rebuild_dns', :value => true, :category => 'Setting::Discovered')
-  FactoryBot.create(:setting, :name => 'discovery_error_on_existing', :value => false, :category => 'Setting::Discovered')
+  FactoryBot.create(:setting, :name => 'discovery_action_on_existing', :value => "Ignore", :category => 'Setting::Discovered')
   FactoryBot.create(:setting, :name => 'discovery_naming', :value => 'Fact', :category => 'Setting::Discovered')
   FactoryBot.create(:setting, :name => 'discovery_auto_bond', :value => false, :category => 'Setting::Discovered')
 end


### PR DESCRIPTION
When there is an existing managed host, discovery process either fail or pass depending on if the existing host has the same MAC provisioning address or just hostname. Hostnames must be unique (due to DNS) however MAC addresses do not. There was a setting to change the behavior to error out explicitly or just ignore and allow discovery of hosts with different hostname but conflicting MAC address.

There is a third solution and that is often asked "delete existing managed host when it exists". This is dangerous because it allows to delete hosts via discovery API, so this feature comes only with explicit setting. Documentation will be updated to reflect this new (dangerous) setting.