### PR TITLE
URI.escape is deprecated and fails on RHEL 9.5

### DIFF
--- a/app/services/foreman_discovery/node_api/node_resource.rb
+++ b/app/services/foreman_discovery/node_api/node_resource.rb
@@ -82,7 +82,7 @@ module ForemanDiscovery::NodeAPI
     def get(payload = {}, path = nil)
       logger.debug("Image API GET #{url} (path=#{path}, payload=#{payload})")
       if path
-        resource[URI.escape(path)].get payload
+        resource[CGI.escape(path)].get payload
       else
         resource.get payload
       end


### PR DESCRIPTION
Change URI.escape to CGI.escape