### PR TITLE
Fixes #30105 - Adding reactjs with EmptyState Component

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,7 @@
+{
+  "plugins": ["@theforeman/foreman"],
+  "extends": [
+    "plugin:@theforeman/foreman/core",
+    "plugin:@theforeman/foreman/plugins"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ doc/
 # Foreman app support
 test/foreman_app
 .foreman_app
+
+# React
+node_modules
+package-lock.json
+coverage

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "stylelint-config-standard",
+  ],
+}

--- a/app/services/foreman_discovery/import_hooks/subnet_and_taxonomy.rb
+++ b/app/services/foreman_discovery/import_hooks/subnet_and_taxonomy.rb
@@ -35,6 +35,7 @@ module ForemanDiscovery
         Location.find_by_title(facts["discovery_location"]) ||
           Location.find_by_title(Setting[:discovery_location]) ||
           host.subnet.try(:locations).try(:first) ||
+          host.subnet6.try(:locations).try(:first) ||
           Location.first
       end
 
@@ -48,6 +49,7 @@ module ForemanDiscovery
         Organization.find_by_title(facts["discovery_organization"]) ||
           Organization.find_by_title(Setting[:discovery_organization]) ||
           host.subnet.try(:organizations).try(:first) ||
+          host.subnet6.try(:organizations).try(:first) ||
           Organization.first
       end
     end

--- a/app/views/discovered_hosts/welcome.html.erb
+++ b/app/views/discovered_hosts/welcome.html.erb
@@ -1,10 +1,16 @@
+<% content_for(:javascripts) do %>
+  <%= webpacked_plugins_js_for :'foreman_discovery' %>
+<% end %>
+<% content_for(:stylesheets) do %>
+  <%= webpacked_plugins_css_for :'foreman_discovery' %>
+<% end %>
+
 <% content_for(:title, _("Discovered Hosts")) %>
-<div class="blank-slate-pf">
-  <div class="blank-slate-pf-icon">
-    <%= icon_text("gears", "", :kind => "fa") %>
-  </div>
-  <h1><%= _('Discovered Hosts') %></h1>
-  <p><%= _("No discovered hosts found in this context.") %>
-  <%= _("This page shows discovered bare-metal or virtual nodes waiting to be provisioned.") %></p>
-  <p><%= link_to _('Learn more about this in the documentation.'), documentation_url("#{ForemanDiscovery::VERSION.scan(/\d+\.\d+/).first}/index.html", {:root_url => 'https://theforeman.org/plugins/foreman_discovery/'})%></p>
-</div>
+
+<% content_for(:content) do %>
+  <%= notifications %>
+  <div id="organization-id" data-id="<%= Organization.current.id if Organization.current %>" ></div>
+  <div id="user-id" data-id="<%= User.current.id if User.current %>" ></div>
+  <%= react_component('DiscoveredHosts',
+       docUrl: "https://theforeman.org/plugins/foreman_discovery/#{ForemanDiscovery::VERSION.scan(/\d+\.\d+/).first}/index.html" ) %>
+<% end %>

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ["@theforeman/builder/babel"],
+};

--- a/lib/foreman_discovery/engine.rb
+++ b/lib/foreman_discovery/engine.rb
@@ -49,7 +49,8 @@ module ForemanDiscovery
         security_block :discovery do
           permission :view_discovered_hosts, {
             :discovered_hosts          => [:index, :show, :auto_complete_search, :welcome],
-            :"api/v2/discovered_hosts" => [:index, :show]
+            :"api/v2/discovered_hosts" => [:index, :show],
+            :'discovered_hosts/react' => [:index]
           }, :resource_type => 'Host'
           permission :submit_discovered_hosts, {
             :"api/v2/discovered_hosts" => [:facts, :create]

--- a/package.json
+++ b/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "foreman_discovery",
+  "version": "16.2.0",
+  "description": "This plugin enables Foreman to do automatic bare-metal discovery of unknown nodes on the provisioning network.",
+  "main": "index.js",
+  "scripts": {
+    "lint": "tfm-lint --plugin -d /webpack",
+    "test": "tfm-test --plugin",
+    "test:watch": "tfm-test --plugin --watchAll",
+    "test:current": "tfm-test --plugin --watch",
+    "publish-coverage": "tfm-publish-coverage",
+    "stories": "tfm-stories --plugin",
+    "stories:build": "tfm-build-stories --plugin",
+    "create-react-component": "yo react-domain"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/theforeman/foreman_discovery.git"
+  },
+  "bugs": {
+    "url": "http://projects.theforeman.org/projects/foreman_discovery/issues"
+  },
+  "peerDependencies": {
+    "@theforeman/vendor": ">= 4.14.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.7.0",
+    "@theforeman/builder": "^4.14.0",
+    "@theforeman/eslint-plugin-foreman": "4.14.0",
+    "@theforeman/stories": "^4.14.0",
+    "@theforeman/test": "^4.14.0",
+    "@theforeman/vendor-dev": "^4.14.0",
+    "babel-eslint": "^10.0.3",
+    "eslint": "^6.7.2",
+    "prettier": "^1.19.1",
+    "stylelint": "^9.3.0",
+    "stylelint-config-standard": "^18.0.0"
+  }
+}

