### PR TITLE
Fixes #37643 Hostname Inconsistency in WebUI

### DIFF
--- a/app/controllers/discovered_hosts_controller.rb
+++ b/app/controllers/discovered_hosts_controller.rb
@@ -58,12 +58,14 @@ class DiscoveredHostsController < ::ApplicationController
 
   def edit
     quick = params.delete(:quick_submit)
+    name = @host.name
     @host = ::ForemanDiscovery::HostConverter.to_managed(@host, true, false, discovered_host_params_host) unless @host.nil?
     setup_host_class_variables
     @override_taxonomy = true
     # need to permit this one but don't know how
     if quick
-      perform_update(@host, _('Successfully provisioned %s') % @host.name)
+      name = @host.name if name.nil? || name.empty?
+      perform_update(@host, _('Successfully started provision for %s') % name)
     else
       @host.build = true
       render :template => 'discovered_hosts/edit'

--- a/app/controllers/discovered_hosts_controller.rb
+++ b/app/controllers/discovered_hosts_controller.rb
@@ -64,7 +64,7 @@ class DiscoveredHostsController < ::ApplicationController
     @override_taxonomy = true
     # need to permit this one but don't know how
     if quick
-      name = @host.name if name.nil? || name.empty?
+      name = @host.name if name.blank?
       perform_update(@host, _('Successfully started provision for %s') % name)
     else
       @host.build = true


### PR DESCRIPTION
Description of problem:

WebUI shows wrong hostname while customizing and provisioning a discovered host. The host itself has the correct hostname after provisioning.

Version-Release number of selected component (if applicable):
6.14

How reproducible:
100%

Steps to Reproduce:
1. Discover a host
2. Click "Provision" and "Customize" after
3. Refer to the attached screenshots for details
4. Once host is provisioned a popup notifications contains a wrong hostname too (screenshot is from another host, hence it has a different random name)

Actual results:
Refer to the attached screenshots

Expected results:
WebUI shows correct hostname