### PR TITLE
Fixes #34232 - clean discovery attributes during managed destroy

### DIFF
--- a/app/models/host/managed_extensions.rb
+++ b/app/models/host/managed_extensions.rb
@@ -4,7 +4,8 @@ module Host::ManagedExtensions
   included do
     # execute standard callbacks
     after_validation :queue_reboot
-    after_save :delete_discovery_attribute_set, :update_notifications
+    after_save :clean_discovery_attributes_on_save, :update_notifications
+    after_destroy :clean_discovery_attributes_on_destroy
 
     belongs_to :discovery_rule
 
@@ -66,10 +67,14 @@ module Host::ManagedExtensions
     # no kexec on orchestration rollback
   end
 
-  def delete_discovery_attribute_set
+  def clean_discovery_attributes_on_save
     return if new_record?
 
     DiscoveryAttributeSet.where(:host_id => self.id).destroy_all if saved_change_to_attribute?(:type) && type_previously_changed?
+  end
+
+  def clean_discovery_attributes_on_destroy
+    DiscoveryAttributeSet.where(:host_id => self.id).destroy_all
   end
 
   def update_notifications


### PR DESCRIPTION
Discovered hosts have 1:1 relationship to DiscoveryAttributeSet model, in Rails the relationship is also specified for the "Host::Discovered" STI class.

During discovered provisioning, application performs a ton of stuff and we do not use SQL transactions due to the fact it breaks callbacks (thus Dynflow/Tasks). When discovery process fails, an incorrect managed host can be sometimes left in the database. The host was already changed to Host::Managed type, but transaction was not processed to the end, when DiscoveryAttributeSet is deleted.

Such a host now still have a related record in the SQL database (with its FOREIGN KEY constraint), but Rails does not see the relationship anymore as the type is not Host::Discovered. Any attempt to delete such host will fail with a foreign key SQL error.

The solution is to simply extend the managed host to also clean up all (now irrelevant) DiscoveryAttributeSet records on delete.

https://community.theforeman.org/t/cannot-remove-host-id-is-still-referenced-from-table-discovery-attribute-sets/26699