### PR TITLE
Avoid re-declaring of a constant

### DIFF
--- a/lib/foreman_discovery/engine.rb
+++ b/lib/foreman_discovery/engine.rb
@@ -309,10 +309,7 @@ module ForemanDiscovery
           :execute_discovery_rules,
           :edit_discovery_rules,
           :destroy_discovery_rules,
-        ]
-        if defined?(ForemanPuppet::Engine)
-          MANAGER += [ :view_environments, :view_puppetclasses ]
-        end
+        ] + (defined?(ForemanPuppet::Engine) ? [ :view_environments, :view_puppetclasses ] : [])
         role "Discovery Reader", READER, "Role granting permissions to view discovered hosts"
         role "Discovery Manager", MANAGER, "Role granting permissions to perform provisioning of discovered hosts"
 


### PR DESCRIPTION
This was generating a warning, possibly because of constants being frozen.

Fixes: 68ed667859ad01881975f14c1b12f04f2aa183ea