### PR TITLE
Fixes #33559 - Update the call for registration of fact parser

### DIFF
--- a/lib/foreman_discovery/engine.rb
+++ b/lib/foreman_discovery/engine.rb
@@ -198,7 +198,7 @@ module ForemanDiscovery
     config.to_prepare do
 
       # Fact parsing
-      ::FactParser.register_fact_parser(:foreman_discovery, ForemanDiscovery::FactParser)
+      Foreman::Plugin.fact_parser_registry.register(:foreman_discovery, ForemanDiscovery::FactParser)
 
       # Taxonomy extensions
       ::Location.send :include, DiscoveryTaxonomyExtensions


### PR DESCRIPTION
There is a Parser registry in core and that makes old style of registration at fact parser outdated. This PR updates the registration.

Thanks @lzap for noticing it (https://github.com/theforeman/foreman/pull/8762#issuecomment-926362672)! You're faster that me.