### PR TITLE
fixes #19404 - Introducing notification about failed discovery

### DIFF
--- a/app/controllers/api/v2/discovered_hosts_controller.rb
+++ b/app/controllers/api/v2/discovered_hosts_controller.rb
@@ -122,6 +122,7 @@ module Api
         end
         process_response state
       rescue Exception => e
+        ForemanDiscovery::UINotifications::FailedDiscovery.new(e).deliver!
         Foreman::Logging.exception("Host discovery failed, facts: #{facts}", e)
         render :json => {'message'=>e.to_s}, :status => :unprocessable_entity
       end

--- a/app/services/foreman_discovery/ui_notifications/failed_discovery.rb
+++ b/app/services/foreman_discovery/ui_notifications/failed_discovery.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+module ForemanDiscovery
+  module UINotifications
+    # Adds notification upon failed discovery
+    class FailedDiscovery < ::UINotifications::Base
+      def initialize(message)
+        @message = message
+      end
+
+      private
+
+      def create
+        add_notification if update_notifications.zero?
+      end
+
+      def update_notifications
+        blueprint.mass_update_expiry
+      end
+
+      def add_notification
+        Notification.create!(
+          initiator: initiator,
+          audience: ::Notification::AUDIENCE_ADMIN,
+          message: _("One or more hosts with failed discovery due to error: #{@message}"),
+          notification_blueprint: blueprint,
+        )
+      end
+
+      def blueprint
+        @blueprint ||= NotificationBlueprint.find_by(name: 'failed_discovery')
+      end
+    end
+  end
+end

--- a/db/seeds.d/80_discovery_ui_notification.rb
+++ b/db/seeds.d/80_discovery_ui_notification.rb
@@ -10,8 +10,14 @@
       links:
       [
         path_method: :discovered_hosts_path,
-        title: _('Details')
-      ]
-    }
-  }
+        title: _('Details'),
+      ],
+    },
+  },
+  {
+    group: _('Hosts'),
+    name: 'failed_discovery',
+    message: _('Error message goes here'),
+    level: 'error',
+  },
 ].each { |blueprint| UINotifications::Seed.new(blueprint).configure }

--- a/test/functional/api/v2/discovered_hosts_controller_test.rb
+++ b/test/functional/api/v2/discovered_hosts_controller_test.rb
@@ -4,6 +4,8 @@ class Api::V2::DiscoveredHostsControllerTest < ActionController::TestCase
   include FactImporterIsolation
   allow_transactions_for_any_importer
 
+  alias_method  :blueprint, :failed_discovery_blueprint
+
   def switch_controller(klass)
     old_controller = @controller
     @controller = klass.new
@@ -26,6 +28,8 @@ class Api::V2::DiscoveredHostsControllerTest < ActionController::TestCase
     set_default_settings
     ::ForemanDiscovery::NodeAPI::PowerService.any_instance.stubs(:reboot).returns(true)
     ::ForemanDiscovery::HostConverter.stubs(:unused_ip_for_host)
+
+    assert blueprint
   end
 
   def test_get_index
@@ -206,4 +210,9 @@ class Api::V2::DiscoveredHostsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  def test_failed_discovery_notification
+    bad_facts = { this_is: 'bad' }
+    post :facts, params: { facts: bad_facts }
+    assert_equal 1, Notification.all.count
+  end
 end

--- a/test/test_helper_discovery.rb
+++ b/test/test_helper_discovery.rb
@@ -172,6 +172,11 @@ def discovered_notification_blueprint
                                    name: 'new_discovered_host')
 end
 
+def failed_discovery_blueprint
+  @blueprint ||= FactoryBot.create(:notification_blueprint,
+                                   name: 'failed_discovery')
+end
+
 def parse_json_fixture(filename, remove_root_element = false)
   raw = JSON.parse(File.read(File.expand_path(File.dirname(__FILE__) + "/facts/#{filename}.json")))
   remove_root_element ? raw['facts'] : raw


### PR DESCRIPTION
Today the user has no way how to be informed about failed discovery of new hosts in Foreman. This PR tries to solve that by creating notification about failed discovery and also what error occurs.