### PR TITLE
Fixes #33917 - skip invalid IP address

### DIFF
--- a/app/services/foreman_discovery/subnet_suggestion.rb
+++ b/app/services/foreman_discovery/subnet_suggestion.rb
@@ -14,7 +14,14 @@ module ForemanDiscovery
     def call
       return unless ip
 
-      subnet = Subnet.unscoped.subnet_for(ip)
+      begin
+        subnet = Subnet.unscoped.subnet_for(ip)
+      rescue Exception => e
+        Rails.logger.error "Error while detecting subnet for IP #{ip}"
+        Foreman::Logging.exception "Unable to detect subnet", e
+        subnet = nil
+      end
+
       if subnet
         Rails.logger.info "Detected #{kind} subnet: #{subnet} with taxonomy #{subnet.organizations.collect(&:name)}/#{subnet.locations.collect(&:name)}"
       else


### PR DESCRIPTION
Some hosts errors out with IP address exception which we are unable to reproduce. To me it looks like some bug in Ruby and IPv6. Symptoms:

error (IPAddr::InvalidAddressError): invalid address