### PR TITLE
Fixes #31935 - notify errors for enforced discovery taxonomy

### DIFF
--- a/app/models/discovery_rule.rb
+++ b/app/models/discovery_rule.rb
@@ -49,11 +49,11 @@ class DiscoveryRule < ApplicationRecord
     return if hostgroup.nil?
     unless (ms = hostgroup.organizations - organizations).empty?
       names = ms.collect(&:name).to_sentence
-      errors.add(:organizations, n_("Host group organization %s must also be associated to the discovery rule", "Host group organizations %s must also be associated to the discovery rule", ms.size) % names)
+      errors.add(:base, n_("Host group organization %s must also be associated to the discovery rule", "Host group organizations %s must also be associated to the discovery rule", ms.size) % names)
     end
     unless (ms = hostgroup.locations - locations).empty?
       names = ms.collect(&:name).to_sentence
-      errors.add(:locations, n_("Host group location %s must also be associated to the discovery rule", "Host group locations %s must also be associated to the discovery rule", ms.size) % names)
+      errors.add(:base, n_("Host group location %s must also be associated to the discovery rule", "Host group locations %s must also be associated to the discovery rule", ms.size) % names)
     end
   end
 end

--- a/test/unit/discovery_rule_test.rb
+++ b/test/unit/discovery_rule_test.rb
@@ -155,7 +155,7 @@ class DiscoveryRuleTest < ActiveSupport::TestCase
       :search => "cpu_count > 1",
       :hostgroup_id => @hostgroup.id
     refute_valid rule
-    assert_equal "Host group organization #{organization_one.name} must also be associated to the discovery rule", rule.errors[:organizations].first
+    assert_equal "Host group organization #{organization_one.name} must also be associated to the discovery rule", rule.errors[:base].first
   end
 
   test "should enforce hostgroup organizations and locations" do
@@ -168,7 +168,7 @@ class DiscoveryRuleTest < ActiveSupport::TestCase
       :organization_ids => [organization_one.id],
       :location_ids => [location_one.id]
     refute_valid rule
-    assert_equal "Host group location #{loc.name} must also be associated to the discovery rule", rule.errors[:locations].first
+    assert_equal "Host group location #{loc.name} must also be associated to the discovery rule", rule.errors[:base].first
   end
 
   context 'auditing related to discovery rule' do


### PR DESCRIPTION
Use:
```ruby
errors.add(:base, '') or errors.add(:conflict, '')
```

Else, the error will only be logged and there will not be any notification for the failure of the creation of discovery rules.


![discoveryRuleError](https://user-images.githubusercontent.com/10976840/108710980-bd55c580-753a-11eb-9f6f-c5f9e8374522.png)
