### PR TITLE
Fixes #39670 - Use SeedHelper.format_errors in seeds

### DIFF
--- a/db/seeds.d/60_discovery_proxy_feature.rb
+++ b/db/seeds.d/60_discovery_proxy_feature.rb
@@ -1,2 +1,2 @@
 f = Feature.unscoped.where(:name => 'Discovery').first_or_create
-raise "Unable to create proxy feature: #{format_errors f}" if f.nil? || f.errors.any?
+raise "Unable to create proxy feature: #{SeedHelper.format_errors(f)}" if f.nil? || f.errors.any?


### PR DESCRIPTION
Refs #39670

The top-level `format_errors` seed helper in Foreman core is deprecated (since 3.4) and is being removed as part of Foreman #39667 (theforeman/foreman#11193). This switches the plugin seed scripts to call `SeedHelper.format_errors` directly.

`SeedHelper.format_errors` has been available since the helper was deprecated, so this change is backward compatible with all supported Foreman versions and can be merged independently of the core removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)