### PR TITLE
Fix menu item integration test

### DIFF
--- a/lib/discovery.rake
+++ b/lib/discovery.rake
@@ -19,7 +19,8 @@ end
 
 load 'tasks/jenkins.rake'
 if Rake::Task.task_defined?(:'jenkins:unit')
-  Rake::Task["jenkins:unit"].enhance do
+  # The "unit" tests also include system tests
+  Rake::Task["jenkins:unit"].enhance(['webpack:compile']) do
     Rake::Task['test:discovery'].invoke
   end
 end

--- a/test/functional/discovery_rules_controller_test.rb
+++ b/test/functional/discovery_rules_controller_test.rb
@@ -3,12 +3,6 @@ require_relative '../test_plugin_helper'
 class DiscoveryRulesControllerTest < ActionController::TestCase
   setup :initialize_host
 
-  test "should add a link to navigation" do
-    get :index, params: {}, session: set_session_user
-    assert_response :success
-    assert response.body =~ /\/discovery_rules/
-  end
-
   test "reader role should get index" do
     get :index, params: {}, session: set_session_user_default_reader
     assert_response :success

--- a/test/integration/menu_test.rb
+++ b/test/integration/menu_test.rb
@@ -1,0 +1,8 @@
+require 'test_helper'
+
+class ManagedExtensionsTest < ActiveSupport::TestCase
+  def test_discovery_rules_is_in_menu
+    menu = UserMenu.new.generate
+    assert_includes(menu, { name: 'Discovery Rules', url: '/discovery_rules' })
+  end
+end


### PR DESCRIPTION
Since Foreman 2.0 there has been a UserMenu service that provides the entire user menu. At some point the UI also changed to retrieve this dynamically rather than include it in the actual HTML. This rewrites the test to use the service, rather than testing the base template indirectly.