### PR TITLE
Fixes #32016 - suggest priority for discovery rules

### DIFF
--- a/app/models/discovery_rule.rb
+++ b/app/models/discovery_rule.rb
@@ -41,8 +41,14 @@ class DiscoveryRule < ApplicationRecord
    self.priority  ||= 0
   end
 
-  def self.suggest_priority
-    self.unscoped.maximum(:priority).to_i + STEP
+  def self.suggest_priority(organization = Organization.current)
+    discovery_rules = DiscoveryRule.unscoped
+    return (discovery_rules.maximum(:priority).to_i + STEP) if organization.nil?
+    discovery_rule_ids = TaxableTaxonomy.where(
+      taxable_type: 'DiscoveryRule',
+      taxonomy_id: organization.id).pluck(:taxable_id)
+    discovery_rules = discovery_rules.where(id: discovery_rule_ids)
+    discovery_rules.maximum(:priority).to_i + STEP
   end
 
   def enforce_taxonomy

--- a/test/unit/discovery_rule_test.rb
+++ b/test/unit/discovery_rule_test.rb
@@ -218,4 +218,26 @@ class DiscoveryRuleTest < ActiveSupport::TestCase
       assert_equal DiscoveryRule::STEP, second_new.priority - first_new.priority
     end
   end
+
+  context 'suggest next priority' do
+    setup do
+      @organization = FactoryBot.create(:organization)
+      @location = FactoryBot.create(:location)
+    end
+
+    test 'when there exists a discovery_rule of the given organization' do
+      hostgroup = FactoryBot.create(:hostgroup, organizations: [@organization], locations: [@location] )
+      discovery_rule = FactoryBot.create(:discovery_rule,
+        priority: rand(100),
+        hostgroup: hostgroup,
+        organizations: [@organization],
+        locations: [@location])
+
+      assert_equal DiscoveryRule.suggest_priority(@organization), (discovery_rule.priority + DiscoveryRule::STEP)
+    end
+
+    test 'when there is no discovery_rule of the given organization' do
+      assert_equal DiscoveryRule.suggest_priority(@organization), DiscoveryRule::STEP
+    end
+  end
 end


### PR DESCRIPTION
The PR is a part of fixing the _**priority**_ in Discovery Rules as discussed in https://github.com/theforeman/foreman_discovery/pull/450:
* [x] Drop priority uniqueness test : https://github.com/theforeman/foreman_discovery/pull/532
* [ ] Fix the order of discovery rule processing (and on index page as well): priority first, name second
* [x] Add organizations/locations to the index page: https://github.com/theforeman/foreman_discovery/pull/531
* [x] Priority suggestion must be suggested from current organization: https://github.com/theforeman/foreman_discovery/pull/533
<hr />

Test this PR with https://github.com/theforeman/foreman_discovery/pull/532, after that PR is merged, we can go ahead and merge this.