### PR TITLE
Fixes #31278 - make the plugin version available in production

### DIFF
--- a/app/helpers/discovered_hosts_helper.rb
+++ b/app/helpers/discovered_hosts_helper.rb
@@ -97,4 +97,9 @@ module DiscoveredHostsHelper
     return super unless controller_name == 'discovered_hosts'
     discovered_host_path(host)
   end
+
+  def discovery_doc_url
+    doc_version = Foreman::Plugin.find(:foreman_discovery).version.scan(/\d+\.\d+/).first
+    "https://theforeman.org/plugins/foreman_discovery/#{doc_version}"
+  end
 end

--- a/app/views/discovered_hosts/welcome.html.erb
+++ b/app/views/discovered_hosts/welcome.html.erb
@@ -11,6 +11,5 @@
   <%= notifications %>
   <div id="organization-id" data-id="<%= Organization.current.id if Organization.current %>" ></div>
   <div id="user-id" data-id="<%= User.current.id if User.current %>" ></div>
-  <%= react_component('DiscoveredHosts',
-       docUrl: "https://theforeman.org/plugins/foreman_discovery/#{ForemanDiscovery::VERSION.scan(/\d+\.\d+/).first}/index.html" ) %>
+  <%= react_component('DiscoveredHosts', docUrl: discovery_doc_url ) %>
 <% end %>


### PR DESCRIPTION
continued from #516 
@rabajaj0509 @lzap I tested it on nightly,
basically, it will generate the following URL: https://theforeman.org/plugins/foreman_discovery/16.3/index.html
