### PR TITLE
Fixes #31207 - add github actions

### DIFF
--- a/.github/workflows/js_tests.yml
+++ b/.github/workflows/js_tests.yml
@@ -1,0 +1,28 @@
+name: JavaScript Testing
+on:
+  pull_request:
+    paths:
+      - "webpack/**"
+      - "package.json"
+      - ".github/workflows/js_tests.yml"
+
+jobs:
+  test_js:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout plugin
+        uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Install plugin npm dependencies
+        run: npm install
+      - name: Run plugin linter
+        run: npm run lint
+      - name: Run plugin tests
+        run: npm run test
+      - name: Publish Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/webpack/__mocks__/foremanReact/common/I18n.js
+++ b/webpack/__mocks__/foremanReact/common/I18n.js
@@ -1,0 +1,3 @@
+export const translate = s => s;
+
+export const ngettext = s => s;

--- a/webpack/__mocks__/foremanReact/components/common/EmptyState/DefaultEmptyState.js
+++ b/webpack/__mocks__/foremanReact/components/common/EmptyState/DefaultEmptyState.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import { push } from 'connected-react-router';
+import { Button } from '@patternfly/react-core';
+import EmptyStatePattern from './EmptyStatePattern';
+import { defaultEmptyStatePropTypes } from './EmptyStatePropTypes';
+
+const DefaultEmptyState = props => {
+  const {
+    icon,
+    iconType,
+    header,
+    description,
+    documentation,
+    action,
+    secondaryActions,
+  } = props;
+
+  const dispatch = useDispatch();
+  const actionButtonClickHandler = ({ url, onClick }) => {
+    if (onClick) onClick();
+    else if (url) dispatch(push(url));
+  };
+
+  const ActionButton = action ? (
+    <Button
+      component="a"
+      onClick={() => actionButtonClickHandler(action)}
+      variant="primary"
+    >
+      {action.title}
+    </Button>
+  ) : null;
+
+  const SecondaryButton = secondaryActions
+    ? secondaryActions.map(({ title, url, onClick }) => (
+        <Button
+          component="a"
+          key={`sec-button-${title}`}
+          onClick={() => actionButtonClickHandler({ url, onClick })}
+          variant="secondary"
+        >
+          {title}
+        </Button>
+      ))
+    : null;
+
+  return (
+    <EmptyStatePattern
+      icon={icon}
+      iconType={iconType}
+      header={header}
+      description={description}
+      documentation={documentation}
+      action={ActionButton}
+      secondaryActions={SecondaryButton}
+    />
+  );
+};
+
+DefaultEmptyState.propTypes = defaultEmptyStatePropTypes;
+
+DefaultEmptyState.defaultProps = {
+  icon: 'add-circle-o',
+  secondaryActions: [],
+  iconType: 'pf',
+};
+
+export default DefaultEmptyState;

--- a/webpack/__mocks__/foremanReact/components/common/EmptyState/EmptyStatePattern.js
+++ b/webpack/__mocks__/foremanReact/components/common/EmptyState/EmptyStatePattern.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import { Icon } from 'patternfly-react';
+import {
+  Title,
+  EmptyState,
+  EmptyStateVariant,
+  EmptyStateBody,
+  EmptyStateSecondaryActions,
+} from '@patternfly/react-core';
+import { emptyStatePatternPropTypes } from './EmptyStatePropTypes';
+import { translate as __ } from '../../../common/I18n';
+
+const EmptyStatePattern = props => {
+  const {
+    documentation,
+    action,
+    secondaryActions,
+    iconType,
+    icon,
+    header,
+    description,
+  } = props;
+
+  const DocumentationBlock = () => {
+    if (!documentation) {
+      return null;
+    }
+    // The documentation prop can also be a customized node
+    if (React.isValidElement(documentation)) {
+      return documentation;
+    }
+    const {
+      label = __('For more information please see '),
+      buttonLabel = __('documentation'),
+      url,
+    } = documentation;
+    return (
+      <span>
+        {label}
+        <a href={url}>{buttonLabel}</a>
+      </span>
+    );
+  };
+
+  return (
+    <EmptyState variant={EmptyStateVariant.xl}>
+      <span className="empty-state-icon">
+        {/* TODO: Add pf4 icons, Redmine issue: #30865 */}
+        <Icon name={icon} type={iconType} size="2x" />
+      </span>
+      <Title headingLevel="h5" size="4xl">
+        {header}
+      </Title>
+      <EmptyStateBody>
+        <div className="empty-state-description">{description}</div>
+        <DocumentationBlock />
+      </EmptyStateBody>
+      {action}
+      <EmptyStateSecondaryActions>
+        {secondaryActions}
+      </EmptyStateSecondaryActions>
+    </EmptyState>
+  );
+};
+
+EmptyStatePattern.propTypes = emptyStatePatternPropTypes;
+
+EmptyStatePattern.defaultProps = {
+  icon: 'add-circle-o',
+  secondaryActions: [],
+  documentation: {
+    url: '#',
+  },
+  iconType: 'pf',
+};
+
+export default EmptyStatePattern;

