### PR TITLE
require Foreman 3.10+ now that we do not use webpacked_plugins_*_for

### DIFF
--- a/lib/foreman_discovery/engine.rb
+++ b/lib/foreman_discovery/engine.rb
@@ -30,7 +30,7 @@ module ForemanDiscovery
 
     initializer 'foreman_discovery.register_plugin', :before => :finisher_hook do |app|
       Foreman::Plugin.register :foreman_discovery do
-        requires_foreman '>= 3.8'
+        requires_foreman '>= 3.10'
         register_gettext
 
         # settings


### PR DESCRIPTION
Fixes: 43352a831d4641545a8f38de2f0770464bb8a2c5