### PR TITLE
fixes #19448 - Improving notification about new host

### DIFF
--- a/app/services/foreman_discovery/ui_notifications/new_host.rb
+++ b/app/services/foreman_discovery/ui_notifications/new_host.rb
@@ -8,7 +8,7 @@ module ForemanDiscovery
       private
 
       def create
-        add_notification if update_notifications.zero?
+        add_notification
       end
 
       def update_notifications
@@ -19,6 +19,7 @@ module ForemanDiscovery
         Notification.create!(
           initiator: initiator,
           audience: ::Notification::AUDIENCE_SUBJECT,
+          message: _("Host %s has been dicovered") % subject.name,
           subject: subject,
           notification_blueprint: blueprint
         )

--- a/db/seeds.d/80_discovery_ui_notification.rb
+++ b/db/seeds.d/80_discovery_ui_notification.rb
@@ -1,7 +1,7 @@
 # seeds UI notification blueprints that are supported by Disocvery.
 [
   {
-    group: _('Hosts'),
+    group: _('New hosts'),
     name: 'new_discovered_host',
     message: _('One or more hosts have been discovered'),
     level: 'info',

--- a/test/unit/ui_notifications/destroy_host_test.rb
+++ b/test/unit/ui_notifications/destroy_host_test.rb
@@ -21,13 +21,6 @@ class DestroyHostNotificationTest < ActiveSupport::TestCase
       ForemanDiscovery::UINotifications::NewHost.deliver!(host)
     end
     assert_equal 1, blueprint.notifications.count
-    assert_no_difference('blueprint.notifications.count') do
-      host = FactoryBot.create(:discovered_host)
-      ForemanDiscovery::UINotifications::NewHost.deliver!(host)
-    end
-    assert_no_difference('blueprint.notifications.count') do
-      Host::Discovered.all.last.destroy
-    end
     Host::Discovered.destroy_all
     assert_equal 0, blueprint.notifications.count
   end
@@ -55,9 +48,9 @@ class DestroyHostNotificationTest < ActiveSupport::TestCase
     ForemanDiscovery::UINotifications::NewHost.deliver!(host1)
     host2 = FactoryBot.create(:discovered_host)
     ForemanDiscovery::UINotifications::NewHost.deliver!(host2)
-    assert_equal 1, blueprint.notifications.count
+    assert_equal 2, blueprint.notifications.count
     new_host = ::ForemanDiscovery::HostConverter.to_managed(host1, false, false)
     assert new_host.save!
-    assert_equal 1, blueprint.notifications.count
+    assert_equal 2, blueprint.notifications.count
   end
 end

--- a/test/unit/ui_notifications/new_host_test.rb
+++ b/test/unit/ui_notifications/new_host_test.rb
@@ -16,14 +16,14 @@ class NewHostNotificationTest < ActiveSupport::TestCase
     end
   end
 
-  test 'multiple discovered hosts should generate only one notification' do
+  test 'multiple discovered hosts should generate multiple notifications' do
     host1 = FactoryBot.create :discovered_host
     ForemanDiscovery::UINotifications::NewHost.deliver!(host1)
     expired_at = blueprint.notifications.first.expired_at
     Time.any_instance.stubs(:utc).returns(expired_at + 1.hour)
     host2 = FactoryBot.create :discovered_host
     ForemanDiscovery::UINotifications::NewHost.deliver!(host2)
-    assert_equal 1, blueprint.notifications.count
-    assert_not_equal expired_at, blueprint.notifications.first.expired_at
+    assert_equal 2, blueprint.notifications.count
+    assert_not_equal expired_at, blueprint.notifications.last.expired_at
   end
 end


### PR DESCRIPTION
Today the notification informs about one or more discovered hosts. However, this can be little confusing. So this PR improving notification to work on per host basis. That means that every discovered get own notification about discovery.