### PR TITLE
Fixes #35188 - fix puppet plugin detection for permissions issues

### DIFF
--- a/lib/foreman_discovery/engine.rb
+++ b/lib/foreman_discovery/engine.rb
@@ -310,7 +310,7 @@ module ForemanDiscovery
           :edit_discovery_rules,
           :destroy_discovery_rules,
         ]
-        if defined?(ForemanPuppet::VERSION) 
+        if defined?(ForemanPuppet::Engine)
           MANAGER += [ :view_environments, :view_puppetclasses ]
         end
         role "Discovery Reader", READER, "Role granting permissions to view discovered hosts"


### PR DESCRIPTION
the discovery detection for puppet plugin presence didn't work