### PR TITLE
fixes #14229 - Refactoring assign_to_fact_category method

### DIFF
--- a/app/services/foreman_discovery/fact_to_category_resolver.rb
+++ b/app/services/foreman_discovery/fact_to_category_resolver.rb
@@ -1,0 +1,106 @@
+module ForemanDiscovery
+  class FactToCategoryResolver
+    include ActionView::Helpers::NumberHelper
+
+    attr_reader :categories, :interfaces
+
+    CATEGORIES_NAMES = [N_("Highlights"),
+                        N_("Storage"),
+                        N_("Hardware"),
+                        N_("Network"),
+                        N_("Software"),
+                        N_("IPMI"),
+                        N_("Miscellaneous")].freeze
+
+    def initialize(host)
+      categories = %i[highlights storage hardware network software ipmi]
+
+      @regex_array = categories.map do |category|
+        settings_category = settings_discovery_fact_prefix(category)
+        if settings_category.empty?
+          send(category)
+        else
+          Regexp.new(settings_category)
+        end
+      end
+
+      @regex_array << false
+
+      @categories = []
+
+      @interfaces = host.interfaces.map do |interface|
+        {
+          identifier: interface["identifier"],
+          type: interface["type"],
+          mac: interface["mac"],
+          ip: interface["ip"] || "N/A",
+          primary: interface["primary"],
+          provision: interface["provision"],
+        }
+      end
+
+      assign_facts(host)
+    end
+
+    private
+
+    def assign_facts(host)
+      host.facts_hash.each do |key, value|
+        value = number_to_human_size(value) if /size$/.match(key)
+        assign_fact_to_category(key, value)
+      end
+
+      return if host.primary_interface.subnet.nil?
+
+      discovery_subnet = "#{host.primary_interface.subnet.name} (#{host.primary_interface.subnet.network})"
+      assign_fact_to_category("discovery_subnet", discovery_subnet)
+    end
+
+    def assign_fact_to_category(key, value)
+      if @interfaces.any? { |interface| key.include? interface[:identifier] }
+        @categories[3] = {} if @categories[3].nil?
+        @categories[3][key] = value
+        return
+      end
+
+      @regex_array.each_with_index do |regex, index|
+        @categories[index] = {} if @categories[index].nil?
+        if !regex
+          @categories[index][key] = value
+        elsif regex.match key
+          @categories[index][key] = value
+          break
+        end
+      end
+    end
+
+    def highlights
+      /^(productname|memorysize|manufacturer|architecture|macaddress$|processorcount|physicalprocessorcount|discovery_subnet|discovery_boot|ipaddress$)/
+    end
+
+    def storage
+      /^blockdevice/
+    end
+
+    def hardware
+      /^(hardw|manufacturer|memo|process)/
+    end
+
+    def network
+      /^(interfaces|dhcp|fqdn|hostname)/
+    end
+
+    def software
+      /^(bios|os|discovery)/
+    end
+
+    def ipmi
+      /^ipmi/
+    end
+
+    def settings_discovery_fact_prefix(name)
+      Setting["discovery_facts_#{name}".to_sym]
+    end
+  end
+end
+

--- a/test/unit/fact_to_category_resolver_test.rb
+++ b/test/unit/fact_to_category_resolver_test.rb
@@ -1,0 +1,41 @@
+require_relative '../test_plugin_helper'
+
+class FactToCategoryResolverTest < ActiveSupport::TestCase
+  class FakePrimaryInterface < OpenStruct
+    def subnet
+      nil
+    end
+  end
+
+  setup do
+    interfaces = [{
+      identifier: 'eth0',
+      mac: 'aa:bb:cc:dd:ee:f1',
+      ip: '192.168.1.1',
+    }.with_indifferent_access]
+    facts = {
+      :macaddress_eth0 => 'aa:bb:cc:dd:ee:f1',
+      :ipaddress_eth0 => '192.168.1.1',
+      manufacturer: 'TEST-Creator',
+      hardwaremodel: 'TEST_X64',
+      bios_vendor: 'TEST_BIOS',
+    }.with_indifferent_access
+
+    @host = Host::Discovered.new(name: 'dummy')
+    @host.stubs(:facts_hash).returns(facts)
+    @host.stubs(:interfaces).returns(interfaces)
+    @host.stubs(:primary_interface).returns(FakePrimaryInterface.new)
+    @resolver = ForemanDiscovery::FactToCategoryResolver.new(@host)
+  end
+
+  test 'resolve facts to right category' do
+    categories = @resolver.categories
+    hardware_category = categories[2]
+    network_category = categories[3]
+    software_category = categories[4]
+
+    assert_equal hardware_category['hardwaremodel'], 'TEST_X64'
+    assert_equal network_category['ipaddress_eth0'], '192.168.1.1'
+    assert_equal software_category['bios_vendor'], 'TEST_BIOS'
+  end
+end


### PR DESCRIPTION
This method doesn't have ideal place in code. It placed in controller. Also this method is full of repeating code that can produce more bugs.

So this is my attempt to refactor this method. This PR is a draft due to lacking some things like tests. However I think it will be good to have at least draft PR for comments.

Stuff to do:

- [x] Move `assign_fact_to_category` method to separate class
- [x] Move complementary stuff for method to the same class
- [x] Write some tests for that

Feel free to look at it and any comments are welcome.
