### PR TITLE
Fixes #34845 - Support non-RSA private keys

### DIFF
--- a/app/services/foreman_discovery/node_api/node_resource.rb
+++ b/app/services/foreman_discovery/node_api/node_resource.rb
@@ -18,7 +18,7 @@ module ForemanDiscovery::NodeAPI
 
           @connect_params.merge!(
             :ssl_client_cert  =>  OpenSSL::X509::Certificate.new(File.read(cert)),
-            :ssl_client_key   =>  OpenSSL::PKey::RSA.new(File.read(hostprivkey)),
+            :ssl_client_key   =>  OpenSSL::PKey.read(File.read(hostprivkey)),
             :ssl_ca_file      =>  ca_cert,
             :verify_ssl       =>  OpenSSL::SSL::VERIFY_PEER
           )


### PR DESCRIPTION
OpenSSL can figure out which key is used and this allows supporting non-RSA keys, like elliptic curve.

I didn't test this, just trusting the instructions in https://projects.theforeman.org/issues/34842.