### PR TITLE
Fixes #32341 - parametrize bootif hardware type

### DIFF
--- a/app/views/foreman_discovery/debian_kexec.erb
+++ b/app/views/foreman_discovery/debian_kexec.erb
@@ -19,7 +19,7 @@ Extra options like --reset-vga can be set via "extra" array.
 -%>
 <%
   mac = @host.facts['discovery_bootif']
-  bootif = '00-' + mac.gsub(':', '-') if mac
+  bootif = host_param("hardware_type", "01") + mac.gsub(':', '-') if mac
   ip_cidr = @host.facts['discovery_ip_cidr']
   ip = @host.facts['discovery_ip']
   mask = @host.facts['discovery_netmask']

--- a/app/views/foreman_discovery/redhat_kexec.erb
+++ b/app/views/foreman_discovery/redhat_kexec.erb
@@ -29,7 +29,7 @@ Extra options like --reset-vga can be set via "extra" array.
 -%>
 <%
   mac = @host.facts['discovery_bootif']
-  bootif = '00-' + mac.gsub(':', '-') if mac
+  bootif = host_param("hardware_type", "01") + mac.gsub(':', '-') if mac
   ip_cidr = @host.facts['discovery_ip_cidr']
   ip = @host.facts['discovery_ip']
   mask = @host.facts['discovery_netmask']


### PR DESCRIPTION
RHEL 8.3 no longer accepts 00- in BOOTIF kernel command line argument and therefore the correct interface is not picked. We have fixed bootdisk workflows however missed the discovery kexec workflow.

For the whole story see the BZ and the other associated BZ. But in short, we must send 01- instead of 00- by default.

Please test rendering, I am not entirely sure if `host_param` is actually available in kexec rendering context. It actualy might fail, therefore I would need to rewrite the patch and use 01 as a constant.