### PR TITLE
Put back webpacked_plugins_js_for, this is required for webpack

### DIFF
--- a/app/views/discovered_hosts/welcome.html.erb
+++ b/app/views/discovered_hosts/welcome.html.erb
@@ -1,3 +1,7 @@
+<% content_for(:javascripts) do %>
+  <%= webpacked_plugins_js_for :'foreman_discovery' %>
+<% end %>
+
 <% content_for(:title, _("Discovered Hosts")) %>
 
 <% content_for(:content) do %>

--- a/app/views/discovery_rules/welcome.html.erb
+++ b/app/views/discovery_rules/welcome.html.erb
@@ -1,3 +1,7 @@
+<% content_for(:javascripts) do %>
+  <%= webpacked_plugins_js_for :'foreman_discovery' %>
+<% end %>
+
 <% content_for(:title, _("Discovered Rules")) %>
 
 <% content_for(:content) do %>

--- a/lib/foreman_discovery/version.rb
+++ b/lib/foreman_discovery/version.rb
@@ -1,3 +1,3 @@
 module ForemanDiscovery
-  VERSION = "24.0.0"
+  VERSION = "24.0.1"
 end


### PR DESCRIPTION
Only webpacked_plugins_css_for is deprecated and should have been removed.

Fixes: 43352a831d4641545a8f38de2f0770464bb8a2c5