### PR TITLE
Fixes #33926 - add necessary puppet helpers

### DIFF
--- a/app/controllers/discovered_hosts_controller.rb
+++ b/app/controllers/discovered_hosts_controller.rb
@@ -15,7 +15,10 @@ class DiscoveredHostsController < ::ApplicationController
 
   helper :hosts
   if defined?(ForemanPuppet)
+    helper ForemanPuppet::HostsHelper
     helper ForemanPuppet::HostsAndHostgroupsHelper
+    helper ForemanPuppet::PuppetclassesHelper
+    helper ForemanPuppet::PuppetclassLookupKeysHelper
   end
 
   layout 'layouts/application'


### PR DESCRIPTION
We need Puppetclasses and PuppetclassLookupKeys helpers.
Adding HostsHelper just to be sure.