### PR TITLE
fix missing delimiter dash in the resulting mac address string

### DIFF
--- a/app/views/foreman_discovery/debian_kexec.erb
+++ b/app/views/foreman_discovery/debian_kexec.erb
@@ -19,7 +19,7 @@ Extra options like --reset-vga can be set via "extra" array.
 -%>
 <%
   mac = @host.facts['discovery_bootif']
-  bootif = host_param("hardware_type", "01") + mac.gsub(':', '-') if mac
+  bootif = host_param("hardware_type", "01") + '-' + mac.gsub(':', '-') if mac
   ip_cidr = @host.facts['discovery_ip_cidr']
   ip = @host.facts['discovery_ip']
   mask = @host.facts['discovery_netmask']

--- a/app/views/foreman_discovery/redhat_kexec.erb
+++ b/app/views/foreman_discovery/redhat_kexec.erb
@@ -29,7 +29,7 @@ Extra options like --reset-vga can be set via "extra" array.
 -%>
 <%
   mac = @host.facts['discovery_bootif']
-  bootif = host_param("hardware_type", "01") + mac.gsub(':', '-') if mac
+  bootif = host_param("hardware_type", "01") + '-' + mac.gsub(':', '-') if mac
   ip_cidr = @host.facts['discovery_ip_cidr']
   ip = @host.facts['discovery_ip']
   mask = @host.facts['discovery_netmask']


### PR DESCRIPTION
this should fix the resulting string, which would otherwise end up in a format `01XX-XX-XX...`
Thanks @ezr-ondrej for extra pair of eyes.