### PR TITLE
Fixes #37068 - fix redirect after provisioning discovered host

### DIFF
--- a/app/controllers/discovered_hosts_controller.rb
+++ b/app/controllers/discovered_hosts_controller.rb
@@ -83,7 +83,8 @@ class DiscoveredHostsController < ::ApplicationController
       ::ForemanDiscovery::HostConverter.set_build_clean_facts(host)
       ::ForemanDiscovery::HostConverter.unused_ip_for_host(host)
       if host.save
-        success_options = { :success_redirect => host_path(host), :redirect_xhr => request.xhr? }
+        host_path = Setting['host_details_ui'] ? host_details_page_path(host) : host_path(host)
+        success_options = { :success_redirect => host_path, :redirect_xhr => request.xhr? }
         success_options[:success_msg] = success_message if success_message
         process_success success_options
       else

--- a/test/functional/discovered_hosts_controller_test.rb
+++ b/test/functional/discovered_hosts_controller_test.rb
@@ -101,7 +101,7 @@ class DiscoveredHostsControllerTest < ActionController::TestCase
 
     managed_host = Host.find(host.id)
     assert managed_host.build
-    assert_redirected_to host_url(managed_host)
+    assert_redirected_to host_details_page_path(managed_host)
     assert_equal hostgroup.id, managed_host.hostgroup_id
     assert_match(/Successfully/, flash[:success])
   end


### PR DESCRIPTION
Redirect to the correct page after provisioning discovered hosts, based on user settings.