### PR TITLE
Fixes #30945: Add create.json.rabl template for discovery rules

### DIFF
--- a/app/views/api/v2/discovery_rules/create.json.rabl
+++ b/app/views/api/v2/discovery_rules/create.json.rabl
@@ -1,0 +1,3 @@
+object @discovery_rule
+
+extends "api/v2/discovery_rules/show"


### PR DESCRIPTION
The lack of a template for create results in a different output
format being used from the show response. Further, without this
template the rendering engine will perform a to_json and skip
the Rabl layer all together.