### PR TITLE
Refs #29994 - add note about reset-vga

### DIFF
--- a/app/views/foreman_discovery/debian_kexec.erb
+++ b/app/views/foreman_discovery/debian_kexec.erb
@@ -12,9 +12,10 @@ environments. The template must generate JSON format with the following items
 "kernel", "initram", "append" and "extra". The kexec command is composed in
 the following way:
 
-kexec --force --reset-vga --append=$append --initrd=$initram $extra $kernel
+kexec --force --debug --append=$append --initrd=$initram $extra $kernel
 
 Please read kexec(8) man page for more information about semantics.
+Extra options like --reset-vga can be set via "extra" array.
 -%>
 <%
   mac = @host.facts['discovery_bootif']

--- a/app/views/foreman_discovery/redhat_kexec.erb
+++ b/app/views/foreman_discovery/redhat_kexec.erb
@@ -22,9 +22,10 @@ environments. The template must generate JSON format with the following items
 "kernel", "initram", "append" and "extra". The kexec command is composed in
 the following way:
 
-kexec --force --reset-vga --append=$append --initrd=$initram $extra $kernel
+kexec --force --debug --append=$append --initrd=$initram $extra $kernel
 
 Please read kexec(8) man page for more information about semantics.
+Extra options like --reset-vga can be set via "extra" array.
 -%>
 <%
   mac = @host.facts['discovery_bootif']


### PR DESCRIPTION
We are removing the hardcoded `--reset-vga` from the image plugin so users can eventually put it via extra flag but by default we will not use that as it was reported it is causing issues in EFI mode.

https://github.com/theforeman/smart_proxy_discovery_image/pull/8