### PR TITLE
Fixes #38620 - Validate permission filters for view_discovered_hosts

### DIFF
--- a/app/lib/discovery_filter_validator.rb
+++ b/app/lib/discovery_filter_validator.rb
@@ -1,0 +1,19 @@
+class DiscoveryFilterValidator < ActiveModel::Validator
+  # Users can assign a search filter to a discovered host that is valid
+  # only for the Host model, but not for the Host::Discovered model.
+  # For example, the 'hostgroup' field is valid for Host, but not for Host::Discovered.
+  def validate(record)
+    return if record.search.blank?
+
+    has_permission = record.permissions.find { |perm| perm.name == 'view_discovered_hosts' }
+
+    return unless has_permission
+
+    begin
+      Host::Discovered.search_for(record.search)
+    rescue ScopedSearch::QueryNotSupported => _e
+      msg = N_("Search filter is invalid: Field 'search' is not recognized for Discovered hosts.")
+      record.errors.add(:search, msg)
+    end
+  end
+end

--- a/app/models/concerns/discovery_filter_extensions.rb
+++ b/app/models/concerns/discovery_filter_extensions.rb
@@ -1,0 +1,7 @@
+module DiscoveryFilterExtensions
+  extend ActiveSupport::Concern
+
+  included do
+    validates_with DiscoveryFilterValidator
+  end
+end

--- a/lib/foreman_discovery/engine.rb
+++ b/lib/foreman_discovery/engine.rb
@@ -351,6 +351,7 @@ module ForemanDiscovery
       ::Host::Managed.send :include, Host::ManagedExtensions
       ::Hostgroup.send :include, HostgroupExtensions
       ::Nic::Managed.send :include, Nic::ManagedExtensions
+      ::Filter.send :include, DiscoveryFilterExtensions
 
       # Controller extensions
       ::HostsController.send :include, ForemanDiscovery::Concerns::HostsControllerExtensions

--- a/test/unit/discovery_filter_validator_test.rb
+++ b/test/unit/discovery_filter_validator_test.rb
@@ -1,0 +1,32 @@
+require_relative '../test_plugin_helper'
+
+class DiscoveryFilterValidatorTest < ActiveSupport::TestCase
+  setup do
+    @filter = FactoryBot.create(:filter, :search => "name = 'test'")
+    @filter.permissions << Permission.find_by(name: 'view_discovered_hosts')
+  end
+
+  test "should not validate if search is blank" do
+    filter = FactoryBot.build(:filter, resource_type: 'Host', search: nil)
+    assert filter.valid?
+  end
+
+  test "should not validate if discovery permission is not present" do
+    filter = FactoryBot.build(:filter, resource_type: 'Host', search: "name = 'test'")
+    assert filter.valid?
+  end
+
+  test "run validation with invalid search" do
+    filter = FactoryBot.build(:filter, resource_type: 'Host', search: "hostgroup = 'test'")
+    filter.permissions << Permission.find_by(name: 'view_discovered_hosts')
+    assert_not filter.valid?
+    assert filter.errors[:search].present?
+  end
+
+  test "run validation with valid search" do
+    filter = FactoryBot.build(:filter, resource_type: 'Host', search: "name = 'test'")
+    filter.permissions << Permission.find_by(name: 'view_discovered_hosts')
+    assert filter.valid?
+    assert_empty filter.errors[:search]
+  end
+end


### PR DESCRIPTION
Users can assign a search filter to a discovered host that is valid only for the Host model, but not for the Host::Discovered model. For example, the 'hostgroup' field is valid for Host, but not for Host::Discovered.