### PR TITLE
Refs #33531 - fix deep cloning of rules

### DIFF
--- a/app/controllers/discovery_rules_controller.rb
+++ b/app/controllers/discovery_rules_controller.rb
@@ -20,7 +20,7 @@ class DiscoveryRulesController < ApplicationController
   end
 
   def clone
-    @discovery_rule.deep_clone except: [:name, :priority], include: [:organizations, :locations]
+    @discovery_rule = @discovery_rule.deep_clone except: [:name, :priority], include: [:organizations, :locations]
     @discovery_rule.priority = DiscoveryRule.suggest_priority
   end
 


### PR DESCRIPTION
I somehow tested this and missed that it actually did not create a clone but edited the original. This fixes it. I also tested it works with taxonomy, in order to change taxonomy you need to test with a hostgroup with more than one loc/org otherwise edit form will not allow you to remove taxonomy from a rule during cloning/editing (you would loose access to it I think that is the reason).