### PR TITLE
Move to inline settings validations

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
     uses: theforeman/actions/.github/workflows/rubocop.yml@v0
     with:
       command: bundle exec rubocop --parallel --format github
-      
+
   test:
     name: Ruby
     needs: rubocop

--- a/app/views/discovered_hosts/welcome.html.erb
+++ b/app/views/discovered_hosts/welcome.html.erb
@@ -1,10 +1,3 @@
-<% content_for(:javascripts) do %>
-  <%= webpacked_plugins_js_for :'foreman_discovery' %>
-<% end %>
-<% content_for(:stylesheets) do %>
-  <%= webpacked_plugins_css_for :'foreman_discovery' %>
-<% end %>
-
 <% content_for(:title, _("Discovered Hosts")) %>
 
 <% content_for(:content) do %>

--- a/app/views/discovery_rules/welcome.html.erb
+++ b/app/views/discovery_rules/welcome.html.erb
@@ -1,10 +1,3 @@
-<% content_for(:javascripts) do %>
-  <%= webpacked_plugins_js_for :'foreman_discovery' %>
-<% end %>
-<% content_for(:stylesheets) do %>
-  <%= webpacked_plugins_css_for :'foreman_discovery' %>
-<% end %>
-
 <% content_for(:title, _("Discovered Rules")) %>
 
 <% content_for(:content) do %>

--- a/lib/foreman_discovery/engine.rb
+++ b/lib/foreman_discovery/engine.rb
@@ -75,10 +75,9 @@ module ForemanDiscovery
             setting "discovery_hostname",
               type: :array,
               default: ["discovery_bootif"],
+              validate: { presence: true },
               full_name: N_("Hostname facts"),
               description: N_("List of facts to use for the hostname (first wins)")
-
-            validates "discovery_hostname", presence: true
 
             setting "discovery_auto",
               type: :boolean,
@@ -95,10 +94,9 @@ module ForemanDiscovery
             setting "discovery_prefix",
               type: :string,
               default: "mac",
+              validate: { presence: true },
               full_name: N_("Hostname prefix"),
               description: N_("The default prefix to use for the host name, must start with a letter")
-
-            validates "discovery_prefix", presence: true
 
             setting "discovery_fact_column",
               type: :array,


### PR DESCRIPTION
This makes it clearer how the setting is exactly defined. As a bonus, this syntax is compatible with both Ruby 2 and 3. At least, that's what I hope the tests will confirm for me.