### PR TITLE
Fixes #29658 - discovery_rule hosts association on Rails 6

### DIFF
--- a/app/models/discovery_rule.rb
+++ b/app/models/discovery_rule.rb
@@ -22,7 +22,7 @@ class DiscoveryRule < ApplicationRecord
   before_validation :enforce_taxonomy
 
   belongs_to :hostgroup
-  has_many :hosts, :dependent => :nullify
+  has_many_hosts :dependent => :nullify
 
   scoped_search :on => :name, :complete_value => :true
   scoped_search :on => :priority, :only_explicit => true


### PR DESCRIPTION
@lzap as of https://community.theforeman.org/t/activerecord-woe-implicit-order-and-association/18492 this solves it, but there might be other places. I would love if you could think of getting rid of `Host` factory in favor of `Host` model from `Host::Discovered` perspective, as it could be only blocker.