--- a/test/functional/discovered_hosts_controller_test.rb
+++ b/test/functional/discovered_hosts_controller_test.rb
@@ -168,7 +168,7 @@ class DiscoveredHostsControllerTest < ActionController::TestCase
   def test_add_entry_to_nav_menu
     get :index, params: {}, session: set_session_user
     assert_response :success
-    assert response.body =~ /\/discovered_hosts/
+    assert response.body.include?('Discovered Hosts')
   end
 
   def test_reboot_success

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -1,0 +1,18 @@
+/* eslint import/no-unresolved: [2, { ignore: [foremanReact/*] }] */
+/* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable import/extensions */
+import componentRegistry from "foremanReact/components/componentRegistry";
+import { registerReducer } from "foremanReact/common/MountingService";
+import reducers from "./src/reducers";
+import DiscoveredHosts from "./src/ForemanDiscovery/DiscoveredHosts";
+
+// register reducers
+Object.entries(reducers).forEach(([key, reducer]) =>
+  registerReducer(key, reducer)
+);
+
+// register components for erb mounting
+componentRegistry.register({
+  name: "DiscoveredHosts",
+  type: DiscoveredHosts,
+});

--- a/webpack/src/ForemanDiscovery/DiscoveredHosts/Components/EmptyState/EmptyState.js
+++ b/webpack/src/ForemanDiscovery/DiscoveredHosts/Components/EmptyState/EmptyState.js
@@ -1,0 +1,28 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { translate as __ } from "foremanReact/common/I18n";
+import ForemanEmptyState from "foremanReact/components/common/EmptyState";
+
+const EmptyState = (props) => {
+  const description = __(
+    "No discovered hosts found in this context. This page shows discovered bare-metal or virtual nodes waiting to be provisioned."
+  );
+  const documentation = {
+    url: props.docUrl,
+  };
+  return (
+    <ForemanEmptyState
+      header="Foreman Discovery"
+      description={description}
+      icon="gears"
+      iconType="fa"
+      documentation={documentation}
+    />
+  );
+};
+
+EmptyState.propTypes = {
+  docUrl: PropTypes.string,
+};
+
+export default EmptyState;

--- a/webpack/src/ForemanDiscovery/DiscoveredHosts/Components/EmptyState/index.js
+++ b/webpack/src/ForemanDiscovery/DiscoveredHosts/Components/EmptyState/index.js
@@ -1,0 +1,1 @@
+export { default } from "./EmptyState";

--- a/webpack/src/ForemanDiscovery/DiscoveredHosts/index.js
+++ b/webpack/src/ForemanDiscovery/DiscoveredHosts/index.js
@@ -1,0 +1,6 @@
+import React from "react";
+import EmptyState from "./Components/EmptyState";
+
+const DiscoveredHosts = ({ docUrl }) => <EmptyState docUrl={docUrl} />;
+
+export default DiscoveredHosts;

--- a/webpack/src/reducers.js
+++ b/webpack/src/reducers.js
@@ -1,0 +1,7 @@
+import { combineReducers } from "redux";
+
+const reducers = {
+  foremanDiscovery: {},
+};
+
+export default reducers;


### PR DESCRIPTION
Tasks involved in this effort are as follows:

* [x]  Adding Example Component
* [x]  Adding Foreman metapackages (test, lint, storybook, vendor)
* [x]  Adding API usage via APIMiddleware
* [x]  Use EmptyState from Foreman core
* [x]  work out packaging
