### PR TITLE
Fixes #31975 - remove uniqueness validation from discovery rules

### DIFF
--- a/app/models/discovery_rule.rb
+++ b/app/models/discovery_rule.rb
@@ -17,7 +17,6 @@ class DiscoveryRule < ApplicationRecord
   validates :max_count, :numericality => { :only_integer => true, :greater_than_or_equal_to => 0, :less_than => 2**31 }
   validates :priority, :presence => true, :numericality => { :only_integer => true, :greater_than_or_equal_to => 0, :less_than => 2**31 }
   validates_lengths_from_database
-  validates_uniqueness_of :priority
   before_validation :default_int_attributes
   before_validation :enforce_taxonomy
 


### PR DESCRIPTION
The PR is a part of fixing the _**priority**_ in Discovery Rules as discussed in https://github.com/theforeman/foreman_discovery/pull/450:
* [x] Drop priority uniqueness test : https://github.com/theforeman/foreman_discovery/pull/532
* [ ] Fix the order of discovery rule processing (and on index page as well): priority first, name second
* [x] Add organizations/locations to the index page: https://github.com/theforeman/foreman_discovery/pull/531
* [x] Priority suggestion must be suggested from current organization: https://github.com/theforeman/foreman_discovery/pull/533
<hr />

This PR should only be merged after the taxonomy scope is defined for the rules and priority suggestion is fixed.