--- a/webpack/__mocks__/foremanReact/components/common/EmptyState/EmptyStatePropTypes.js
+++ b/webpack/__mocks__/foremanReact/components/common/EmptyState/EmptyStatePropTypes.js
@@ -1,0 +1,29 @@
+import PropTypes from 'prop-types';
+
+export const actionButtonPropTypes = {
+  title: PropTypes.node.isRequired,
+  url: PropTypes.string,
+  onChange: PropTypes.func,
+};
+
+export const emptyStatePatternPropTypes = {
+  icon: PropTypes.string.isRequired,
+  header: PropTypes.string.isRequired,
+  documentation: PropTypes.oneOfType([
+    PropTypes.shape({
+      label: PropTypes.string,
+      buttonLabel: PropTypes.string,
+      url: PropTypes.string.isRequired,
+    }),
+    PropTypes.node,
+  ]),
+  description: PropTypes.string.isRequired,
+  action: PropTypes.node,
+  secondaryActions: PropTypes.node,
+};
+
+export const defaultEmptyStatePropTypes = {
+  ...emptyStatePatternPropTypes,
+  action: PropTypes.shape(actionButtonPropTypes),
+  secondaryActions: PropTypes.arrayOf(PropTypes.shape(actionButtonPropTypes)),
+};

--- a/webpack/__mocks__/foremanReact/components/common/EmptyState/index.js
+++ b/webpack/__mocks__/foremanReact/components/common/EmptyState/index.js
@@ -1,0 +1,5 @@
+import EmptyStatePattern from './EmptyStatePattern';
+import DefaultEmptyState from './DefaultEmptyState';
+
+export default DefaultEmptyState;
+export { EmptyStatePattern };

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -1,10 +1,10 @@
 /* eslint import/no-unresolved: [2, { ignore: [foremanReact/*] }] */
 /* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable import/extensions */
