### PR TITLE
Fixes #30478 - try again when IP is invalid

### DIFF
--- a/app/models/host/managed_extensions.rb
+++ b/app/models/host/managed_extensions.rb
@@ -27,7 +27,7 @@ module Host::ManagedExtensions
   end
 
   def setReboot
-    old.becomes(Host::Discovered).reboot(facts["discovery_bootip"] || facts["ipaddress"])
+    old.becomes(Host::Discovered).reboot(old.ip, ip)
     # It is too late to report error in the post_queue, we catch them and
     # continue. If flash is implemented for new hosts (http://projects.theforeman.org/issues/10559)
     # we can report the error to the user perhaps.
@@ -55,7 +55,7 @@ module Host::ManagedExtensions
   end
 
   def setKexec
-    old.becomes(Host::Discovered).kexec(render_kexec_template.to_json)
+    old.becomes(Host::Discovered).kexec(render_kexec_template.to_json, old.ip, ip)
     true
   rescue ::Foreman::Exception => e
     Foreman::Logging.exception("Unable to kexec", e)

--- a/app/services/foreman_discovery/node_api/node_resource.rb
+++ b/app/services/foreman_discovery/node_api/node_resource.rb
@@ -6,6 +6,7 @@ module ForemanDiscovery::NodeAPI
       @args = args
       @connect_params = {
         :headers => { :accept => :json },
+        :timeout => 20, # tighter timeout, discovery performs up to two calls per request
       }
 
       if url.match(/^https/i) && Rails.env != "test"

--- a/test/unit/discovered_extensions_test.rb
+++ b/test/unit/discovered_extensions_test.rb
@@ -9,6 +9,7 @@ class DiscoveredExtensionsTest < ActiveSupport::TestCase
     @facts = facts_simple_network100_42
     @facts_ipv6 = facts_network_2001_db8
     set_default_settings
+    ProxyAPI::DHCP.any_instance.stubs(:record).returns(nil)
     ::ForemanDiscovery::HostConverter.stubs(:unused_ip_for_host)
   end
 

--- a/test/unit/managed_extensions_test.rb
+++ b/test/unit/managed_extensions_test.rb
@@ -18,6 +18,7 @@ class ManagedExtensionsTest < ActiveSupport::TestCase
 
       @host = StubHost.new
       @host.type = "Host::Discovered"
+      @host.stubs(:ip).returns("192.168.1.1")
       @host.stubs(:old).returns(@host)
       @facts = {}
       @host.stubs(:facts).returns(@facts)


### PR DESCRIPTION
The fix to use old lease when rebooting was not working correctly. It was not implemented for kexec completely, also it was not passing IP correctly. Also it could timeout on client. This fixes it all.