### PR TITLE
fixes #21041 - unify usage of datetime macros

### DIFF
--- a/app/helpers/discovered_hosts_helper.rb
+++ b/app/helpers/discovered_hosts_helper.rb
@@ -7,7 +7,7 @@ module DiscoveredHostsHelper
   end
 
   def disc_report_column(record)
-    record.last_report? ? (_("%s ago") % time_ago_in_words(record.last_report.getlocal)) : ""
+    record.last_report? ? date_time_relative(record.last_report.getlocal) : ""
   end
 
   def discovered_hosts_title_actions(host)


### PR DESCRIPTION
This PR unifies usage of datetime macros from core version 1.16