### PR TITLE
Fixes #35283 - populate templates description from metadata

### DIFF
--- a/db/seeds.d/50_discovery_templates.rb
+++ b/db/seeds.d/50_discovery_templates.rb
@@ -22,6 +22,10 @@ ProvisioningTemplate.without_auditing do
     tmpl.template = content
     tmpl.organizations = organizations
     tmpl.locations = locations
+
+    metadata = Template.parse_metadata(content)
+    tmpl.description = metadata['description']
+
     tmpl.save!(:validate => false) if tmpl.changes.present?
   end
 end


### PR DESCRIPTION
This PR applies a simpler solution for the missing description issue(compared to this [PR](https://github.com/theforeman/foreman_discovery/pull/578)), and it is intended for Satellite 6.12.