### PR TITLE
Fixes #29482 - favor update over update_attributes

### DIFF
--- a/app/controllers/api/v2/discovery_rules_controller.rb
+++ b/app/controllers/api/v2/discovery_rules_controller.rb
@@ -55,7 +55,7 @@ module Api
       param_group :discovery_rule, :as => :update
 
       def update
-        process_response @discovery_rule.update_attributes(discovery_rule_params)
+        process_response @discovery_rule.update(discovery_rule_params)
       end
 
       api :DELETE, "/discovery_rules/:id/", N_("Delete a rule")

--- a/app/controllers/discovery_rules_controller.rb
+++ b/app/controllers/discovery_rules_controller.rb
@@ -28,7 +28,7 @@ class DiscoveryRulesController < ApplicationController
   end
 
   def update
-    if @discovery_rule.update_attributes(discovery_rule_params)
+    if @discovery_rule.update(discovery_rule_params)
       process_success
     else
       process_error

--- a/app/services/foreman_discovery/host_converter.rb
+++ b/app/services/foreman_discovery/host_converter.rb
@@ -1,6 +1,6 @@
 class ForemanDiscovery::HostConverter
   # Converts discovered host to managed host without uptading the database.
-  # Record must be saved explicitly (using save! or update_attributes! or similar).
+  # Record must be saved explicitly (using save! or update! or similar).
   # Creates shallow copy.
   def self.to_managed(original_host, set_managed = true, set_build = true, added_attributes = {})
     host = original_host.becomes(::Host::Managed)

--- a/db/migrate/20150512150432_remove_old_discovery_reader_permissions.rb
+++ b/db/migrate/20150512150432_remove_old_discovery_reader_permissions.rb
@@ -1,7 +1,7 @@
 class RemoveOldDiscoveryReaderPermissions < ActiveRecord::Migration[4.2]
   def up
     Permission.where("name like '%_discovery_rules' and resource_type is null").each do |permission|
-      permission.update_attributes(:resource_type => 'DiscoveryRule')
+      permission.update(:resource_type => 'DiscoveryRule')
     end
   end
 

--- a/db/migrate/20151023144501_regenerate_red_hat_kexec.rb
+++ b/db/migrate/20151023144501_regenerate_red_hat_kexec.rb
@@ -1,7 +1,7 @@
 class RegenerateRedHatKexec < ActiveRecord::Migration[4.2]
   def up
     t = ProvisioningTemplate.find_by_name("Discovery Red Hat kexec")
-    t.update_attributes(:template => t.template.sub(/rescue ''$/, 'if mac')) if t
+    t.update(:template => t.template.sub(/rescue ''$/, 'if mac')) if t
   end
 
   def down

--- a/db/migrate/20180412124505_add_priority_score_to_discovery_rules.rb
+++ b/db/migrate/20180412124505_add_priority_score_to_discovery_rules.rb
@@ -9,7 +9,7 @@
     # and makes sure there are no two entities with the same priority.
     DiscoveryRules.reset_column_information
     DiscoveryRules.unscoped.reorder(:priority, :created_at).find_each do |rule|
-      rule.update_attributes!(:priority => score)
+      rule.update!(:priority => score)
       score += delta
     end
     change_column :discovery_rules, :priority, :integer, null: false


### PR DESCRIPTION
`update_attributes` got deprecated in Rails 6.0