### PR TITLE
Fixes #33599 - Update call fact parser and remove importer

### DIFF
--- a/app/services/discovery_fact_importer.rb
+++ b/app/services/discovery_fact_importer.rb
@@ -1,5 +1,0 @@
-class DiscoveryFactImporter < StructuredFactImporter
-  def fact_name_class
-    DiscoveryFactName
-  end
-end

--- a/app/services/foreman_discovery/fact_parser.rb
+++ b/app/services/foreman_discovery/fact_parser.rb
@@ -22,5 +22,9 @@ module ForemanDiscovery
     def get_facts_for_interface(interface)
       super.merge(keep_subnet: true)
     end
+
+    def fact_name_class
+      DiscoveryFactName
+    end
   end
 end

--- a/lib/foreman_discovery/engine.rb
+++ b/lib/foreman_discovery/engine.rb
@@ -212,8 +212,6 @@ module ForemanDiscovery
       # Controller extensions
       ::HostsController.send :include, ForemanDiscovery::Concerns::HostsControllerExtensions
       ::Api::V2::FactValuesController.send :include, Api::V2::FactValuesControllerExtensions
-
-      Foreman::Plugin.fact_importer_registry.register(:foreman_discovery, DiscoveryFactImporter)
     end
 
     rake_tasks do


### PR DESCRIPTION
There is a effort to unify fact importers in core (https://github.com/theforeman/foreman/pull/8781) but discovery doesn't reflect that. This PR removes Discovery fact importer because it's not needed. It handles importer in core.

Note: Please merge it after core PR (https://github.com/theforeman/foreman/pull/8781)! Otherwise It's going to break Discovery fact handling (becuase I don't register a `DiscoveryFactImporter`)