### PR TITLE
Add find_resource method to hosts_controller_extensions

### DIFF
--- a/app/controllers/foreman_discovery/concerns/hosts_controller_extensions.rb
+++ b/app/controllers/foreman_discovery/concerns/hosts_controller_extensions.rb
@@ -25,11 +25,10 @@ module ForemanDiscovery
           not_found
           return false
         end
-        @host = Host::Discovered.authorized(:edit_discovered_hosts, Host::Discovered).find_by_id(id)
+        @host = Host::Discovered.authorized(:edit_discovered_hosts, Host::Discovered).find_by(id: id)
         @host ||= super
         @host
       end
-
     end
   end
 end

--- a/app/controllers/foreman_discovery/concerns/hosts_controller_extensions.rb
+++ b/app/controllers/foreman_discovery/concerns/hosts_controller_extensions.rb
@@ -19,6 +19,17 @@ module ForemanDiscovery
 
         @host = ::ForemanDiscovery::HostConverter.to_managed(@host, true, false, host_params) if @host.is_a?(Host::Discovered)
       end
+
+      def find_resource
+        if (id = params[:id]).blank?
+          not_found
+          return false
+        end
+        @host = Host::Discovered.authorized(:edit_discovered_hosts, Host::Discovered).find_by_id(id)
+        @host ||= super
+        @host
+      end
+
     end
   end
 end

--- a/db/seeds.d/60_discovery_proxy_feature.rb
+++ b/db/seeds.d/60_discovery_proxy_feature.rb
@@ -1,2 +1,2 @@
 f = Feature.unscoped.where(:name => 'Discovery').first_or_create
-raise "Unable to create proxy feature: #{format_errors f}" if f.nil? || f.errors.any?
+raise "Unable to create proxy feature: #{SeedHelper.format_errors(f)}" if f.nil? || f.errors.any?

--- a/test/functional/foreman_discovery/concerns/hosts_controller_extensions_test.rb
+++ b/test/functional/foreman_discovery/concerns/hosts_controller_extensions_test.rb
@@ -50,6 +50,47 @@ module ForemanDiscovery
           assert_instance_of Host::Managed, assigns(:host)
         end
       end
+
+      describe 'find_resource' do
+        include FactImporterIsolation
+        allow_transactions_for_any_importer
+
+        setup do
+          @facts = {
+            "interfaces" => "lo,eth0",
+            "ipaddress" => "192.168.100.42",
+            "ipaddress_eth0" => "192.168.100.42",
+            "macaddress_eth0" => "AA:BB:CC:DD:EE:FF",
+            "discovery_bootif" => "AA:BB:CC:DD:EE:FF",
+            "physicalprocessorcount" => "42",
+            "discovery_version" => "3.0.0",
+          }
+        end
+
+        test 'finds a discovered host directly without converting it' do
+          host = discover_host_from_facts(@facts)
+          get :build_errors, params: { id: host.id }, session: set_session_user
+
+          assert_response :success
+          assert_instance_of Host::Discovered, assigns(:host)
+          assert_equal host, assigns(:host)
+        end
+
+        test 'falls back to the core lookup for a managed host' do
+          host = FactoryBot.create(:host, :managed)
+          get :build_errors, params: { id: host.id }, session: set_session_user
+
+          assert_response :success
+          assert_instance_of Host::Managed, assigns(:host)
+          assert_equal host, assigns(:host)
+        end
+
+        test 'renders not found for an unknown host id' do
+          get :build_errors, params: { id: 0 }, session: set_session_user
+
+          assert_response :not_found
+        end
+      end
     end
   end
 end

--- a/test/unit/discovered_extensions_test.rb
+++ b/test/unit/discovered_extensions_test.rb
@@ -238,8 +238,8 @@ class DiscoveredExtensionsTest < ActiveSupport::TestCase
     ::ForemanDiscovery::HostConverter.unstub(:unused_ip_for_host)
     facts = @facts_ipv6.merge({"somefact" => "abc"})
     domain = FactoryBot.create(:domain)
-    subnet = FactoryBot.create(:subnet_ipv6, :tftp, :dhcp, :network => "2001:db8::/32", :mask => "ffff:ffff::", :name => "ipv6_discovered", :ipam => IPAM::MODES[:eui64], :organizations => [Organization.find_by_name("Organization 1")], :locations => [Location.find_by_name("Location 1")])
-    subnet2 = FactoryBot.create(:subnet_ipv6, :tftp, :dhcp, :network => "2001:db9::/32", :mask => "ffff:ffff::", :name => "ipv6_provision", :ipam => IPAM::MODES[:eui64], :organizations => [Organization.find_by_name("Organization 1")], :locations => [Location.find_by_name("Location 1")])
+    subnet = FactoryBot.create(:subnet_ipv6, :tftp, :dhcp, :network => "2001:db8::", :mask => "ffff:ffff::", :name => "ipv6_discovered", :ipam => IPAM::MODES[:eui64], :organizations => [Organization.find_by_name("Organization 1")], :locations => [Location.find_by_name("Location 1")])
+    subnet2 = FactoryBot.create(:subnet_ipv6, :tftp, :dhcp, :network => "2001:db9::", :mask => "ffff:ffff::", :name => "ipv6_provision", :ipam => IPAM::MODES[:eui64], :organizations => [Organization.find_by_name("Organization 1")], :locations => [Location.find_by_name("Location 1")])
     host = discover_host_from_facts(facts)
     assert_equal subnet, host.subnet6
     hostgroup = FactoryBot.create(:hostgroup, :with_rootpass, :with_os, :pxe_loader => "PXELinux BIOS", :subnet6 => subnet2, :domain => domain)


### PR DESCRIPTION
ensure Host::Discovered is checked before falling back to standard managed host lookup