### PR TITLE
Fixes #35188 - fix puppet plugin detection for permissions issues (#573)

### DIFF
--- a/lib/foreman_discovery/engine.rb
+++ b/lib/foreman_discovery/engine.rb
@@ -310,7 +310,7 @@ module ForemanDiscovery
           :edit_discovery_rules,
           :destroy_discovery_rules,
         ]
-        if defined?(ForemanPuppet::VERSION) 
+        if defined?(ForemanPuppet::Engine)
           MANAGER += [ :view_environments, :view_puppetclasses ]
         end
         role "Discovery Reader", READER, "Role granting permissions to view discovered hosts"

--- a/lib/foreman_discovery/version.rb
+++ b/lib/foreman_discovery/version.rb
@@ -1,3 +1,3 @@
 module ForemanDiscovery
-  VERSION = "21.0.4"
+  VERSION = "21.0.5"
 end


### PR DESCRIPTION
the discovery detection for puppet plugin presence didn't work

(cherry picked from commit ea10b983b5e09f085c795757b56e1f7307d16f0b)