### PR TITLE
Fix rails constants warning

### DIFF
--- a/lib/foreman_discovery/engine.rb
+++ b/lib/foreman_discovery/engine.rb
@@ -266,7 +266,7 @@ module ForemanDiscovery
           # discovered_rules
           :view_discovery_rules,
         ]
-        MANAGER = READER + [
+        manager_permissions = READER + [
           # core permissions
           :create_hosts,
           :edit_hosts,
@@ -297,8 +297,9 @@ module ForemanDiscovery
           :destroy_discovery_rules,
         ]
         if defined?(ForemanPuppet::Engine)
-          MANAGER += [ :view_environments, :view_puppetclasses ]
+          manager_permissions += [ :view_environments, :view_puppetclasses ]
         end
+        MANAGER= manager_permissions
         role "Discovery Reader", READER, "Role granting permissions to view discovered hosts"
         role "Discovery Manager", MANAGER, "Role granting permissions to perform provisioning of discovered hosts"
 


### PR DESCRIPTION
This fixes:
lib/foreman_discovery/engine.rb:302: warning: already initialized constant ForemanDiscovery::Engine::MANAGER lib/foreman_discovery/engine.rb:271: warning: previous definition of MANAGER was here