### PR TITLE
Fixes #31203 - welcome page for discovery rules

### DIFF
--- a/app/controllers/discovery_rules_controller.rb
+++ b/app/controllers/discovery_rules_controller.rb
@@ -6,6 +6,10 @@ class DiscoveryRulesController < ApplicationController
 
   before_action :find_resource, :only => [:edit, :update, :destroy, :enable, :disable, :auto_provision]
 
+  def model_of_controller
+    Host::Discovered
+  end
+
   def index
     base = resource_base.search_for(params[:search], :order => (params[:order]))
     @discovery_rules = base.paginate(:page => params[:page], :per_page => params[:per_page]).includes(:hostgroup)

--- a/app/views/discovery_rules/welcome.html.erb
+++ b/app/views/discovery_rules/welcome.html.erb
@@ -1,0 +1,15 @@
+<% content_for(:javascripts) do %>
+  <%= webpacked_plugins_js_for :'foreman_discovery' %>
+<% end %>
+<% content_for(:stylesheets) do %>
+  <%= webpacked_plugins_css_for :'foreman_discovery' %>
+<% end %>
+
+<% content_for(:title, _("Discovered Rules")) %>
+
+<% content_for(:content) do %>
+  <%= notifications %>
+  <div id="organization-id" data-id="<%= Organization.current.id if Organization.current %>" ></div>
+  <div id="user-id" data-id="<%= User.current.id if User.current %>" ></div>
+  <%= react_component('DiscoveryRules', docUrl: discovery_doc_url + '/#4.3Automaticprovisioning' ) %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   post 'medium_selected_discovered_hosts'       => 'hosts#medium_selected'
 
   get 'discovered_hosts/help', :action => :welcome, :controller => 'discovered_hosts'
+  get 'discovery_rules/help', :action => :welcome, :controller => 'discovery_rules'
 
   constraints(:id => /[^\/]+/) do
     resources :discovered_hosts, :except => [:new, :create] do

