### PR TITLE
23.0.2 - Cherry-picks for content-mismatch with 23.0.1

### DIFF
--- a/app/controllers/discovered_hosts_controller.rb
+++ b/app/controllers/discovered_hosts_controller.rb
@@ -83,7 +83,8 @@ class DiscoveredHostsController < ::ApplicationController
       ::ForemanDiscovery::HostConverter.set_build_clean_facts(host)
       ::ForemanDiscovery::HostConverter.unused_ip_for_host(host)
       if host.save
-        success_options = { :success_redirect => host_path(host), :redirect_xhr => request.xhr? }
+        host_path = Setting['host_details_ui'] ? host_details_page_path(host) : host_path(host)
+        success_options = { :success_redirect => host_path, :redirect_xhr => request.xhr? }
         success_options[:success_msg] = success_message if success_message
         process_success success_options
       else

--- a/lib/discovery.rake
+++ b/lib/discovery.rake
@@ -19,7 +19,8 @@ end
 
 load 'tasks/jenkins.rake'
 if Rake::Task.task_defined?(:'jenkins:unit')
-  Rake::Task["jenkins:unit"].enhance do
+  # The "unit" tests also include system tests
+  Rake::Task["jenkins:unit"].enhance(['webpack:compile']) do
     Rake::Task['test:discovery'].invoke
   end
 end

--- a/test/functional/discovered_hosts_controller_test.rb
+++ b/test/functional/discovered_hosts_controller_test.rb
@@ -101,7 +101,7 @@ class DiscoveredHostsControllerTest < ActionController::TestCase
 
     managed_host = Host.find(host.id)
     assert managed_host.build
-    assert_redirected_to host_url(managed_host)
+    assert_redirected_to host_details_page_path(managed_host)
     assert_equal hostgroup.id, managed_host.hostgroup_id
     assert_match(/Successfully/, flash[:success])
   end

--- a/test/functional/discovery_rules_controller_test.rb
+++ b/test/functional/discovery_rules_controller_test.rb
@@ -3,12 +3,6 @@ require_relative '../test_plugin_helper'
 class DiscoveryRulesControllerTest < ActionController::TestCase
   setup :initialize_host
 
-  test "should add a link to navigation" do
-    get :index, params: {}, session: set_session_user
-    assert_response :success
-    assert response.body =~ /\/discovery_rules/
-  end
-
   test "reader role should get index" do
     get :index, params: {}, session: set_session_user_default_reader
     assert_response :success

--- a/test/integration/menu_test.rb
+++ b/test/integration/menu_test.rb
@@ -1,0 +1,8 @@
+require 'test_helper'
+
+class ManagedExtensionsTest < ActiveSupport::TestCase
+  def test_discovery_rules_is_in_menu
+    menu = UserMenu.new.generate
+    assert_includes(menu, { name: 'Discovery Rules', url: '/discovery_rules' })
+  end
+end

--- a/test/unit/host_discovered_test.rb
+++ b/test/unit/host_discovered_test.rb
@@ -271,7 +271,8 @@ class HostDiscoveredTest < ActiveSupport::TestCase
     @facts["productname"] = "Dishwasher DW400"
     host2 = discover_host_from_facts(@facts)
     assert_equal 'mace41f13cc3658', host2.name
-    assert_equal 'Dishwasher DW400', host2.facts["productname"]
+    # Bypass fact cache by using it as a method
+    assert_equal 'Dishwasher DW400', host2.facts('productname')['productname']
     assert_equal '10.35.27.2', host2.ip
     assert_equal 1, Host::Discovered.where(:name => 'mace41f13cc3658').count
   end


### PR DESCRIPTION
I accidentally pushed version `23.0.1` from my repository [0] , making it unavailable in the `upstream`.

This PR will match the changes with my fork [1] and create a new 23.0.2 version with one additional fix [2]

[0] https://github.com/stejskalleos/foreman_discovery/commits/develop/
[1] https://my.diffend.io/gems/foreman_discovery/23.0.0/23.0.1
[2] https://github.com/theforeman/foreman_discovery/commit/98aee2cd4218cfe2884a6ea359b636867de05d91