### PR TITLE
fixes #18932 - Introducing Discovery kind of facts

### DIFF
--- a/app/models/discovery_fact_name.rb
+++ b/app/models/discovery_fact_name.rb
@@ -1,0 +1,9 @@
+class DiscoveryFactName < FactName
+  def origin
+    'Discovery'
+  end
+
+  def icon_path
+    "icons16x16/stub/darkred-d"
+  end
+end

--- a/app/services/discovery_fact_importer.rb
+++ b/app/services/discovery_fact_importer.rb
@@ -1,0 +1,5 @@
+class DiscoveryFactImporter < StructuredFactImporter
+  def fact_name_class
+    DiscoveryFactName
+  end
+end

--- a/app/services/foreman_discovery/host_converter.rb
+++ b/app/services/foreman_discovery/host_converter.rb
@@ -21,10 +21,10 @@ class ForemanDiscovery::HostConverter
   def self.set_build_clean_facts(host)
     # fact cleaning
     if Setting['discovery_clean_facts']
-      # clean all facts except those starting with "discovery_"
+      # clean all facts except those from Discovery
       host.define_singleton_method(:clear_facts) do
-          keep_ids = FactValue.where("host_id = #{host.id}").joins(:fact_name).where("fact_names.name like 'discovery_%'").pluck("fact_values.id")
-          FactValue.where("host_id = #{host.id} and id not in (?)", keep_ids).delete_all
+        keep_ids = FactValue.where(host_id: host.id, fact_names: { type: 'DiscoveryFactName' }).where("fact_names.name like 'discovery_%'").joins(:fact_name).pluck("fact_values.id")
+        FactValue.where.not(id: keep_ids).delete_all
       end
     else
       # clean no facts (default behavior)

--- a/lib/foreman_discovery/engine.rb
+++ b/lib/foreman_discovery/engine.rb
@@ -216,6 +216,8 @@ module ForemanDiscovery
       # Controller extensions
       ::HostsController.send :include, ForemanDiscovery::Concerns::HostsControllerExtensions
       ::Api::V2::FactValuesController.send :include, Api::V2::FactValuesControllerExtensions
+
+      Foreman::Plugin.fact_importer_registry.register(:foreman_discovery, DiscoveryFactImporter)
     end
 
     rake_tasks do


### PR DESCRIPTION
Fixing bug in Discovery where all facts from dicovered hosts are recognised as puppet facts. So this PR solved this problem by creating Discovery kind of facts for non-Puppet environments.

The code problem was in `FactImporterRegistry` where is defined only one importer `PuppetFactImporter` and this importer as marker as default. That means that this importer is used every time when there no importer that fits better for given fact. Because Discovery doesn't have any own importer, every fact from Discovery is taken as puppet fact. Thanks to that the `FactName` is type of 'PuppetFactName' and Puppet fact is created and recognized even there no puppet installed at all.

So to avoid this, I created a `DiscoveryFactImporter` with own `DiscoveryFactName`. This will keep facts of discovered hosts as discovery type. However, this PR is targeted to non-puppet environments so I'm not sure if it's work properly with puppet. 

Also, there is missing a piece that could transform a puppet like facts from discovery into discovery like facts. And because it's change of type of `FactName`, the migration will be easy to write. However, only for non-puppet environments. So it will be better to do migration for that, or a task? 