### PR TITLE
Refs #32341 - added missing bootif dash

### DIFF
--- a/app/views/foreman_discovery/debian_kexec.erb
+++ b/app/views/foreman_discovery/debian_kexec.erb
@@ -19,7 +19,7 @@ Extra options like --reset-vga can be set via "extra" array.
 -%>
 <%
   mac = @host.facts['discovery_bootif']
-  bootif = host_param("hardware_type", "01") + mac.gsub(':', '-') if mac
+  bootif = host_param("hardware_type", "01") + '-' + mac.gsub(':', '-') if mac
   ip_cidr = @host.facts['discovery_ip_cidr']
   ip = @host.facts['discovery_ip']
   mask = @host.facts['discovery_netmask']

--- a/app/views/foreman_discovery/redhat_kexec.erb
+++ b/app/views/foreman_discovery/redhat_kexec.erb
@@ -29,7 +29,7 @@ Extra options like --reset-vga can be set via "extra" array.
 -%>
 <%
   mac = @host.facts['discovery_bootif']
-  bootif = host_param("hardware_type", "01") + mac.gsub(':', '-') if mac
+  bootif = host_param("hardware_type", "01") + '-' + mac.gsub(':', '-') if mac
   ip_cidr = @host.facts['discovery_ip_cidr']
   ip = @host.facts['discovery_ip']
   mask = @host.facts['discovery_netmask']


### PR DESCRIPTION
I'm seeing the following in the kernel args during kexec-ing:

ksdevice=bootif BOOTIF=0156-6f-0d-72-0a-9d

Is the missing delimmiting dash between first two bytes intended?

My host is unable to fetch the kickstart from the server so I'm trying to understand whether this is the issue or it's just my env being configured incorrectly.

https://bugzilla.redhat.com/show_bug.cgi?id=1950929