### PR TITLE
Fixed issue with puppet and discovery

### DIFF
--- a/app/controllers/discovered_hosts_controller.rb
+++ b/app/controllers/discovered_hosts_controller.rb
@@ -16,6 +16,8 @@ class DiscoveredHostsController < ::ApplicationController
   helper :hosts
   if defined?(ForemanPuppet)
     helper ForemanPuppet::HostsAndHostgroupsHelper
+    helper ForemanPuppet::PuppetclassesHelper
+    helper ForemanPuppet::PuppetclassLookupKeysHelper
   end
 
   layout 'layouts/application'


### PR DESCRIPTION
Fixed error with functions not being found when trying to provision discovered hosts when using discovery 18 and foreman_puppet 1.0.3.
