### PR TITLE
Fixes #30948 - autoprovisioning for non-default taxonomies

### DIFF
--- a/app/controllers/api/v2/discovered_hosts_controller.rb
+++ b/app/controllers/api/v2/discovered_hosts_controller.rb
@@ -107,11 +107,11 @@ module Api
           # the anonymous admin can see all records. We set taxonomy explicitly via
           # discovery SubnetAndTaxonomy import hook and enforce taxnomy manually
           # in find_discovery_rule method via validate_rule_by_taxonomy.
-          Organization.current = nil
-          Location.current = nil
-          Rails.logger.warn 'Discovered facts import unsuccessful, skipping auto provisioning' unless @discovered_host
-          if Setting['discovery_auto'] && @discovered_host && (rule = find_discovery_rule(@discovered_host))
-            state = perform_auto_provision(@discovered_host, rule)
+          Taxonomy.no_taxonomy_scope do
+            Rails.logger.warn 'Discovered facts import unsuccessful, skipping auto provisioning' unless @discovered_host
+            if Setting['discovery_auto'] && @discovered_host && (rule = find_discovery_rule(@discovered_host))
+              state = perform_auto_provision(@discovered_host, rule)
+            end
           end
         end
         process_response state

--- a/app/controllers/api/v2/discovered_hosts_controller.rb
+++ b/app/controllers/api/v2/discovered_hosts_controller.rb
@@ -102,6 +102,13 @@ module Api
         state = true
         User.as_anonymous_admin do
           @discovered_host = Host::Discovered.import_host(facts)
+          # Host::Based.set_taxonomies sets taxonomies during import from either
+          # facts or via Global Foreman setting "default_taxonomy", reset it back so
+          # the anonymous admin can see all records. We set taxonomy explicitly via
+          # discovery SubnetAndTaxonomy import hook and enforce taxnomy manually
+          # in find_discovery_rule method via validate_rule_by_taxonomy.
+          Organization.current = nil
+          Location.current = nil
           Rails.logger.warn 'Discovered facts import unsuccessful, skipping auto provisioning' unless @discovered_host
           if Setting['discovery_auto'] && @discovered_host && (rule = find_discovery_rule(@discovered_host))
             state = perform_auto_provision(@discovered_host, rule)


### PR DESCRIPTION
Auto-provisioning does not work when Foreman core enforces taxonomy of imported host via "default_organization" (and location) global settings during import. Discovery sets taxonomy via its own mechanism, this is then overriden by the import code in Host::Base.set_taxonomies and if discovery rule and hostgroup is in a different taxonomy than the default one (Default Organization/Location), auto provisioning fails to find a rule, even when it works in as_anonymous_admin.

This was reported as a regression, something had to change in core that triggered this problem.

More info at: https://community.theforeman.org/t/discovery-auto-provisioning-not-working/20610