### PR TITLE
Fixes #30871 - display boolean consistently

### DIFF
--- a/app/views/discovery_rules/index.html.erb
+++ b/app/views/discovery_rules/index.html.erb
@@ -18,7 +18,7 @@
       <td><%= trunc_with_tooltip(rule.search) %></td>
       <td><%= label_with_link(rule.hostgroup, 26, authorizer) %></td>
       <td><%= rule.hosts.count %> / <%= rule.max_count %></td>
-      <td><%= rule.enabled %></td>
+      <td><%= checked_icon rule.enabled %></td>
       <td><%= action_buttons(*permitted_discovery_actions(rule)) %></td>
     </tr>
   <% end %>


### PR DESCRIPTION
To be more consistent with other tables

before
![dis1](https://user-images.githubusercontent.com/109773/93604194-59483780-f9c5-11ea-9e3d-c5c4f81115ed.png)

after
![dis2](https://user-images.githubusercontent.com/109773/93604213-5e0ceb80-f9c5-11ea-8fb3-62fc09263fe6.png)
