### PR TITLE
Read AUTHORS from the gemspec directory

### DIFF
--- a/foreman_discovery.gemspec
+++ b/foreman_discovery.gemspec
@@ -1,4 +1,4 @@
-$:.push File.expand_path("../lib", __FILE__)
+$:.push File.expand_path("lib", __dir__)
 
 # Maintain your gem's version:
 require "foreman_discovery/version"
@@ -7,7 +7,7 @@ require "foreman_discovery/version"
 Gem::Specification.new do |s|
   s.name = "foreman_discovery"
   s.version = ForemanDiscovery::VERSION
-  s.authors = IO.readlines("AUTHORS", encoding: "utf-8").map(&:strip)
+  s.authors = IO.readlines(File.join(__dir__, "AUTHORS"), encoding: "utf-8").map(&:strip)
   s.email = "gsutclif@redhat.com"
   s.description = "MaaS Discovery Plugin engine for Foreman"
   s.extra_rdoc_files = [


### PR DESCRIPTION
This allows reading the gemspec from any directory. It also slightly simplifies the first line by using `__dir__`.