### PR TITLE
Fixes #28870 - use host_param macro for lang

### DIFF
--- a/app/views/foreman_discovery/debian_kexec.erb
+++ b/app/views/foreman_discovery/debian_kexec.erb
@@ -28,7 +28,7 @@ Please read kexec(8) man page for more information about semantics.
   options << @host.facts['append']
   options << "domain=#{@host.domain}"
   options << 'console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true'
-  options << "locale=#{@host.params['lang'] || 'en_US'}"
+  options << "locale=#{host_param('lang') || 'en_US'}"
   options << "inst.stage2=#{@host.operatingsystem.medium_uri(@host)}" if @host.operatingsystem.name.match(/Atomic/i)
 -%>
 {


### PR DESCRIPTION
This has been deprecated a while ago and we have missed it. It's no longer available via safemode.