-import componentRegistry from "foremanReact/components/componentRegistry";
-import { registerReducer } from "foremanReact/common/MountingService";
-import reducers from "./src/reducers";
-import DiscoveredHosts from "./src/ForemanDiscovery/DiscoveredHosts";
+import componentRegistry from 'foremanReact/components/componentRegistry';
+import { registerReducer } from 'foremanReact/common/MountingService';
+import reducers from './src/reducers';
+import DiscoveredHosts from './src/ForemanDiscovery/DiscoveredHosts';
 
 // register reducers
 Object.entries(reducers).forEach(([key, reducer]) =>
@@ -13,6 +13,6 @@ Object.entries(reducers).forEach(([key, reducer]) =>
 
 // register components for erb mounting
 componentRegistry.register({
-  name: "DiscoveredHosts",
+  name: 'DiscoveredHosts',
   type: DiscoveredHosts,
 });

--- a/webpack/src/ForemanDiscovery/DiscoveredHosts/Components/EmptyState/EmptyState.js
+++ b/webpack/src/ForemanDiscovery/DiscoveredHosts/Components/EmptyState/EmptyState.js
@@ -1,11 +1,11 @@
-import React from "react";
-import PropTypes from "prop-types";
-import { translate as __ } from "foremanReact/common/I18n";
-import ForemanEmptyState from "foremanReact/components/common/EmptyState";
+import React from 'react';
+import PropTypes from 'prop-types';
+import { translate as __ } from 'foremanReact/common/I18n';
+import ForemanEmptyState from 'foremanReact/components/common/EmptyState';
 
-const EmptyState = (props) => {
+const EmptyState = props => {
   const description = __(
-    "No discovered hosts found in this context. This page shows discovered bare-metal or virtual nodes waiting to be provisioned."
+    'No discovered hosts found in this context. This page shows discovered bare-metal or virtual nodes waiting to be provisioned.'
   );
   const documentation = {
     url: props.docUrl,
@@ -22,7 +22,7 @@ const EmptyState = (props) => {
 };
 
 EmptyState.propTypes = {
-  docUrl: PropTypes.string,
+  docUrl: PropTypes.string.isRequired,
 };
 
 export default EmptyState;

--- a/webpack/src/ForemanDiscovery/DiscoveredHosts/Components/EmptyState/__test__/EmptyState.test.js
+++ b/webpack/src/ForemanDiscovery/DiscoveredHosts/Components/EmptyState/__test__/EmptyState.test.js
@@ -1,0 +1,12 @@
+import { testComponentSnapshotsWithFixtures } from '@theforeman/test';
+
+import ForemanEmptyState from '../EmptyState';
+
+const fixtures = {
+  'render with Props': { docUrl: 'https://foreman.example.com' },
+};
+
+describe('ForemanEmptyState', () => {
+  describe('rendering', () =>
+    testComponentSnapshotsWithFixtures(ForemanEmptyState, fixtures));
+});

--- a/webpack/src/ForemanDiscovery/DiscoveredHosts/Components/EmptyState/__test__/__snapshots__/EmptyState.test.js.snap
+++ b/webpack/src/ForemanDiscovery/DiscoveredHosts/Components/EmptyState/__test__/__snapshots__/EmptyState.test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ForemanEmptyState rendering render with Props 1`] = `
+<DefaultEmptyState
+  description="No discovered hosts found in this context. This page shows discovered bare-metal or virtual nodes waiting to be provisioned."
+  documentation={
+    Object {
+      "url": "https://foreman.example.com",
+    }
+  }
+  header="Foreman Discovery"
+  icon="gears"
+  iconType="fa"
+  secondaryActions={Array []}
+/>
+`;

--- a/webpack/src/ForemanDiscovery/DiscoveredHosts/Components/EmptyState/index.js
+++ b/webpack/src/ForemanDiscovery/DiscoveredHosts/Components/EmptyState/index.js
@@ -1,1 +1,1 @@
-export { default } from "./EmptyState";
+export { default } from './EmptyState';

--- a/webpack/src/ForemanDiscovery/DiscoveredHosts/index.js
+++ b/webpack/src/ForemanDiscovery/DiscoveredHosts/index.js
@@ -1,6 +1,6 @@
-import React from "react";
-import EmptyState from "./Components/EmptyState";
+import React from 'react';
+import EmptyState from './Components/EmptyState';
 
-const DiscoveredHosts = ({ docUrl }) => <EmptyState docUrl={docUrl} />;
+const DiscoveredHosts = props => <EmptyState {...props} />;
 
 export default DiscoveredHosts;

--- a/webpack/src/reducers.js
+++ b/webpack/src/reducers.js
@@ -1,5 +1,3 @@
-import { combineReducers } from "redux";
-
 const reducers = {
   foremanDiscovery: {},
 };


### PR DESCRIPTION
These github actions will enable regression JS tests. It will also look out for code quality and prompt with suitable suggestions.

As a follow up I will add the caching to this github action. Let me know your thoughts @laviro :+1: 