--- a/lib/foreman_discovery/engine.rb
+++ b/lib/foreman_discovery/engine.rb
@@ -86,7 +86,7 @@ module ForemanDiscovery
         # discovery rules permissions
         security_block :discovery_rules do
           permission :view_discovery_rules, {
-            :discovery_rules => [:index, :show, :auto_complete_search],
+            :discovery_rules => [:index, :show, :auto_complete_search, :welcome],
             :"api/v2/discovery_rules" => [:index, :show]
           }, :resource_type => 'DiscoveryRule'
           permission :create_discovery_rules, {

--- a/test/functional/discovery_rules_controller_test.rb
+++ b/test/functional/discovery_rules_controller_test.rb
@@ -12,7 +12,6 @@ class DiscoveryRulesControllerTest < ActionController::TestCase
   test "reader role should get index" do
     get :index, params: {}, session: set_session_user_default_reader
     assert_response :success
-    assert_not_nil assigns(:discovery_rules)
   end
 
   test "should get new" do

--- a/webpack/__mocks__/foremanReact/common/helpers.js
+++ b/webpack/__mocks__/foremanReact/common/helpers.js
@@ -1,0 +1,1 @@
+export const foremanUrl = path => `${window.URL_PREFIX}${path}`;

--- a/webpack/__mocks__/foremanReact/common/index.js
+++ b/webpack/__mocks__/foremanReact/common/index.js
@@ -1,0 +1,5 @@
+import EmptyStatePattern from '../components/common/EmptyState/EmptyStatePattern';
+import DefaultEmptyState from '../components/common/EmptyState/DefaultEmptyState';
+
+export default DefaultEmptyState;
+export { EmptyStatePattern };

--- a/webpack/__mocks__/foremanReact/components/common/EmptyState/EmptyStatePattern.js
+++ b/webpack/__mocks__/foremanReact/components/common/EmptyState/EmptyStatePattern.js
@@ -30,9 +30,9 @@ const EmptyStatePattern = props => {
       return documentation;
     }
     const {
-      label = __('For more information please see '),
-      buttonLabel = __('documentation'),
-      url,
+      label = __('For more information please see '), // eslint-disable-line react/prop-types
+      buttonLabel = __('documentation'), // eslint-disable-line react/prop-types
+      url, // eslint-disable-line react/prop-types
     } = documentation;
     return (
       <span>

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -5,6 +5,7 @@ import componentRegistry from 'foremanReact/components/componentRegistry';
 import { registerReducer } from 'foremanReact/common/MountingService';
 import reducers from './src/reducers';
 import DiscoveredHosts from './src/ForemanDiscovery/DiscoveredHosts';
+import DiscoveryRules from './src/ForemanDiscovery/DiscoveryRules';
 
 // register reducers
 Object.entries(reducers).forEach(([key, reducer]) =>
@@ -12,7 +13,7 @@ Object.entries(reducers).forEach(([key, reducer]) =>
 );
 
 // register components for erb mounting
-componentRegistry.register({
-  name: 'DiscoveredHosts',
-  type: DiscoveredHosts,
-});
+componentRegistry.registerMultiple([
+  { name: 'DiscoveredHosts', type: DiscoveredHosts },
+  { name: 'DiscoveryRules', type: DiscoveryRules },
+]);

--- a/webpack/src/ForemanDiscovery/DiscoveryRules/Components/EmptyState/EmptyState.js
+++ b/webpack/src/ForemanDiscovery/DiscoveryRules/Components/EmptyState/EmptyState.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { translate as __ } from 'foremanReact/common/I18n';
+import ForemanEmptyState from 'foremanReact/components/common/EmptyState';
+import { foremanUrl } from 'foremanReact/common/helpers';
+
+const EmptyState = props => {
+  const action = {
+    title: __('Create Rule'),
+    url: foremanUrl('/discovery_rules/new'),
+  };
+  const description = __(
+    'No Discovery Rules found in this context. Create Discovery Rules to perform automated provisioning on Discovered Hosts'
+  );
+  const documentation = {
+    url: props.docUrl,
+  };
+  return (
+    <ForemanEmptyState
+      header="Discovery Rules"
+      description={description}
+      icon="gavel"
+      iconType="fa"
+      documentation={documentation}
+      action={action}
+    />
+  );
+};
+
+EmptyState.propTypes = {
+  docUrl: PropTypes.string.isRequired,
+};
+
+export default EmptyState;

--- a/webpack/src/ForemanDiscovery/DiscoveryRules/Components/EmptyState/index.js
+++ b/webpack/src/ForemanDiscovery/DiscoveryRules/Components/EmptyState/index.js
@@ -1,0 +1,1 @@
+export { default } from './EmptyState';

--- a/webpack/src/ForemanDiscovery/DiscoveryRules/Components/__test__/EmptyState.test.js
+++ b/webpack/src/ForemanDiscovery/DiscoveryRules/Components/__test__/EmptyState.test.js
@@ -1,0 +1,19 @@
+import { testComponentSnapshotsWithFixtures } from '@theforeman/test';
+import ForemanEmptyState from '../EmptyState';
+
+const action = {
+  title: 'action-title',
+  url: `action-url`,
+};
+
+const fixtures = {
+  'render with Props': {
+    docUrl: 'https://foreman.example.com',
+    action,
+  },
+};
+
+describe('ForemanEmptyState', () => {
+  describe('rendering', () =>
+    testComponentSnapshotsWithFixtures(ForemanEmptyState, fixtures));
+});

--- a/webpack/src/ForemanDiscovery/DiscoveryRules/Components/__test__/__snapshots__/EmptyState.test.js.snap
+++ b/webpack/src/ForemanDiscovery/DiscoveryRules/Components/__test__/__snapshots__/EmptyState.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ForemanEmptyState rendering render with Props 1`] = `
+<DefaultEmptyState
+  action={
+    Object {
+      "title": "Create Rule",
+      "url": "/discovery_rules/new",
+    }
+  }
+  description="No Discovery Rules found in this context. Create Discovery Rules to perform automated provisioning on Discovered Hosts"
+  documentation={
+    Object {
+      "url": "https://foreman.example.com",
+    }
+  }
+  header="Discovery Rules"
+  icon="gavel"
+  iconType="fa"
+  secondaryActions={Array []}
+/>
+`;

--- a/webpack/src/ForemanDiscovery/DiscoveryRules/index.js
+++ b/webpack/src/ForemanDiscovery/DiscoveryRules/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import EmptyState from './Components/EmptyState';
+
+const DiscoveryRules = props => <EmptyState {...props} />;
+
+export default DiscoveryRules;


### PR DESCRIPTION
Tasks involved in this effort are as follows:

* [x]  Adding button for the `Create Discovery Rule`
* [x]  Suitable icon for Discovery Rules
* [x]  Suitable description for Discovery Rules
* [x]  Add test cases for welcome page

![RulesPage](https://user-images.githubusercontent.com/10976840/100876335-41188c80-34cd-11eb-8ae1-2c2d3b35182a.png)



Apart from this, what do you think @laviro?