### PR TITLE
Fixes #31183 - Enforce new token during discovery

### DIFF
--- a/app/services/foreman_discovery/host_converter.rb
+++ b/app/services/foreman_discovery/host_converter.rb
@@ -30,8 +30,9 @@ class ForemanDiscovery::HostConverter
       # clean no facts (default behavior)
       host.define_singleton_method(:clear_facts) {}
     end
-    # set build flag
+    # set build flag and call set_token explicitly to force new one
     host.build = true
+    host.set_token
   end
 
   def self.unused_ip_for_subnet(subnet, mac, existing_ip)

--- a/extra/discover-host
+++ b/extra/discover-host
@@ -12,6 +12,7 @@ def find_base name = "default"
   file
 end
 
+executable = nil
 base = find_base
 version = "3.4.0"
 interfaces = []
@@ -24,6 +25,12 @@ organization = nil
 location = nil
 OptionParser.new do |opts|
   opts.banner = "Usage: discover-host [options]"
+
+  # example:
+  # discover-host -e "facter --json --custom-dir=../foreman-discovery-image/root/usr/share/fdi/facts"
+  opts.on("-eFILE", "--exec=FILE", "Execute external facter program") do |v|
+    executable = v
+  end
 
   opts.on("-jFILE", "--json=FILE", "Base JSON filename") do |v|
     base = find_base(v)
@@ -66,33 +73,37 @@ OptionParser.new do |opts|
   end
 end.parse!
 
-interfaces << ["eth0", "192.168.122.0/24"] if interfaces.empty?
-primary ||= interfaces.first.first
-bootif ||= interfaces.first.first
-json = JSON.parse(File.read(base))
-json["foreman_organization"] = organization if organization
-json["foreman_location"] = location if location
-json["discovery_version"] = version
-unless preserve_interfaces
-  json["interfaces"] = interfaces.map{|i| i.first}.join(',')
-  interfaces.each do |iface|
-    name, subnet, mac, explicit_ip = iface
-    mac ||= (["52"] + 5.times.map { '%02x' % rand(0..255) }).join(':')
-    json["macaddress_#{name}"] = mac
-    _, prefix = subnet.split('/')
-    if subnet.include?('.')
-      random_ip = IPAddr.new(subnet, Socket::AF_INET) | IPAddr.new(rand(2**(32 - prefix.to_i)), Socket::AF_INET)
-      fact_name = "ipaddress"
-    else
-      random_ip = IPAddr.new(subnet, Socket::AF_INET6) | IPAddr.new(rand(2**(32 - prefix.to_i)), Socket::AF_INET6)
-      fact_name = "ipaddress6"
+if executable
+  json = JSON.parse(`#{executable}`)
+else
+  interfaces << ["eth0", "192.168.122.0/24"] if interfaces.empty?
+  primary ||= interfaces.first.first
+  bootif ||= interfaces.first.first
+  json = JSON.parse(File.read(base))
+  json["foreman_organization"] = organization if organization
+  json["foreman_location"] = location if location
+  json["discovery_version"] = version
+  unless preserve_interfaces
+    json["interfaces"] = interfaces.map{|i| i.first}.join(',')
+    interfaces.each do |iface|
+      name, subnet, mac, explicit_ip = iface
+      mac ||= (["52"] + 5.times.map { '%02x' % rand(0..255) }).join(':')
+      json["macaddress_#{name}"] = mac
+      _, prefix = subnet.split('/')
+      if subnet.include?('.')
+        random_ip = IPAddr.new(subnet, Socket::AF_INET) | IPAddr.new(rand(2**(32 - prefix.to_i)), Socket::AF_INET)
+        fact_name = "ipaddress"
+      else
+        random_ip = IPAddr.new(subnet, Socket::AF_INET6) | IPAddr.new(rand(2**(32 - prefix.to_i)), Socket::AF_INET6)
+        fact_name = "ipaddress6"
+      end
+      json["#{fact_name}_#{name}"] = explicit_ip ? explicit_ip : random_ip
+      if name == primary
+        json["macaddress"] = json["macaddress_#{name}"]
+        json[fact_name] = json["#{fact_name}_#{name}"]
+      end
+      json["discovery_bootif"] = mac if name == bootif
     end
-    json["#{fact_name}_#{name}"] = explicit_ip ? explicit_ip : random_ip
-    if name == primary
-      json["macaddress"] = json["macaddress_#{name}"]
-      json[fact_name] = json["#{fact_name}_#{name}"]
-    end
-    json["discovery_bootif"] = mac if name == bootif
   end
 end
 puts JSON.pretty_generate(json)


### PR DESCRIPTION
Some users report that discovered hosts don't get token generated during provisioning. This comes back regularly, discovery relies on validation callback in core to create new token, let's simply call this explicitly when converting the host to ensure it exists.