### PR TITLE
Fixes #35283 - populate templates description from metadata

### DIFF
--- a/db/seeds.d/50_discovery_templates.rb
+++ b/db/seeds.d/50_discovery_templates.rb
@@ -22,6 +22,10 @@ ProvisioningTemplate.without_auditing do
     tmpl.template = content
     tmpl.organizations = organizations
     tmpl.locations = locations
+
+    metadata = Template.parse_metadata(content)
+    tmpl.description = metadata['description']
+
     tmpl.save!(:validate => false) if tmpl.changes.present?
   end
 end


### PR DESCRIPTION
This PR is still in progress (should be applied on an older version of the plugin)