### PR TITLE
Fixes #32812 - try IPv6 for reboot/kexec

### DIFF
--- a/app/models/host/managed_extensions.rb
+++ b/app/models/host/managed_extensions.rb
@@ -27,7 +27,7 @@ module Host::ManagedExtensions
   end
 
   def setReboot
-    old.becomes(Host::Discovered).reboot(old.ip, ip)
+    old.becomes(Host::Discovered).reboot(old.ip, ip, old.ip6, ip6)
     # It is too late to report error in the post_queue, we catch them and
     # continue. If flash is implemented for new hosts (http://projects.theforeman.org/issues/10559)
     # we can report the error to the user perhaps.
@@ -55,7 +55,7 @@ module Host::ManagedExtensions
   end
 
   def setKexec
-    old.becomes(Host::Discovered).kexec(render_kexec_template.to_json, old.ip, ip)
+    old.becomes(Host::Discovered).kexec(render_kexec_template.to_json, old.ip, ip, old.ip6, ip6)
     true
   rescue ::Foreman::Exception => e
     Foreman::Logging.exception("Unable to kexec", e)

--- a/app/models/setting/discovered.rb
+++ b/app/models/setting/discovered.rb
@@ -37,6 +37,7 @@ class Setting::Discovered < ::Setting
       self.set('discovery_always_rebuild_dns', N_("Force DNS entries creation when provisioning discovered host"), true, N_("Force DNS")),
       self.set('discovery_error_on_existing', N_("Do not allow to discover existing managed host matching MAC of a provisioning NIC (errors out early)"), false, N_("Error on existing NIC")),
       self.set('discovery_naming', N_("Discovery hostname naming pattern"), 'Fact', N_("Type of name generator"), nil, {:collection => Proc.new {::Host::Discovered::NAMING_PATTERNS} }),
+      self.set('discovery_prefer_ipv6', N_("Prefer IPv6 to IPv4 when calling discovered nodes"), false, N_("Prefer IPv6")),
     ]
   end
 

--- a/test/unit/managed_extensions_test.rb
+++ b/test/unit/managed_extensions_test.rb
@@ -19,6 +19,7 @@ class ManagedExtensionsTest < ActiveSupport::TestCase
       @host = StubHost.new
       @host.type = "Host::Discovered"
       @host.stubs(:ip).returns("192.168.1.1")
+      @host.stubs(:ip6).returns(nil)
       @host.stubs(:old).returns(@host)
       @facts = {}
       @host.stubs(:facts).returns(@facts)


### PR DESCRIPTION
Introducing also a new setting so users can override if they prefer IPv6 or IPv4.