### PR TITLE
Fixes #29221 - Subnet is blank after provisioning a discovered host

### DIFF
--- a/app/controllers/discovered_hosts_controller.rb
+++ b/app/controllers/discovered_hosts_controller.rb
@@ -199,15 +199,17 @@ class DiscoveredHostsController < ::ApplicationController
 
   def setup_host_class_variables
     if @host.hostgroup
+      subnet = @host.hostgroup.subnet || @host.subnet
+      subnet6 = @host.hostgroup.subnet6 || @host.subnet6
       @architecture    = @host.hostgroup.architecture
       @operatingsystem = @host.hostgroup.operatingsystem
       @environment     = @host.hostgroup.environment
       @domain          = @host.hostgroup.domain
-      @subnet          = @host.hostgroup.subnet
+      @subnet          = subnet
+      @subnet6         = subnet6
       @compute_profile = @host.hostgroup.compute_profile
       @realm           = @host.hostgroup.realm
-      @host.interfaces.first.assign_attributes(subnet: @subnet,
-                                               domain: @domain)
+      @host.interfaces.first.assign_attributes(subnet: subnet, subnet6: subnet6, domain: @domain)
       @host.environment = @environment
     end
   end

--- a/app/views/discovered_hosts/_discovered_host_modal.html.erb
+++ b/app/views/discovered_hosts/_discovered_host_modal.html.erb
@@ -17,8 +17,6 @@
           <% if show_location_tab? %>
             <%= select_f f, :location_id, Location.my_locations, :id, :to_label, {}, {:size => 'col-md-10'} %>
           <% end %>
-
-          <div>Changing the Host's Subnet is not possible via Customize Host form, use Create Host or Auto provisioning and set the desired Subnet in the Hostgroup.</div>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>

--- a/extra/discover-host
+++ b/extra/discover-host
@@ -33,7 +33,7 @@ OptionParser.new do |opts|
     version = v
   end
 
-  opts.on("-iARRAY", "--interface=ARRAY", Array, "Comma separated array: name,subnet,ip,mac (can be used multiple times, default: eth0,122,7,AA:BB:CC:DD:EE:FF") do |v|
+  opts.on("-iARRAY", "--interface=ARRAY", Array, "Comma separated array: name,network/prefix,mac,ip (can be used multiple times, default: eth0,192.168.122.0/24") do |v|
     interfaces << v
   end
 
@@ -66,7 +66,7 @@ OptionParser.new do |opts|
   end
 end.parse!
 
-interfaces << ["eth0", "122"] if interfaces.empty?
+interfaces << ["eth0", "192.168.122.0/24"] if interfaces.empty?
 primary ||= interfaces.first.first
 bootif ||= interfaces.first.first
 json = JSON.parse(File.read(base))
@@ -76,15 +76,21 @@ json["discovery_version"] = version
 unless preserve_interfaces
   json["interfaces"] = interfaces.map{|i| i.first}.join(',')
   interfaces.each do |iface|
-    name, subnet, ipo, mac = iface
+    name, subnet, mac, explicit_ip = iface
     mac ||= (["52"] + 5.times.map { '%02x' % rand(0..255) }).join(':')
-    ipo ||= rand(1..253)
-    ip = "192.168.#{subnet}.#{ipo}"
     json["macaddress_#{name}"] = mac
-    json["ipaddress_#{name}"] = ip
+    subnet_woprefix, prefix = subnet.split('/')
+    if subnet.include?('.')
+      random_ip = IPAddr.new(subnet, Socket::AF_INET) | IPAddr.new(rand(2**prefix.to_i), Socket::AF_INET)
+      fact_name = "ipaddress"
+    else
+      random_ip = IPAddr.new(subnet, Socket::AF_INET6) | IPAddr.new(rand(2**prefix.to_i), Socket::AF_INET6)
+      fact_name = "ipaddress6"
+    end
+    json["#{fact_name}_#{name}"] = explicit_ip ? explicit_ip : random_ip
     if name == primary
-      json["macaddress"] = mac
-      json["ipaddress"] = ip
+      json["macaddress"] = json["macaddress_#{name}"]
+      json[fact_name] = json["#{fact_name}_#{name}"]
     end
     json["discovery_bootif"] = mac if name == bootif
   end


### PR DESCRIPTION
Subnet is blindly taken from hostgroup even if its set to nil then. The expected behavior is that subnet where discovered host was detected in should carry over to provisioning (if its nil in hostgroup).

Edit: This is no longer a doco PR, @melcorr nevermind.