### PR TITLE
Fixes #14595 - Removing macros that are in core

### DIFF
--- a/lib/foreman_discovery/engine.rb
+++ b/lib/foreman_discovery/engine.rb
@@ -173,10 +173,6 @@ module ForemanDiscovery
         # add dashboard widget
         widget 'discovery_widget', :name=>N_('Discovered Hosts'), :sizex => 6, :sizey =>1
 
-        # allowed helpers and variables
-        allowed_template_helpers :rand
-        allowed_template_variables :kexec_kernel, :kexec_initrd
-
         template_labels 'kexec' => N_('Discovery Kexec template')
 
         # apipie API documentation


### PR DESCRIPTION
Removing allowance of macros and variables because they are now live in
core.