### PR TITLE
Fixes #28330 - reboot/kexec use old IP address

### DIFF
--- a/app/models/host/managed_extensions.rb
+++ b/app/models/host/managed_extensions.rb
@@ -27,7 +27,7 @@ module Host::ManagedExtensions
   end
 
   def setReboot
-    old.becomes(Host::Discovered).reboot
+    old.becomes(Host::Discovered).reboot(facts["discovery_bootip"] || facts["ipaddress"])
     # It is too late to report error in the post_queue, we catch them and
     # continue. If flash is implemented for new hosts (http://projects.theforeman.org/issues/10559)
     # we can report the error to the user perhaps.

--- a/test/functional/discovered_hosts_controller_test.rb
+++ b/test/functional/discovered_hosts_controller_test.rb
@@ -183,7 +183,7 @@ class DiscoveredHostsControllerTest < ActionController::TestCase
   def test_reboot_failure
     @request.env["HTTP_REFERER"] = discovered_hosts_url
     host = discover_host_from_facts(@facts)
-    ::ForemanDiscovery::NodeAPI::PowerService.any_instance.expects(:reboot).returns(false)
+    ::ForemanDiscovery::NodeAPI::PowerService.any_instance.expects(:reboot).twice.returns(false)
     post :reboot, params: { :id => host.id }, session: set_session_user_default_manager
     assert_redirected_to discovered_hosts_url
     assert_equal "Failed to reboot host #{host.name}", flash[:error]
@@ -195,7 +195,7 @@ class DiscoveredHostsControllerTest < ActionController::TestCase
     ::ForemanDiscovery::NodeAPI::PowerService.any_instance.expects(:reboot).raises("request failed")
     post :reboot, params: { :id => host.id }, session: set_session_user_default_manager
     assert_redirected_to discovered_hosts_url
-    assert_match(/ERF50-4973/, flash[:error])
+    assert_match(/ERF50-9494/, flash[:error])
   end
 
   def test_auto_provision_success
@@ -271,7 +271,7 @@ class DiscoveredHostsControllerTest < ActionController::TestCase
   def test_multiple_reboot_failure
     @request.env["HTTP_REFERER"] = discovered_hosts_url
     host = discover_host_from_facts(@facts)
-    ::ForemanDiscovery::NodeAPI::PowerService.any_instance.expects(:reboot).returns(false)
+    ::ForemanDiscovery::NodeAPI::PowerService.any_instance.expects(:reboot).twice.returns(false)
     post :submit_multiple_reboot, params: {:host_ids => host.id}, session: set_session_user(User.current)
     assert_redirected_to discovered_hosts_url
     assert_equal "Errors during reboot: #{host.name}: failed to reboot", flash[:error]
@@ -284,7 +284,7 @@ class DiscoveredHostsControllerTest < ActionController::TestCase
     ::ForemanDiscovery::NodeAPI::PowerService.any_instance.expects(:reboot).raises("request failed")
     post :submit_multiple_reboot, params: {:host_ids => host.id}, session: set_session_user(User.current)
     assert_redirected_to discovered_hosts_url
-    assert_match(/ERF50-4973/, flash[:error])
+    assert_match(/ERF50-9494/, flash[:error])
     assert_nil flash[:success]
   end
 


### PR DESCRIPTION
With the RM-16143 change discovery now performs unused_ip call during provisioning. This changes IP address and creates DHCP reservation, however the discovered node still have the old lease. The fix is to use old lease IP to perform reboot or kexec API commands. There could be a race condition when a node already acquired new IP and reconfigured network, for this reason if the first request fails, there is additional second query against the reserved IP just to make sure.