### PR TITLE
Add resource_class for DiscoveredHostsController

### DIFF
--- a/app/controllers/discovered_hosts_controller.rb
+++ b/app/controllers/discovered_hosts_controller.rb
@@ -198,6 +198,10 @@ class DiscoveredHostsController < ::ApplicationController
     end
   end
 
+  def resource_class
+    Host::Discovered
+  end
+
   private
 
   def setup_host_class_variables


### PR DESCRIPTION
Fix the error on the Discovered host detail page:
```
unable to detect breadcrumb title name in for discovered_hosts, defaulting to name <NameError>
 Could not find resource class for resource discovered_host
```