### PR TITLE
Fixes #31242 - update the engine.rb to use latest foreman

### DIFF
--- a/lib/foreman_discovery/engine.rb
+++ b/lib/foreman_discovery/engine.rb
@@ -43,7 +43,7 @@ module ForemanDiscovery
 
     initializer 'foreman_discovery.register_plugin', :before => :finisher_hook do |app|
       Foreman::Plugin.register :foreman_discovery do
-        requires_foreman '>= 2.2'
+        requires_foreman '>= 2.3'
 
         # discovered hosts permissions
         security_block :discovery do

--- a/lib/foreman_discovery/version.rb
+++ b/lib/foreman_discovery/version.rb
@@ -1,3 +1,3 @@
 module ForemanDiscovery
-  VERSION = "16.3.1"
+  VERSION = "16.3.2"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foreman_discovery",
-  "version": "16.2.0",
+  "version": "16.3.2",
   "description": "This plugin enables Foreman to do automatic bare-metal discovery of unknown nodes on the provisioning network.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I think the empty state component does not display in the nightly because we are using an older version of Foreman where the EmptyState component is not updated. 

Although, I am  not sure if a version upgrade to gem will be required or not, please let me know your thoughts on this @lzap 