### PR TITLE
Add ip.present? check, to avoid using empty string as IP address

### DIFF
--- a/app/services/foreman_discovery/host_converter.rb
+++ b/app/services/foreman_discovery/host_converter.rb
@@ -55,7 +55,7 @@ class ForemanDiscovery::HostConverter
   end
 
   def self.ip_for_subnet(subnet, mac, ip)
-    return ip if ip && subnet&.unused_ip(mac)&.ip_include?(ip)
+    return ip if ip.present? && subnet&.unused_ip(mac)&.ip_include?(ip)
 
     unused_ip_for_subnet(subnet, mac, ip)
   end


### PR DESCRIPTION
Just ran into this issue on attempting a provisioning, so throwing up a quick PR with the local fix.

The error that was hit;
```
Backtrace for 'invalid address: ' error (IPAddr::InvalidAddressError): invalid address: 
/usr/share/ruby/ipaddr.rb:598:in `rescue in initialize'
/usr/share/ruby/ipaddr.rb:557:in `initialize'
/usr/share/ruby/ipaddr.rb:606:in `new'
/usr/share/ruby/ipaddr.rb:606:in `coerce_other'
/usr/share/ruby/ipaddr.rb:174:in `include?'
/usr/share/foreman/app/services/ipam/base.rb:38:in `ip_include?'
/usr/share/gems/gems/foreman_discovery-26.1.3/app/services/foreman_discovery/host_converter.rb:58:in `ip_for_subnet'
/usr/share/gems/gems/foreman_discovery-26.1.3/app/services/foreman_discovery/host_converter.rb:71:in `block in unused_ip_for_host'
/usr/share/gems/gems/activerecord-7.0.10/lib/active_record/relation/delegation.rb:88:in `each'
/usr/share/gems/gems/activerecord-7.0.10/lib/active_record/relation/delegation.rb:88:in `each'
/usr/share/gems/gems/foreman_discovery-26.1.3/app/services/foreman_discovery/host_converter.rb:64:in `unused_ip_for_host'
/usr/share/gems/gems/foreman_discovery-26.1.3/app/controllers/discovered_hosts_controller.rb:84:in `block in perform_update'
...
```