### PR TITLE
Fixes #31006 - set taxonomy from subnet6 too

### DIFF
--- a/app/services/foreman_discovery/import_hooks/subnet_and_taxonomy.rb
+++ b/app/services/foreman_discovery/import_hooks/subnet_and_taxonomy.rb
@@ -35,6 +35,7 @@ module ForemanDiscovery
         Location.find_by_title(facts["discovery_location"]) ||
           Location.find_by_title(Setting[:discovery_location]) ||
           host.subnet.try(:locations).try(:first) ||
+          host.subnet6.try(:locations).try(:first) ||
           Location.first
       end
 
@@ -48,6 +49,7 @@ module ForemanDiscovery
         Organization.find_by_title(facts["discovery_organization"]) ||
           Organization.find_by_title(Setting[:discovery_organization]) ||
           host.subnet.try(:organizations).try(:first) ||
+          host.subnet6.try(:organizations).try(:first) ||
           Organization.first
       end
     end


### PR DESCRIPTION
Some users report that discovered hosts don't get token generated during provisioning. This comes back regularly, discovery relies on validation callback in core to create new token, let's simply call this explicitly when converting the host to ensure it exists.