### PR TITLE
Fixes #19523 - warning banner for not found subnets

### DIFF
--- a/app/controllers/discovered_hosts_controller.rb
+++ b/app/controllers/discovered_hosts_controller.rb
@@ -9,6 +9,7 @@ class DiscoveredHostsController < ::ApplicationController
   before_action :find_by_name_incl_subnet, :only => [:show]
   before_action :find_multiple, :only => [:multiple_destroy, :submit_multiple_destroy, :multiple_reboot, :submit_multiple_reboot, :multiple_auto_provision, :submit_multiple_auto_provision]
   before_action :taxonomy_scope, :only => [:edit]
+  before_action :check_for_subnet, :only => [:reboot, :auto_provision, :submit_multiple_reboot, :submit_multiple_auto_provision]
 
   around_action :skip_bullet, :only => [:edit]
 
@@ -290,6 +291,20 @@ class DiscoveredHostsController < ::ApplicationController
     @host ||= includes.empty? ? resource_base.find_by_name(id) : resource_base.includes(includes).find_by_name(id)
     not_found and return(false) unless @host
     @host
+  end
+
+  def check_for_subnet
+    case params[:action]
+      when 'reboot', 'auto_provision'
+        if @host.subnet.nil?
+          warning _("Discovered host reported from unknown subnet, communication will not be proxied.")
+        end
+      when 'submit_multiple_reboot', 'submit_multiple_auto_provision'
+        hosts_without_subnet = @hosts.limit(5).select { |host| host.subnet.nil? }.pluck(:name)
+        if hosts_without_subnet.present?
+          warning _("Discovered hosts reported from unknown subnet are #{hosts_without_subnet}, communication will not be proxied.")
+        end
+    end
   end
 
   def find_by_name_incl_subnet

--- a/test/integration/discovered_hosts_test.rb
+++ b/test/integration/discovered_hosts_test.rb
@@ -19,6 +19,8 @@ class DiscoveredHostsTest < IntegrationTestWithJavascript
 
   describe 'Multiple host Reboot' do
     test 'triggers reboot on all discovered_hosts' do
+      subnet = FactoryBot.create(:subnet_ipv4, :network => "192.168.100.0")
+      Host::Discovered.any_instance.stubs(:subnet).returns(subnet)
       Host::Discovered.any_instance
                       .expects(:reboot)
                       .at_least(discovered_hosts.count)
@@ -33,6 +35,8 @@ class DiscoveredHostsTest < IntegrationTestWithJavascript
 
   describe 'Multiple host Autoprovision' do
     test 'converts all discovered to managed hosts' do
+      subnet = FactoryBot.create(:subnet_ipv4, :network => "192.168.100.0")
+      Host::Discovered.any_instance.stubs(:subnet).returns(subnet)
       select_host_checkbox(discovered_host.id)
       page.find_link('Select Action').click
       page.find_link('Auto Provision').click


### PR DESCRIPTION
Adding a warning banner about subnet that is not found

This PR originally comes from @rabajaj0509 (https://github.com/theforeman/foreman_discovery/pull/463) but I think it would great to finish this. 